### PR TITLE
✍️ Sign transaction from extension

### DIFF
--- a/packages/ui/src/components/notifications/HelpNotification.tsx
+++ b/packages/ui/src/components/notifications/HelpNotification.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { BorderRad, Colors, Transitions } from '../../constants/styles'
+import { BorderRad, Colors, Transitions } from '../../constants'
 import { QuestionIcon } from '../icons/QuestionIcon'
 
 interface HelpNotificationProps {

--- a/packages/ui/src/hooks/useBalances.ts
+++ b/packages/ui/src/hooks/useBalances.ts
@@ -21,6 +21,7 @@ export function useBalances(accounts: Account[]): UseBalances {
   const [balances, setBalances] = useState<AddressToBalanceMap>({})
   const [hasBalances, setHasBalances] = useState(false)
   const { isConnected, api } = useApi()
+  const addresses = accounts.map(({ address }) => address).join()
 
   useEffect(() => {
     let unsubscribeAll: any
@@ -49,7 +50,7 @@ export function useBalances(accounts: Account[]): UseBalances {
     }
 
     return () => unsubscribeAll && unsubscribeAll()
-  }, [api, isConnected, accounts])
+  }, [api, isConnected, addresses])
 
   return {
     hasBalances: hasBalances,

--- a/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
+++ b/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
@@ -69,9 +69,9 @@ export function SignTransferModal({ onClose, from, amount, to }: Props) {
     if (keyringPair.meta.isInjected) {
       const { signer } = await web3FromAddress(from.address)
 
-      await submittableExtrinsic.signAndSend(from.address, { signer: signer }, statusCallback).catch(console.log)
+      await submittableExtrinsic.signAndSend(from.address, { signer: signer }, statusCallback).catch(console.error)
     } else {
-      await submittableExtrinsic.signAndSend(keyringPair, statusCallback).catch(console.log)
+      await submittableExtrinsic.signAndSend(keyringPair, statusCallback).catch(console.error)
     }
   }
 

--- a/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
+++ b/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
@@ -21,6 +21,7 @@ import {
   TransactionInfo,
   TransactionInfoRow,
 } from './TransferModal'
+import { web3FromAddress } from '@polkadot/extension-dapp'
 import { HelpNotification } from '../../components/notifications/HelpNotification'
 
 interface Props {
@@ -50,6 +51,8 @@ export function SignTransferModal({ onClose, from, amount, to }: Props) {
     if (!submittableExtrinsic) {
       return
     }
+
+    const injector = await web3FromAddress(from.address)
 
     await submittableExtrinsic
       .signAndSend(keyring.getPair(from.address), (result) => {

--- a/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
+++ b/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
@@ -1,10 +1,14 @@
-import { RuntimeDispatchInfo } from '@polkadot/types/interfaces'
-import BN from 'bn.js'
 import React, { useEffect, useState } from 'react'
+import { RuntimeDispatchInfo } from '@polkadot/types/interfaces'
+import { ISubmittableResult } from '@polkadot/types/types'
+import { web3FromAddress } from '@polkadot/extension-dapp'
+import BN from 'bn.js'
+
 import { AccountInfo } from '../../components/AccountInfo'
 import { ButtonPrimaryMedium } from '../../components/buttons/Buttons'
 import { ArrowDownExpandedIcon } from '../../components/icons/ArrowDownExpandedIcon'
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '../../components/modal'
+import { HelpNotification } from '../../components/notifications/HelpNotification'
 import { TokenValue } from '../../components/TokenValue'
 import { Account } from '../../hooks/types'
 import { useApi } from '../../hooks/useApi'
@@ -21,9 +25,6 @@ import {
   TransactionInfo,
   TransactionInfoRow,
 } from './TransferModal'
-import { web3FromAddress } from '@polkadot/extension-dapp'
-import { HelpNotification } from '../../components/notifications/HelpNotification'
-import { ISubmittableResult } from '@polkadot/types/types'
 
 interface Props {
   onClose: () => void
@@ -55,16 +56,14 @@ export function SignTransferModal({ onClose, from, amount, to }: Props) {
 
     const keyringPair = keyring.getPair(from.address)
 
-    const statusCallback = (result: ISubmittableResult) => {
-      const { status } = result
-
-      if (status.isInBlock) {
-        onClose()
+    const statusCallback = ({ status }: ISubmittableResult) => {
+      if (!status.isInBlock) {
+        console.log(`Current transaction status: ${status.type}`)
+        return
       }
 
-      status.isInBlock
-        ? console.log(`In Block. Block hash: ${status.asInBlock.toString()}`)
-        : console.log(`Current transaction status: ${status.type}`)
+      console.log(`In Block. Block hash: ${status.asInBlock.toString()}`)
+      onClose()
     }
 
     if (keyringPair.meta.isInjected) {

--- a/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
+++ b/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
@@ -45,7 +45,7 @@ export function SignTransferModal({ onClose, from, amount, to }: Props) {
     })
   }, [api, amount])
 
-  const submittableExtrinsic = api?.tx.balances.transfer(to.address, amount)
+  const submittableExtrinsic = api?.tx?.balances?.transfer(to.address, amount)
   const signAndSend = async () => {
     setIsSending(true)
 

--- a/packages/ui/src/modals/TransferModal/TransferDetailsModal.tsx
+++ b/packages/ui/src/modals/TransferModal/TransferDetailsModal.tsx
@@ -58,8 +58,13 @@ export function TransferDetailsModal({ from, to, onClose, onAccept }: Props) {
         </Row>
         <TransactionAmount>
           <AmountInputBlock>
-            <AmountInputLabel>Number of tokens</AmountInputLabel>
-            <AmountInput value={amount} onChange={(event) => setAmount(event.target.value)} placeholder={'0'} />
+            <AmountInputLabel htmlFor={'amount-input'}>Number of tokens</AmountInputLabel>
+            <AmountInput
+              id="amount-input"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              placeholder="0"
+            />
           </AmountInputBlock>
           <AmountButtons>
             <AmountButton onClick={setHalf}>Use half</AmountButton>
@@ -88,7 +93,7 @@ export function TransferDetailsModal({ from, to, onClose, onAccept }: Props) {
   )
 }
 
-const AmountInputLabel = styled.span`
+const AmountInputLabel = styled.label`
   margin-bottom: 8px;
   font-size: 14px;
   line-height: 20px;

--- a/packages/ui/src/pages/Profile/Accounts.tsx
+++ b/packages/ui/src/pages/Profile/Accounts.tsx
@@ -15,8 +15,8 @@ import { TransferButton } from '../../components/TransferButton'
 import { BorderRad, Colors, Shadows } from '../../constants'
 import { useAccounts } from '../../hooks/useAccounts'
 import { useBalances } from '../../hooks/useBalances'
-import { WaitForTheExtensionModal } from '../../modals/WaitForTheExtensionModal'
 import { formatTokenValue } from '../../utils/formatters'
+import { Account } from '../../hooks/types'
 
 export function Accounts() {
   const { allAccounts, hasAccounts } = useAccounts()
@@ -24,7 +24,10 @@ export function Accounts() {
 
   if (!hasAccounts) return <Loading>Loading accounts...</Loading>
 
-  const sendTo = allAccounts[allAccounts.length - 1]
+  const sendTo = (from: Account) => {
+    const to = allAccounts[allAccounts.length - 1]
+    return to === from ? allAccounts[0] : to
+  }
 
   return (
     <MyProfile>
@@ -115,7 +118,7 @@ export function Accounts() {
                   <ButtonInside>
                     <ArrowInsideIcon />
                   </ButtonInside>
-                  <TransferButton from={account} to={sendTo} />
+                  <TransferButton from={account} to={sendTo(account)} />
                   <ButtonApply>
                     <ArrowDownIcon />
                   </ButtonApply>

--- a/packages/ui/src/pages/Profile/Accounts.tsx
+++ b/packages/ui/src/pages/Profile/Accounts.tsx
@@ -15,8 +15,8 @@ import { TransferButton } from '../../components/TransferButton'
 import { BorderRad, Colors, Shadows } from '../../constants'
 import { useAccounts } from '../../hooks/useAccounts'
 import { useBalances } from '../../hooks/useBalances'
-import { formatTokenValue } from '../../utils/formatters'
 import { Account } from '../../hooks/types'
+import { formatTokenValue } from '../../utils/formatters'
 
 export function Accounts() {
   const { allAccounts, hasAccounts } = useAccounts()

--- a/packages/ui/test/mocks/keyring/signers.ts
+++ b/packages/ui/test/mocks/keyring/signers.ts
@@ -6,3 +6,9 @@ export function aliceSigner(): KeyringPair {
 
   return keyring.addFromUri('//Alice')
 }
+
+export function bobSigner(): KeyringPair {
+  const keyring = new Keyring({ type: 'sr25519' })
+
+  return keyring.addFromUri('//Bob')
+}

--- a/packages/ui/test/modals/TransferModal.test.tsx
+++ b/packages/ui/test/modals/TransferModal.test.tsx
@@ -39,21 +39,13 @@ describe('UI: TransferModal', () => {
   })
 
   it('Renders a modal', () => {
-    const { getByText } = render(
-      <ApiContext.Provider value={api}>
-        <TransferModal onClose={sinon.spy()} from={from} to={to} />
-      </ApiContext.Provider>
-    )
+    const { getByText } = renderModal()
 
     expect(getByText('Send tokens')).to.exist
   })
 
   it('Renders an Authorize transaction step', () => {
-    const { getByLabelText, getByText } = render(
-      <ApiContext.Provider value={api}>
-        <TransferModal onClose={sinon.spy()} from={from} to={to} />
-      </ApiContext.Provider>
-    )
+    const { getByLabelText, getByText } = renderModal()
 
     const input = getByLabelText('Number of tokens')
     expect((getByText('Transfer tokens') as HTMLButtonElement).disabled).to.be.true
@@ -67,4 +59,12 @@ describe('UI: TransferModal', () => {
 
     expect(getByText('Authorize transaction')).to.exist
   })
+
+  function renderModal() {
+    return render(
+      <ApiContext.Provider value={api}>
+        <TransferModal onClose={sinon.spy()} from={from} to={to} />
+      </ApiContext.Provider>
+    )
+  }
 })

--- a/packages/ui/test/modals/TransferModal.test.tsx
+++ b/packages/ui/test/modals/TransferModal.test.tsx
@@ -38,33 +38,33 @@ describe('UI: TransferModal', () => {
     })
   })
 
-  it('Renders a modal', async () => {
+  it('Renders a modal', () => {
     const { getByText } = render(
       <ApiContext.Provider value={api}>
         <TransferModal onClose={sinon.spy()} from={from} to={to} />
       </ApiContext.Provider>
     )
 
-    expect(await getByText('Send tokens')).to.exist
+    expect(getByText('Send tokens')).to.exist
   })
 
-  it('Renders an Authorize transaction step', async () => {
+  it('Renders an Authorize transaction step', () => {
     const { getByLabelText, getByText } = render(
       <ApiContext.Provider value={api}>
         <TransferModal onClose={sinon.spy()} from={from} to={to} />
       </ApiContext.Provider>
     )
 
-    const input = await getByLabelText('Number of tokens')
-    expect(((await getByText('Transfer tokens')) as HTMLButtonElement).disabled).to.be.true
+    const input = getByLabelText('Number of tokens')
+    expect((getByText('Transfer tokens') as HTMLButtonElement).disabled).to.be.true
 
     fireEvent.change(input, { target: { value: '50' } })
 
-    const button = (await getByText('Transfer tokens')) as HTMLButtonElement
+    const button = getByText('Transfer tokens') as HTMLButtonElement
     expect(button.disabled).to.be.false
 
     fireEvent.click(button)
 
-    expect(await getByText('Authorize transaction')).to.exist
+    expect(getByText('Authorize transaction')).to.exist
   })
 })

--- a/packages/ui/test/modals/TransferModal.test.tsx
+++ b/packages/ui/test/modals/TransferModal.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import BN from 'bn.js'
+import { ApiPromise } from '@polkadot/api'
+import { cryptoWaitReady } from '@polkadot/util-crypto'
+import { set } from 'lodash'
+import { TransferModal } from '../../src/modals/TransferModal/TransferModal'
+import { Account } from '../../src/hooks/types'
+import { aliceSigner, bobSigner } from '../mocks/keyring'
+import { ApiContext } from '../../src/providers/api/context'
+import { UseApi } from '../../src/providers/api/provider'
+
+describe('UI: TransferModal', () => {
+  before(cryptoWaitReady)
+
+  const from: Account = {
+    address: aliceSigner().address,
+    name: 'alice',
+  }
+  const to: Account = {
+    address: bobSigner().address,
+    name: 'bob',
+  }
+  const api: UseApi = {
+    api: ({} as unknown) as ApiPromise,
+    state: 'CONNECTED',
+    isConnected: true,
+  }
+
+  beforeEach(() => {
+    set(api, 'api.query.system.account.multi', (accounts: any, callback: any) => {
+      callback(accounts.map(() => set({}, 'data.free.toBn', () => new BN(100))))
+      return Promise.resolve()
+    })
+  })
+
+  it('Renders a modal', async () => {
+    const { getByText } = render(
+      <ApiContext.Provider value={api}>
+        <TransferModal onClose={sinon.spy()} from={from} to={to} />
+      </ApiContext.Provider>
+    )
+
+    expect(await getByText('Send tokens')).to.exist
+  })
+})

--- a/packages/ui/test/pages/Accounts.test.tsx
+++ b/packages/ui/test/pages/Accounts.test.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 import { Keyring } from '@polkadot/ui-keyring/Keyring'
+import { cryptoWaitReady } from '@polkadot/util-crypto'
 import { cleanup, render } from '@testing-library/react'
+import BN from 'bn.js'
 import { expect } from 'chai'
 import sinon from 'sinon'
+import { aliceSigner } from '../mocks/keyring'
 import { KeyringContext } from '../../src/providers/keyring/context'
 import * as useAccountsModule from '../../src/hooks/useAccounts'
 import * as useBalancesModule from '../../src/hooks/useBalances'
-import { aliceSigner } from '../mocks/keyring'
 import { UseBalances } from '../../src/hooks/useBalances'
 import { Accounts } from '../../src/pages/Profile/Accounts'
 import { Account } from '../../src/hooks/types'
-import { cryptoWaitReady } from '@polkadot/util-crypto'
-import BN from 'bn.js'
 
 describe('UI: Accounts list', () => {
   let accounts: {


### PR DESCRIPTION
I've introduced a small set of UI tests for the modals. I've used here API mocking since I'm not happy with the limitations (re-run tests for instance) of the Sinon hooks stubbing.

I see two options:
1. Decide on using Jest for proper hooks mocking.
2. Refactor `useApi` (and ` useBalances`) to use Rx API flavor of the API and then see how hooks could be improved.

ps.: I look forward to Rx API as I think that it would play nicer with the hooks API ([link](https://soshace.com/react-hooks-rxjs-or-how-react-is-meant-to-be/), [link](https://github.com/beautifulinteractions/beautiful-react-hooks/blob/master/docs/useObservable.md))