### PR TITLE
⏲ Make keys from extension more reliable

### DIFF
--- a/packages/ui/src/providers/keyring/provider.tsx
+++ b/packages/ui/src/providers/keyring/provider.tsx
@@ -53,7 +53,7 @@ export const KeyringContextProvider = (props: Props) => {
       return
     }
 
-    loadKeysFromExtension()
+    loadKeysFromExtension().catch(console.error)
   }, [isLoaded])
 
   return <KeyringContext.Provider value={keyring}>{props.children}</KeyringContext.Provider>


### PR DESCRIPTION
As described in #209 – the extension was not always available (on Firefox at least) and the keys were not loaded. The library did not detect that extension was loaded later because of a hardcoded check that was evaluated when enabling the extension.