### PR TITLE
Handle extension rejections

### DIFF
--- a/packages/ui/src/hooks/useSignAndSendTransaction.ts
+++ b/packages/ui/src/hooks/useSignAndSendTransaction.ts
@@ -1,9 +1,11 @@
+import React from 'react'
 import { SubmittableExtrinsic } from '@polkadot/api/types'
 import { web3FromAddress } from '@polkadot/extension-dapp'
 import { EventRecord } from '@polkadot/types/interfaces/system'
 import { ISubmittableResult } from '@polkadot/types/types'
 import BN from 'bn.js'
 import { useEffect, useState } from 'react'
+import { Observable } from 'rxjs'
 import { Account } from '../common/types'
 import { useApi } from './useApi'
 import { useKeyring } from './useKeyring'
@@ -19,30 +21,39 @@ type TransactionStatus = 'READY' | 'SIGN' | 'EXTENSION' | 'PENDING' | 'SUCCESS' 
 
 const isError = (events: EventRecord[]) => events.find(({ event: { method } }) => method === 'ExtrinsicFailed')
 
-const statusCallback = (setStatus: (status: TransactionStatus) => void) => (result: ISubmittableResult) => {
-  const { status, events } = result
+const observeTransaction = (
+  transaction: Observable<ISubmittableResult>,
+  setStatus: React.Dispatch<TransactionStatus>
+) => {
+  const statusCallback = (result: ISubmittableResult) => {
+    const { status, events } = result
 
-  console.log(`Current transaction status: ${status.type}`)
+    console.log(`Current transaction status: ${status.type}`)
 
-  if (status.isReady) {
-    setStatus('PENDING')
+    if (status.isReady) {
+      setStatus('PENDING')
+    }
+
+    if (status.isInBlock) {
+      console.log('Included at block hash', JSON.stringify(status.asInBlock))
+      console.log('Events:')
+
+      events.forEach(({ event: { data, method, section }, phase }) => {
+        console.log('\t', JSON.stringify(phase), `: ${section}.${method}`, JSON.stringify(data))
+      })
+      console.log(JSON.stringify(events))
+    }
+
+    if (!status.isFinalized) {
+      return
+    }
+
+    setStatus(isError(events) ? 'ERROR' : 'SUCCESS')
   }
 
-  if (status.isInBlock) {
-    console.log('Included at block hash', JSON.stringify(status.asInBlock))
-    console.log('Events:')
+  const errorHandler = () => setStatus('ERROR')
 
-    events.forEach(({ event: { data, method, section }, phase }) => {
-      console.log('\t', JSON.stringify(phase), `: ${section}.${method}`, JSON.stringify(data))
-    })
-    console.log(JSON.stringify(events))
-  }
-
-  if (!status.isFinalized) {
-    return
-  }
-
-  setStatus(isError(events) ? 'ERROR' : 'SUCCESS')
+  transaction.subscribe(statusCallback, errorHandler)
 }
 
 export const useSignAndSendTransaction = ({ transaction, from, onDone }: UseSignAndSendTransactionParams) => {
@@ -61,11 +72,11 @@ export const useSignAndSendTransaction = ({ transaction, from, onDone }: UseSign
     if (keyringPair.meta.isInjected) {
       setStatus('EXTENSION')
       web3FromAddress(from.address).then(({ signer }) => {
-        transaction.signAndSend(from.address, { signer: signer }).subscribe(statusCallback(setStatus))
+        observeTransaction(transaction.signAndSend(from.address, { signer: signer }), setStatus)
       })
     } else {
       setStatus('PENDING')
-      transaction.signAndSend(keyringPair).subscribe(statusCallback(setStatus))
+      observeTransaction(transaction.signAndSend(keyringPair), setStatus)
     }
   }, [api, status])
 

--- a/packages/ui/src/modals/AddMembershipModal/AddMembershipModal.tsx
+++ b/packages/ui/src/modals/AddMembershipModal/AddMembershipModal.tsx
@@ -1,11 +1,7 @@
-import { EventRecord } from '@polkadot/types/interfaces/system'
-import { ISubmittableResult } from '@polkadot/types/types'
-import React, { useEffect, useState } from 'react'
-import { Observable, Subscription } from 'rxjs'
+import React, { useState } from 'react'
 import { Member } from '../../common/types'
 import { useApi } from '../../hooks/useApi'
 import { useObservable } from '../../hooks/useObservable'
-import { WaitModal } from '../WaitModal'
 import { AddMembershipFailureModal } from './AddMembershipFailureModal'
 import { AddMembershipSuccessModal } from './AddMembershipSuccessModal'
 import { MembershipFormModal } from './MembershipFormModal'
@@ -15,57 +11,20 @@ interface MembershipModalProps {
   onClose: () => void
 }
 
-type ModalState = 'PREPARE' | 'AUTHORIZE' | 'EXTENSION_SIGN' | 'SENDING' | 'SUCCESS' | 'ERROR'
-const isError = (events: EventRecord[]) => events.find(({ event: { method } }) => method === 'ExtrinsicFailed')
+type ModalState = 'PREPARE' | 'AUTHORIZE' | 'SUCCESS' | 'ERROR'
 
 export const AddMembershipModal = ({ onClose }: MembershipModalProps) => {
   const { api } = useApi()
   const membershipPrice = useObservable(api?.query.members.membershipPrice(), [])
   const [step, setStep] = useState<ModalState>('PREPARE')
   const [transactionParams, setParams] = useState<Member>()
-  const [subscription, setSubscription] = useState<Subscription | undefined>(undefined)
-
-  useEffect(() => {
-    if (subscription) {
-      return () => subscription.unsubscribe()
-    }
-  }, [subscription])
 
   const onSubmit = (params: Member) => {
     setStep('AUTHORIZE')
     setParams(params)
   }
 
-  const onSign = (transaction: Observable<ISubmittableResult>) => {
-    const statusCallback = (result: ISubmittableResult) => {
-      const { status, events } = result
-
-      console.log(`Current transaction status: ${status.type}`)
-
-      if (status.isReady) {
-        setStep('SENDING')
-      }
-
-      if (status.isInBlock) {
-        console.log('Included at block hash', JSON.stringify(status.asInBlock))
-        console.log('Events:')
-
-        events.forEach(({ event: { data, method, section }, phase }) => {
-          console.log('\t', JSON.stringify(phase), `: ${section}.${method}`, JSON.stringify(data))
-        })
-        console.log(JSON.stringify(events))
-      }
-
-      if (!status.isFinalized) {
-        return
-      }
-
-      setStep(isError(events) ? 'ERROR' : 'SUCCESS')
-    }
-
-    setStep('EXTENSION_SIGN')
-    setSubscription(transaction.subscribe(statusCallback))
-  }
+  const onDone = (result: boolean) => setStep(result ? 'SUCCESS' : 'ERROR')
 
   if (step === 'PREPARE' || !transactionParams) {
     return <MembershipFormModal onClose={onClose} onSubmit={onSubmit} membershipPrice={membershipPrice} />
@@ -77,29 +36,7 @@ export const AddMembershipModal = ({ onClose }: MembershipModalProps) => {
         onClose={onClose}
         membershipPrice={membershipPrice}
         transactionParams={transactionParams}
-        onSign={onSign}
-      />
-    )
-  }
-
-  if (step === 'EXTENSION_SIGN') {
-    return (
-      <WaitModal
-        onClose={onClose}
-        title="Waiting for the extension"
-        description={'Please, sign the transaction using external signer app.'}
-      />
-    )
-  }
-
-  if (step === 'SENDING') {
-    return (
-      <WaitModal
-        onClose={onClose}
-        title="Pending transaction"
-        description={
-          'We are waiting for your transaction to be mined. It can takes Lorem ipsum deserunt ullamco est sit aliqua dolor do amet sint. Velit officia consequat duis enim.'
-        }
+        onDone={onDone}
       />
     )
   }

--- a/packages/ui/src/modals/AddMembershipModal/SignCreateMemberModal.tsx
+++ b/packages/ui/src/modals/AddMembershipModal/SignCreateMemberModal.tsx
@@ -35,8 +35,8 @@ export const SignCreateMemberModal = ({ onClose, membershipPrice, transactionPar
   const { paymentInfo, send, status } = useSignAndSendTransaction({ transaction, from })
 
   useEffect(() => {
-    const isDONE = status === 'SUCCESS' || status === 'ERROR'
-    isDONE && onDone(status === 'SUCCESS', paymentInfo?.partialFee?.toBn() || new BN(0))
+    const isDone = status === 'SUCCESS' || status === 'ERROR'
+    isDone && onDone(status === 'SUCCESS', paymentInfo?.partialFee?.toBn() || new BN(0))
   })
 
   if (status === 'READY') {

--- a/packages/ui/src/modals/AddMembershipModal/SignCreateMemberModal.tsx
+++ b/packages/ui/src/modals/AddMembershipModal/SignCreateMemberModal.tsx
@@ -1,8 +1,6 @@
 import { BalanceOf } from '@polkadot/types/interfaces/runtime'
-import { ISubmittableResult } from '@polkadot/types/types'
 import BN from 'bn.js'
-import React, { useState } from 'react'
-import { Observable } from 'rxjs'
+import React, { useEffect, useState } from 'react'
 import { Member } from '../../common/types'
 import { ButtonPrimaryMedium } from '../../components/buttons'
 import { Label } from '../../components/forms'
@@ -13,18 +11,18 @@ import { Text, TokenValue } from '../../components/typography'
 import { useApi } from '../../hooks/useApi'
 import { useSignAndSendTransaction } from '../../hooks/useSignAndSendTransaction'
 import { BalanceInfoNarrow, InfoTitle, InfoValue, Row } from '../common'
+import { WaitModal } from '../WaitModal'
 
 interface SignProps {
   onClose: () => void
   membershipPrice?: BalanceOf
   transactionParams: Member
-  onSign: (transaction: Observable<ISubmittableResult>, fee: BN) => void
+  onDone: (result: boolean, fee: BN) => void
 }
 
-export const SignCreateMemberModal = ({ onClose, membershipPrice, transactionParams, onSign }: SignProps) => {
+export const SignCreateMemberModal = ({ onClose, membershipPrice, transactionParams, onDone }: SignProps) => {
   const { api } = useApi()
   const [from, setFrom] = useState(transactionParams.controllerAccount)
-
   const transaction = api?.tx?.members?.buyMembership({
     root_account: transactionParams.rootAccount.address,
     controller_account: transactionParams.controllerAccount.address,
@@ -33,41 +31,71 @@ export const SignCreateMemberModal = ({ onClose, membershipPrice, transactionPar
     avatar_uri: transactionParams.avatarURI,
     about: transactionParams.about,
   })
-  const { paymentInfo, isSending, send } = useSignAndSendTransaction({ transaction, from, onSign })
 
-  return (
-    <Modal modalSize="m" modalHeight="s" onClose={onClose}>
-      <ModalHeader onClick={onClose} title="Authorize transaction" />
-      <ModalBody>
-        <Text>You are intend to create a new membership.</Text>
-        <Text>
-          The creation of the new membership costs <TokenValue value={membershipPrice?.toBn()} />.
-        </Text>
-        <Text>
-          Fees of <TokenValue value={paymentInfo?.partialFee.toBn()} /> will be applied to the transaction.
-        </Text>
-        <Row>
-          <Label>Sending from account</Label>
-          <SelectAccount selected={from} onChange={(account) => setFrom(account)} />
-        </Row>
-      </ModalBody>
-      <ModalFooter>
-        <BalanceInfoNarrow>
-          <InfoTitle>Creation fee:</InfoTitle>
-          <InfoValue>
-            <TokenValue value={membershipPrice?.toBn()} />
-          </InfoValue>
-          <Help helperText={'Lorem ipsum dolor sit amet consectetur, adipisicing elit.'} />
-          <InfoTitle>Transaction fee:</InfoTitle>
-          <InfoValue>
-            <TokenValue value={paymentInfo?.partialFee.toBn()} />
-          </InfoValue>
-          <Help helperText={'Lorem ipsum dolor sit amet consectetur, adipisicing elit.'} />
-        </BalanceInfoNarrow>
-        <ButtonPrimaryMedium onClick={send} disabled={isSending}>
-          Sign and create a member
-        </ButtonPrimaryMedium>
-      </ModalFooter>
-    </Modal>
-  )
+  const { paymentInfo, send, status } = useSignAndSendTransaction({ transaction, from })
+
+  useEffect(() => {
+    const isDONE = status === 'SUCCESS' || status === 'ERROR'
+    isDONE && onDone(status === 'SUCCESS', paymentInfo?.partialFee?.toBn() || new BN(0))
+  })
+
+  if (status === 'READY') {
+    return (
+      <Modal modalSize="m" modalHeight="s" onClose={onClose}>
+        <ModalHeader onClick={onClose} title="Authorize transaction" />
+        <ModalBody>
+          <Text>You are intend to create a new membership.</Text>
+          <Text>
+            The creation of the new membership costs <TokenValue value={membershipPrice?.toBn()} />.
+          </Text>
+          <Text>
+            Fees of <TokenValue value={paymentInfo?.partialFee.toBn()} /> will be applied to the transaction.
+          </Text>
+          <Row>
+            <Label>Sending from account</Label>
+            <SelectAccount selected={from} onChange={(account) => setFrom(account)} />
+          </Row>
+        </ModalBody>
+        <ModalFooter>
+          <BalanceInfoNarrow>
+            <InfoTitle>Creation fee:</InfoTitle>
+            <InfoValue>
+              <TokenValue value={membershipPrice?.toBn()} />
+            </InfoValue>
+            <Help helperText={'Lorem ipsum dolor sit amet consectetur, adipisicing elit.'} />
+            <InfoTitle>Transaction fee:</InfoTitle>
+            <InfoValue>
+              <TokenValue value={paymentInfo?.partialFee.toBn()} />
+            </InfoValue>
+            <Help helperText={'Lorem ipsum dolor sit amet consectetur, adipisicing elit.'} />
+          </BalanceInfoNarrow>
+          <ButtonPrimaryMedium onClick={send} disabled={status !== 'READY'}>
+            Sign and create a member
+          </ButtonPrimaryMedium>
+        </ModalFooter>
+      </Modal>
+    )
+  }
+
+  if (status === 'EXTENSION') {
+    return (
+      <WaitModal
+        onClose={onClose}
+        title="Waiting for the extension"
+        description="Please, sign the transaction using external signer app."
+      />
+    )
+  }
+
+  if (status === 'PENDING') {
+    return (
+      <WaitModal
+        onClose={onClose}
+        title="Pending transaction"
+        description="We are waiting for your transaction to be mined. It can takes Lorem ipsum deserunt ullamco est sit aliqua dolor do amet sint. Velit officia consequat duis enim."
+      />
+    )
+  }
+
+  return null
 }

--- a/packages/ui/src/modals/AddMembershipModal/SignCreateMemberModal.tsx
+++ b/packages/ui/src/modals/AddMembershipModal/SignCreateMemberModal.tsx
@@ -1,6 +1,6 @@
 import { BalanceOf } from '@polkadot/types/interfaces/runtime'
 import BN from 'bn.js'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { Member } from '../../common/types'
 import { ButtonPrimaryMedium } from '../../components/buttons'
 import { Label } from '../../components/forms'
@@ -32,12 +32,7 @@ export const SignCreateMemberModal = ({ onClose, membershipPrice, transactionPar
     about: transactionParams.about,
   })
 
-  const { paymentInfo, send, status } = useSignAndSendTransaction({ transaction, from })
-
-  useEffect(() => {
-    const isDone = status === 'SUCCESS' || status === 'ERROR'
-    isDone && onDone(status === 'SUCCESS', paymentInfo?.partialFee?.toBn() || new BN(0))
-  })
+  const { paymentInfo, send, status } = useSignAndSendTransaction({ transaction, from, onDone })
 
   if (status === 'READY') {
     return (

--- a/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
+++ b/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
@@ -1,5 +1,5 @@
 import BN from 'bn.js'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Account } from '../../common/types'
 import { AccountInfo } from '../../components/AccountInfo'
 import { ButtonPrimaryMedium } from '../../components/buttons'
@@ -37,12 +37,7 @@ export function SignTransferModal({ onClose, from, amount, to, onDone }: Props) 
   const balanceTo = useBalance(to)
   const { api } = useApi()
   const transaction = api?.tx?.balances?.transfer(to.address, amount)
-  const { paymentInfo, send, status } = useSignAndSendTransaction({ transaction, from })
-
-  useEffect(() => {
-    const isDone = status === 'SUCCESS' || status === 'ERROR'
-    isDone && onDone(status === 'SUCCESS', paymentInfo?.partialFee?.toBn() || new BN(0))
-  })
+  const { paymentInfo, send, status } = useSignAndSendTransaction({ transaction, from, onDone })
 
   if (status === 'READY') {
     return (

--- a/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
+++ b/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
@@ -39,10 +39,8 @@ export function SignTransferModal({ onClose, from, amount, to, onDone }: Props) 
   const transaction = api?.tx?.balances?.transfer(to.address, amount)
   const { paymentInfo, send, status } = useSignAndSendTransaction({ transaction, from })
 
-  // TODO: move onDone to useSignAndSend?
   useEffect(() => {
     const isDone = status === 'SUCCESS' || status === 'ERROR'
-
     isDone && onDone(status === 'SUCCESS', paymentInfo?.partialFee?.toBn() || new BN(0))
   })
 

--- a/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
+++ b/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
@@ -48,7 +48,7 @@ export function SignTransferModal({ onClose, from, amount, to, onDone }: Props) 
 
   if (status === 'READY') {
     return (
-      <Modal modalSize="m"  onClose={onClose}>
+      <Modal modalSize="m" onClose={onClose}>
         <ModalHeader onClick={onClose} title="Authorize Transaction" />
         <ModalBody>
           <SignTransferContainer>
@@ -116,7 +116,8 @@ export function SignTransferModal({ onClose, from, amount, to, onDone }: Props) 
 
   if (status === 'EXTENSION') {
     return (
-      <WaitModal onClose={onClose}
+      <WaitModal
+        onClose={onClose}
         title="Waiting for the extension"
         description="Please, sign the transaction using external signer app."
       />
@@ -125,7 +126,8 @@ export function SignTransferModal({ onClose, from, amount, to, onDone }: Props) 
 
   if (status === 'PENDING') {
     return (
-      <WaitModal onClose={onClose}
+      <WaitModal
+        onClose={onClose}
         title="Pending transaction"
         description="We are waiting for your transaction to be mined. It can takes Lorem ipsum deserunt ullamco est sit aliqua dolor do amet sint. Velit officia consequat duis enim."
       />

--- a/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
+++ b/packages/ui/src/modals/TransferModal/SignTransferModal.tsx
@@ -1,14 +1,12 @@
-import { ISubmittableResult } from '@polkadot/types/types'
 import BN from 'bn.js'
-import React from 'react'
-import { Observable } from 'rxjs'
+import React, { useEffect } from 'react'
+import { Account } from '../../common/types'
 import { AccountInfo } from '../../components/AccountInfo'
 import { ButtonPrimaryMedium } from '../../components/buttons'
 import { Help } from '../../components/Help'
 import { ArrowDownExpandedIcon } from '../../components/icons'
 import { Modal, ModalBody, ModalFooter, ModalHeader, SignTransferContainer } from '../../components/Modal'
 import { TokenValue } from '../../components/typography'
-import { Account } from '../../common/types'
 import { useApi } from '../../hooks/useApi'
 import { useBalance } from '../../hooks/useBalance'
 import { useSignAndSendTransaction } from '../../hooks/useSignAndSendTransaction'
@@ -24,85 +22,115 @@ import {
   TransactionInfo,
   TransactionInfoLabel,
 } from '../common'
+import { WaitModal } from '../WaitModal'
 
 interface Props {
   onClose: () => void
   from: Account
   amount: BN
   to: Account
-  onSign: (transaction: Observable<ISubmittableResult>, fee: BN) => void
+  onDone: (result: boolean, fee: BN) => void
 }
 
-export function SignTransferModal({ onClose, from, amount, to, onSign }: Props) {
+export function SignTransferModal({ onClose, from, amount, to, onDone }: Props) {
   const balanceFrom = useBalance(from)
   const balanceTo = useBalance(to)
   const { api } = useApi()
   const transaction = api?.tx?.balances?.transfer(to.address, amount)
-  const { isSending, paymentInfo, send } = useSignAndSendTransaction({ transaction, from, onSign })
+  const { paymentInfo, send, status } = useSignAndSendTransaction({ transaction, from })
 
-  return (
-    <Modal modalSize={'m'} onClose={onClose}>
-      <ModalHeader onClick={onClose} title="Authorize Transaction" />
-      <ModalBody>
-        <SignTransferContainer>
-          <Row>
-            <TransactionInfoLabel>
-              You are transferring <TokenValue value={amount} /> stake from “{from.name}” account to “{to.name}”{' '}
-              destination.
-            </TransactionInfoLabel>
-            <LockedAccount>
-              <AccountInfo account={from} />
-              <BalanceInfoInRow>
-                <InfoTitle>Transferable balance</InfoTitle>
-                <InfoValue>
-                  <TokenValue value={balanceFrom?.transferable} />
-                </InfoValue>
-              </BalanceInfoInRow>
-            </LockedAccount>
-          </Row>
-          <TransactionAmountInfo>
-            <ArrowDownExpandedIcon />
-            <TransactionAmountInfoText>
-              Transferring <TokenValue value={amount} />
-            </TransactionAmountInfoText>
-          </TransactionAmountInfo>
-          <Row>
-            <LockedAccount>
-              <AccountInfo account={to} />
-              <BalanceInfoInRow>
-                <InfoTitle>Transferable balance</InfoTitle>
-                <InfoValue>
-                  <TokenValue value={balanceTo?.transferable} />
-                </InfoValue>
-              </BalanceInfoInRow>
-            </LockedAccount>
-          </Row>
-        </SignTransferContainer>
-      </ModalBody>
-      <ModalFooter>
-        <TransactionInfo>
-          <BalanceInfoNarrow>
-            <InfoTitle>Amount:</InfoTitle>
-            <InfoValue>
-              <TokenValue value={amount} />
-            </InfoValue>
-          </BalanceInfoNarrow>
-          <BalanceInfoNarrow>
-            <InfoTitle>Transaction fee:</InfoTitle>
-            <InfoValue>
-              <TokenValue value={paymentInfo?.partialFee.toBn()} />
-            </InfoValue>
-            <Help
-              helperText={
-                'Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora mollitia necessitatibus, eos recusandae obcaecati facilis sed maiores. Impedit iusto expedita natus perspiciatis, perferendis totam commodi ad, illo, veritatis omnis beatae.Facilis natus recusandae, magni saepe hic veniam aliquid tempore quia assumenda voluptatum reprehenderit. Officiis provident nam corrupti, incidunt, repudiandae accusantium porro libero ipsam illo quae ratione. Beatae itaque quo quidem.'
-              }
-            />
-          </BalanceInfoNarrow>
-        </TransactionInfo>
-        <ButtonPrimaryMedium onClick={send} disabled={isSending}>
-          Sign transaction and Transfer
-        </ButtonPrimaryMedium>
-      </ModalFooter>
-    </Modal>
-  )
+  // TODO: move onDone to useSignAndSend?
+  useEffect(() => {
+    const isDone = status === 'SUCCESS' || status === 'ERROR'
+
+    isDone && onDone(status === 'SUCCESS', paymentInfo?.partialFee?.toBn() || new BN(0))
+  })
+
+  if (status === 'READY') {
+    return (
+      <Modal modalSize="m"  onClose={onClose}>
+        <ModalHeader onClick={onClose} title="Authorize Transaction" />
+        <ModalBody>
+          <SignTransferContainer>
+            <Row>
+              <TransactionInfoLabel>
+                You are transferring <TokenValue value={amount} /> stake from “{from.name}” account to “{to.name}”{' '}
+                destination.
+              </TransactionInfoLabel>
+              <LockedAccount>
+                <AccountInfo account={from} />
+                <BalanceInfoInRow>
+                  <InfoTitle>Transferable balance</InfoTitle>
+                  <InfoValue>
+                    <TokenValue value={balanceFrom?.transferable} />
+                  </InfoValue>
+                </BalanceInfoInRow>
+              </LockedAccount>
+            </Row>
+            <TransactionAmountInfo>
+              <ArrowDownExpandedIcon />
+              <TransactionAmountInfoText>
+                Transferring <TokenValue value={amount} />
+              </TransactionAmountInfoText>
+            </TransactionAmountInfo>
+            <Row>
+              <LockedAccount>
+                <AccountInfo account={to} />
+                <BalanceInfoInRow>
+                  <InfoTitle>Transferable balance</InfoTitle>
+                  <InfoValue>
+                    <TokenValue value={balanceTo?.transferable} />
+                  </InfoValue>
+                </BalanceInfoInRow>
+              </LockedAccount>
+            </Row>
+          </SignTransferContainer>
+        </ModalBody>
+        <ModalFooter>
+          <TransactionInfo>
+            <BalanceInfoNarrow>
+              <InfoTitle>Amount:</InfoTitle>
+              <InfoValue>
+                <TokenValue value={amount} />
+              </InfoValue>
+            </BalanceInfoNarrow>
+            <BalanceInfoNarrow>
+              <InfoTitle>Transaction fee:</InfoTitle>
+              <InfoValue>
+                <TokenValue value={paymentInfo?.partialFee.toBn()} />
+              </InfoValue>
+              <Help
+                helperText={
+                  'Lorem ipsum dolor sit amet consectetur, adipisicing elit. Tempora mollitia necessitatibus, eos recusandae obcaecati facilis sed maiores. Impedit iusto expedita natus perspiciatis, perferendis totam commodi ad, illo, veritatis omnis beatae.Facilis natus recusandae, magni saepe hic veniam aliquid tempore quia assumenda voluptatum reprehenderit. Officiis provident nam corrupti, incidunt, repudiandae accusantium porro libero ipsam illo quae ratione. Beatae itaque quo quidem.'
+                }
+              />
+            </BalanceInfoNarrow>
+          </TransactionInfo>
+          <ButtonPrimaryMedium onClick={send} disabled={status !== 'READY'}>
+            Sign transaction and Transfer
+          </ButtonPrimaryMedium>
+        </ModalFooter>
+      </Modal>
+    )
+  }
+
+  if (status === 'EXTENSION') {
+    return (
+      <WaitModal onClose={onClose}
+        title="Waiting for the extension"
+        description="Please, sign the transaction using external signer app."
+      />
+    )
+  }
+
+  if (status === 'PENDING') {
+    return (
+      <WaitModal onClose={onClose}
+        title="Pending transaction"
+        description="We are waiting for your transaction to be mined. It can takes Lorem ipsum deserunt ullamco est sit aliqua dolor do amet sint. Velit officia consequat duis enim."
+      />
+    )
+  }
+
+  return null
 }

--- a/packages/ui/src/modals/TransferModal/TransferModal.tsx
+++ b/packages/ui/src/modals/TransferModal/TransferModal.tsx
@@ -1,10 +1,6 @@
-import { EventRecord } from '@polkadot/types/interfaces/system'
-import { ISubmittableResult } from '@polkadot/types/types'
 import BN from 'bn.js'
-import React, { ReactElement, useEffect, useState } from 'react'
-import { Observable, Subscription } from 'rxjs'
+import React, { ReactElement, useState } from 'react'
 import { Account } from '../../common/types'
-import { WaitModal } from '../WaitModal'
 import { SignTransferModal } from './SignTransferModal'
 import { TransactionFailureModal } from './TransactionFailureModal'
 import { TransactionSuccessModal } from './TransactionSuccessModal'
@@ -17,8 +13,7 @@ interface Props {
   icon: ReactElement
 }
 
-type ModalState = 'PREPARE' | 'AUTHORIZE' | 'EXTENSION_SIGN' | 'SENDING' | 'SUCCESS' | 'ERROR'
-const isError = (events: EventRecord[]) => events.find(({ event: { method } }) => method === 'ExtrinsicFailed')
+type ModalState = 'PREPARE' | 'AUTHORIZE' | 'SUCCESS' | 'ERROR'
 
 export function TransferModal({ from, to, onClose, icon }: Props) {
   const [step, setStep] = useState<ModalState>('PREPARE')
@@ -26,16 +21,10 @@ export function TransferModal({ from, to, onClose, icon }: Props) {
   const [fee, setFee] = useState<BN>(new BN(0))
   const [transferFrom, setTransferFrom] = useState(from)
   const [transferTo, setTransferTo] = useState<Account | undefined>(to)
-  const [subscription, setSubscription] = useState<Subscription | undefined>(undefined)
+
   const isTransfer = !from && !to
   const isSend = !!from
   const title = isTransfer ? 'Transfer tokens' : isSend ? 'Send tokens' : 'Receive tokens'
-
-  useEffect(() => {
-    if (subscription) {
-      return () => subscription.unsubscribe()
-    }
-  }, [subscription])
 
   const onAccept = (amount: BN, from: Account, to: Account) => {
     setAmount(amount)
@@ -44,40 +33,9 @@ export function TransferModal({ from, to, onClose, icon }: Props) {
     setStep('AUTHORIZE')
   }
 
-  const onSign = (transaction: Observable<ISubmittableResult>, fee: BN) => {
-    if (!transferFrom) {
-      return
-    }
-
-    const statusCallback = (result: ISubmittableResult) => {
-      const { status, events } = result
-
-      console.log(`Current transaction status: ${status.type}`)
-
-      if (status.isReady) {
-        setStep('SENDING')
-      }
-
-      if (status.isInBlock) {
-        console.log('Included at block hash', JSON.stringify(status.asInBlock))
-        console.log('Events:')
-
-        events.forEach(({ event: { data, method, section }, phase }) => {
-          console.log('\t', JSON.stringify(phase), `: ${section}.${method}`, JSON.stringify(data))
-        })
-        console.log(JSON.stringify(events))
-      }
-
-      if (!status.isFinalized) {
-        return
-      }
-
-      setStep(isError(events) ? 'ERROR' : 'SUCCESS')
-    }
-
-    setStep('EXTENSION_SIGN')
+  const onDone = (result: boolean, fee: BN) => {
+    setStep(result ? 'SUCCESS' : 'ERROR')
     setFee(fee)
-    setSubscription(transaction.subscribe(statusCallback))
   }
 
   if (step === 'PREPARE' || !transferTo || !transferFrom) {
@@ -94,29 +52,7 @@ export function TransferModal({ from, to, onClose, icon }: Props) {
   }
 
   if (step === 'AUTHORIZE') {
-    return <SignTransferModal onClose={onClose} from={transferFrom} amount={amount} to={transferTo} onSign={onSign} />
-  }
-
-  if (step === 'EXTENSION_SIGN') {
-    return (
-      <WaitModal
-        title="Waiting for the extension"
-        description={'Please, sign the transaction using external signer app.'}
-        onClose={onClose}
-      />
-    )
-  }
-
-  if (step === 'SENDING') {
-    return (
-      <WaitModal
-        title="Pending transaction"
-        description={
-          'We are waiting for your transaction to be mined. It can takes Lorem ipsum deserunt ullamco est sit aliqua dolor do amet sint. Velit officia consequat duis enim.'
-        }
-        onClose={onClose}
-      />
-    )
+    return <SignTransferModal onClose={onClose} from={transferFrom} amount={amount} to={transferTo} onDone={onDone} />
   }
 
   if (step === 'SUCCESS') {


### PR DESCRIPTION
This PR contains two major changes:

- Refactored the way how singing is handled, now most of the transaction observe is done inside a hook (so, in one place)
- The `<SignXXX>` modals were refactored so handling transaction sends states is handled there. The plan is to have a base `<SignAndSend>` modal to hide "pending transaction" and "wait for extension" modals juggling there.
- I've also added handling of signing rejections handling as "ERROR" – this might change if we introduce detailed messages, but for now, it might be OK.