### PR TITLE
📡 Query my memberships once

### DIFF
--- a/packages/ui/src/accounts/model/sortAccounts.ts
+++ b/packages/ui/src/accounts/model/sortAccounts.ts
@@ -7,8 +7,8 @@ export type SortKey = keyof Balances | 'name'
 
 export function sortAccounts(accounts: Account[], balanceMap: AddressToBalanceMap, key: SortKey, isDescending = false) {
   return key === 'name'
-    ? accounts.sort(Comparator<Account>(isDescending, key).string)
-    : accounts.sort(BalanceComparator(balanceMap, key, isDescending))
+    ? [...accounts].sort(Comparator<Account>(isDescending, key).string)
+    : [...accounts].sort(BalanceComparator(balanceMap, key, isDescending))
 }
 
 export function setOrder(

--- a/packages/ui/src/accounts/providers/accounts/provider.tsx
+++ b/packages/ui/src/accounts/providers/accounts/provider.tsx
@@ -1,6 +1,7 @@
 import { web3Accounts, web3Enable } from '@polkadot/extension-dapp'
 import { Keyring } from '@polkadot/ui-keyring'
 import React, { ReactNode, useEffect, useState } from 'react'
+import { debounceTime } from 'rxjs/operators'
 
 import { useKeyring } from '../../../common/hooks/useKeyring'
 import { useObservable } from '../../../common/hooks/useObservable'
@@ -83,7 +84,7 @@ export const AccountsContextProvider = (props: Props) => {
     loadKeysFromExtension(keyring).catch(console.error)
   }, [isLoaded])
 
-  const accounts = useObservable(keyring.accounts.subject.asObservable(), [keyring])
+  const accounts = useObservable(keyring.accounts.subject.asObservable().pipe(debounceTime(20)), [keyring])
 
   const allAccounts: Account[] = []
 

--- a/packages/ui/src/app/pages/Profile/components/Accounts.tsx
+++ b/packages/ui/src/app/pages/Profile/components/Accounts.tsx
@@ -21,7 +21,7 @@ export function Accounts() {
   const [sortBy, setSortBy] = useState<SortKey>('name')
   const [isDescending, setDescending] = useState(false)
   const visibleAccounts = useMemo(() => filterAccounts(allAccounts, isDisplayAll, balances), [
-    allAccounts,
+    JSON.stringify(allAccounts),
     isDisplayAll,
     hasAccounts,
   ])

--- a/packages/ui/src/app/pages/Profile/components/Memberships.tsx
+++ b/packages/ui/src/app/pages/Profile/components/Memberships.tsx
@@ -11,7 +11,8 @@ import { MembersSection } from '../../../../memberships/components/MembersSectio
 import { useMyMemberships } from '../../../../memberships/hooks/useMyMemberships'
 
 export function Memberships() {
-  const { count, isLoading, members, active } = useMyMemberships()
+  const { isLoading, members, active } = useMyMemberships()
+  const count = members.length
   const hasMemberships = !!count
 
   if (isLoading) {

--- a/packages/ui/src/memberships/components/CurrentMember/CurrentMember.tsx
+++ b/packages/ui/src/memberships/components/CurrentMember/CurrentMember.tsx
@@ -13,9 +13,11 @@ import { AddMembershipButton } from '../AddMembershipButton'
 import { SwitchMemberModal } from './SwitchMemberModal'
 
 export const CurrentMember = () => {
-  const { count, active } = useMyMemberships()
+  const { members, active } = useMyMemberships()
   const [isOpen, toggleOpen] = useToggle()
   const { showModal } = useModal()
+
+  const count = members.length
 
   if (count < 1) {
     return <AddMembershipButton>Create membership</AddMembershipButton>

--- a/packages/ui/src/memberships/components/CurrentMember/SwitchMemberModal.tsx
+++ b/packages/ui/src/memberships/components/CurrentMember/SwitchMemberModal.tsx
@@ -15,7 +15,8 @@ interface Props {
 }
 
 export const SwitchMemberModal = ({ onClose, onCreateMember }: Props) => {
-  const { count, members, setActive, active } = useMyMemberships()
+  const { members, setActive, active } = useMyMemberships()
+  const count = members.length
   const switchMember = (member: Member) => {
     setActive(member)
     onClose()

--- a/packages/ui/src/memberships/hooks/useMyMemberships.ts
+++ b/packages/ui/src/memberships/hooks/useMyMemberships.ts
@@ -1,34 +1,5 @@
 import { useContext } from 'react'
 
-import { useAccounts } from '../../accounts/hooks/useAccounts'
 import { MembershipContext } from '../providers/membership/context'
-import { useGetMembersQuery } from '../queries'
-import { asMember, Member } from '../types'
 
-const POLL_INTERVAL = 5000
-
-interface UseMembership {
-  members: Member[]
-  isLoading: boolean
-  active: Member | undefined
-  setActive: (member: Member) => void
-}
-
-export function useMyMemberships(): UseMembership {
-  const { allAccounts } = useAccounts()
-  const addresses = allAccounts.map((account) => account.address)
-  const options = {
-    variables: { rootAccount_in: addresses, controllerAccount_in: addresses },
-    pollInterval: POLL_INTERVAL,
-  }
-  const { data, loading, error } = useGetMembersQuery(options)
-  const { active, setActive } = useContext(MembershipContext)
-
-  if (error) {
-    console.error(error)
-  }
-
-  const members = (data?.memberships ?? []).map(asMember)
-
-  return { members, isLoading: loading, active, setActive }
-}
+export const useMyMemberships = () => useContext(MembershipContext)

--- a/packages/ui/src/memberships/hooks/useMyMemberships.ts
+++ b/packages/ui/src/memberships/hooks/useMyMemberships.ts
@@ -8,7 +8,6 @@ import { asMember, Member } from '../types'
 const POLL_INTERVAL = 5000
 
 interface UseMembership {
-  count: number
   members: Member[]
   isLoading: boolean
   active: Member | undefined
@@ -29,8 +28,7 @@ export function useMyMemberships(): UseMembership {
     console.error(error)
   }
 
-  const count = data?.memberships.length ?? 0
   const members = (data?.memberships ?? []).map(asMember)
 
-  return { count, members, isLoading: loading, active, setActive }
+  return { members, isLoading: loading, active, setActive }
 }

--- a/packages/ui/src/memberships/model/sortMemberships.ts
+++ b/packages/ui/src/memberships/model/sortMemberships.ts
@@ -5,10 +5,10 @@ export type SortKey = keyof Member
 
 export function sortMemberships(members: Member[], key: SortKey, isDescending = false) {
   if (key === 'handle') {
-    return members.sort(Comparator<Member>(isDescending, key).string)
+    return [...members].sort(Comparator<Member>(isDescending, key).string)
   }
   if (key === 'inviteCount') {
-    return members.sort(Comparator<Member>(isDescending, key).number)
+    return [...members].sort(Comparator<Member>(isDescending, key).number)
   }
   return members
 }

--- a/packages/ui/src/memberships/providers/membership/context.tsx
+++ b/packages/ui/src/memberships/providers/membership/context.tsx
@@ -1,10 +1,12 @@
 import { createContext } from 'react'
 
-import { UseMembership } from './provider'
+import { MyMemberships } from './provider'
 
-export const MembershipContext = createContext<UseMembership>({
+export const MembershipContext = createContext<MyMemberships>({
   active: undefined,
   setActive: () => {
     /**/
   },
+  members: [],
+  isLoading: true,
 })

--- a/packages/ui/src/memberships/providers/membership/provider.tsx
+++ b/packages/ui/src/memberships/providers/membership/provider.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react'
+import React, { ReactNode, useMemo, useState } from 'react'
 
 import { useAccounts } from '../../../accounts/hooks/useAccounts'
 import { useGetMembersQuery } from '../../queries'
@@ -24,17 +24,17 @@ export const MembershipContextProvider = (props: Props) => {
 
   const { allAccounts } = useAccounts()
   const addresses = allAccounts.map((account) => account.address)
-  const options = {
+
+  const { data, loading, error } = useGetMembersQuery({
     variables: { rootAccount_in: addresses, controllerAccount_in: addresses },
     pollInterval: POLL_INTERVAL,
-  }
-  const { data, loading, error } = useGetMembersQuery(options)
+  })
 
   if (error) {
     console.error(error)
   }
 
-  const members = (data?.memberships ?? []).map(asMember)
+  const members = useMemo(() => (data?.memberships ?? []).map(asMember), [loading, JSON.stringify(data?.memberships)])
 
   const value = {
     active,

--- a/packages/ui/src/memberships/providers/membership/provider.tsx
+++ b/packages/ui/src/memberships/providers/membership/provider.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode, useState } from 'react'
 
-import { Member } from '../../types'
+import { useAccounts } from '../../../accounts/hooks/useAccounts'
+import { useGetMembersQuery } from '../../queries'
+import { asMember, Member } from '../../types'
 
 import { MembershipContext } from './context'
 
@@ -8,17 +10,37 @@ interface Props {
   children: ReactNode
 }
 
-export interface UseMembership {
-  active?: Member
+export interface MyMemberships {
+  members: Member[]
+  isLoading: boolean
+  active: Member | undefined
   setActive: (member: Member) => void
 }
+
+const POLL_INTERVAL = 5000
 
 export const MembershipContextProvider = (props: Props) => {
   const [active, setActive] = useState<Member>()
 
+  const { allAccounts } = useAccounts()
+  const addresses = allAccounts.map((account) => account.address)
+  const options = {
+    variables: { rootAccount_in: addresses, controllerAccount_in: addresses },
+    pollInterval: POLL_INTERVAL,
+  }
+  const { data, loading, error } = useGetMembersQuery(options)
+
+  if (error) {
+    console.error(error)
+  }
+
+  const members = (data?.memberships ?? []).map(asMember)
+
   const value = {
     active,
     setActive,
+    members,
+    isLoading: loading,
   }
 
   return <MembershipContext.Provider value={value}>{props.children}</MembershipContext.Provider>

--- a/packages/ui/test/accounts/components/MyAccounts.test.tsx
+++ b/packages/ui/test/accounts/components/MyAccounts.test.tsx
@@ -10,6 +10,7 @@ import { Accounts } from '../../../src/app/pages/Profile/components/Accounts'
 import { shortenAddress } from '../../../src/common/model/formatters'
 import { KeyringContext } from '../../../src/common/providers/keyring/context'
 import { MembershipContext } from '../../../src/memberships/providers/membership/context'
+import { MyMemberships } from '../../../src/memberships/providers/membership/provider'
 import { Member } from '../../../src/memberships/types'
 import { seedMembers } from '../../../src/mocks/data'
 import { alice, aliceStash, bob, bobStash } from '../../_mocks/keyring'
@@ -119,7 +120,7 @@ describe('UI: Accounts list', () => {
     return render(
       <HashRouter>
         <MockApolloProvider>
-          <MembershipContext.Provider value={{ active, setActive: () => undefined }}>
+          <MembershipContext.Provider value={({ active, setActive: () => undefined } as unknown) as MyMemberships}>
             <Accounts />
           </MembershipContext.Provider>
         </MockApolloProvider>

--- a/packages/ui/test/accounts/hooks/useTotalBalances.test.tsx
+++ b/packages/ui/test/accounts/hooks/useTotalBalances.test.tsx
@@ -1,4 +1,5 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto'
+import { act } from '@testing-library/react'
 import { renderHook } from '@testing-library/react-hooks'
 import BN from 'bn.js'
 import set from 'lodash/set'
@@ -13,6 +14,8 @@ import { stubApi } from '../../_mocks/transactions'
 
 describe('useTotalBalances', () => {
   const useApi = stubApi()
+
+  jest.useFakeTimers()
 
   beforeAll(async () => {
     await cryptoWaitReady()
@@ -54,6 +57,10 @@ describe('useTotalBalances', () => {
     useApi.isConnected = true
 
     const { result } = renderUseTotalBalances()
+
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
 
     expect(result.current).toEqual({
       total: new BN(880),

--- a/packages/ui/test/membership/components/MyMemberships.test.tsx
+++ b/packages/ui/test/membership/components/MyMemberships.test.tsx
@@ -1,15 +1,13 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto'
-import { render, waitForElementToBeRemoved, within } from '@testing-library/react'
+import { render, waitForElementToBeRemoved } from '@testing-library/react'
 import React from 'react'
 import { HashRouter } from 'react-router-dom'
 
 import { Account } from '../../../src/accounts/types'
 import { Memberships } from '../../../src/app/pages/Profile/components/Memberships'
-import { MembershipContext } from '../../../src/memberships/providers/membership/context'
-import { Member } from '../../../src/memberships/types'
+import { MembershipContextProvider } from '../../../src/memberships/providers/membership/provider'
 import { seedMembers } from '../../../src/mocks/data'
 import { alice, bob } from '../../_mocks/keyring'
-import { getMember } from '../../_mocks/members'
 import { MockApolloProvider } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 
@@ -32,48 +30,29 @@ describe('UI: Memberships list', () => {
 
   const mockServer = setupMockServer()
 
-  describe('with no memberships', () => {
-    it('Shows Create Membership button', async () => {
-      const { findByRole } = renderMemberships()
+  it('No memberships', async () => {
+    const { findByRole } = renderMemberships()
 
-      expect(await findByRole('button', { name: /create a membership/i })).toBeDefined()
-    })
+    expect(await findByRole('button', { name: /create a membership/i })).toBeDefined()
   })
 
-  describe('with memberships', () => {
-    it('Shows list of memberships', async () => {
-      seedMembers(mockServer.server)
-      const { getByText } = renderMemberships()
+  it('With memberships', async () => {
+    seedMembers(mockServer.server)
+    const { getByText } = renderMemberships()
 
-      await waitForElementToBeRemoved(() => getByText('Loading...'))
+    await waitForElementToBeRemoved(() => getByText('Loading...'))
 
-      expect(getByText(/alice/i)).toBeDefined()
-      expect(getByText(/bob/i)).toBeDefined()
-    })
-
-    it('Shows active membership', async () => {
-      seedMembers(mockServer.server)
-      const { getByText } = renderMemberships(getMember('bob'))
-
-      await waitForElementToBeRemoved(() => getByText('Loading...'))
-
-      const activeMemberships = getByText(/active membership/i).parentElement!
-      expect(activeMemberships).toBeDefined()
-      expect(within(activeMemberships).getByText(/bob/i)).toBeDefined()
-
-      const otherMemberships = getByText(/other memberships/i).parentElement!
-      expect(otherMemberships).toBeDefined()
-      expect(within(otherMemberships).getByText(/alice/i)).toBeDefined()
-    })
+    expect(getByText(/alice/i)).toBeDefined()
+    expect(getByText(/bob/i)).toBeDefined()
   })
 
-  function renderMemberships(active?: Member) {
+  function renderMemberships() {
     return render(
       <HashRouter>
         <MockApolloProvider>
-          <MembershipContext.Provider value={{ active, setActive: () => undefined }}>
+          <MembershipContextProvider>
             <Memberships />
-          </MembershipContext.Provider>
+          </MembershipContextProvider>
         </MockApolloProvider>
       </HashRouter>
     )

--- a/packages/ui/test/membership/hooks/useMyMemberships.test.tsx
+++ b/packages/ui/test/membership/hooks/useMyMemberships.test.tsx
@@ -39,7 +39,6 @@ describe('useMyMemberships', () => {
 
     expect(result.current).toMatchObject({
       active: undefined,
-      count: 0,
       isLoading: true,
       members: [],
     })
@@ -52,7 +51,6 @@ describe('useMyMemberships', () => {
 
     expect(result.current).toMatchObject({
       active: undefined,
-      count: 0,
       isLoading: false,
       members: [],
     })
@@ -69,7 +67,6 @@ describe('useMyMemberships', () => {
 
     expect(result.current).toMatchObject({
       active: undefined,
-      count: 1,
       isLoading: false,
       members: [aliceMember],
     })
@@ -86,7 +83,6 @@ describe('useMyMemberships', () => {
 
     expect(result.current).toMatchObject({
       active: undefined,
-      count: 1,
       isLoading: false,
       members: [bobMember],
     })
@@ -106,7 +102,6 @@ describe('useMyMemberships', () => {
 
     expect(result.current).toMatchObject({
       active: aliceMember,
-      count: 1,
       isLoading: false,
       members: [aliceMember],
     })


### PR DESCRIPTION
@p-sad FYI we had one nasty bug related to how JS sort work :cry: I've forgotten for some reason that `.sort()` is one in-place:

```javascript
const t = [8,3,7,1,5,8,1,3]
t.sort()
console.log( t )
// logs; [1, 1, 3, 3, 5, 7, 8, 8]
```

That made the dependency list of `useMemo()` useless and triggered re-render loop :man\_dancing: 

The other changes are related to reducing the number of initial calls to Hydra as:

*   The way how accounts were returned was causing re-renders (each account triggered hook change) I've added `debounceTime()` for that.