### PR TITLE
💼 Apply for position transaction

### DIFF
--- a/packages/ui/src/working-groups/components/ApplicationQuestionInput.tsx
+++ b/packages/ui/src/working-groups/components/ApplicationQuestionInput.tsx
@@ -6,14 +6,17 @@ import { ApplicationQuestionType } from '../types'
 
 interface ApplicationQuestionInputProps {
   type: ApplicationQuestionType
+  index: number
   question: string
   onChange: (value: string) => void
 }
 
-export const ApplicationQuestionInput = ({ question, type, onChange }: ApplicationQuestionInputProps) => {
+export const ApplicationQuestionInput = ({ question, index, type, onChange }: ApplicationQuestionInputProps) => {
+  const inputId = `field-${index}`
+
   return (
-    <InputComponent label={question} required inputSize={type === 'TEXTAREA' ? 'auto' : 'm'}>
-      {type === 'TEXT' && <InputText onChange={(event) => onChange(event.target.value)} />}
+    <InputComponent label={question} required inputSize={type === 'TEXTAREA' ? 'auto' : 'm'} id={inputId}>
+      {type === 'TEXT' && <InputText id={inputId} onChange={(event) => onChange(event.target.value)} />}
       {type === 'TEXTAREA' && <CKEditor onChange={(event, editor) => onChange(editor.getData())} />}
     </InputComponent>
   )

--- a/packages/ui/src/working-groups/components/OpeningFormPreview.stories.tsx
+++ b/packages/ui/src/working-groups/components/OpeningFormPreview.stories.tsx
@@ -39,5 +39,6 @@ Default.args = {
     applicants: { current: 2, total: 10 },
     hiring: { current: 0, total: 1 },
     status: 'OpeningStatusOpen',
+    stake: new BN(2000),
   },
 }

--- a/packages/ui/src/working-groups/components/OpeningsList.stories.tsx
+++ b/packages/ui/src/working-groups/components/OpeningsList.stories.tsx
@@ -27,6 +27,7 @@ Default.args = {
       applicants: { current: 2, total: 10 },
       hiring: { current: 0, total: 1 },
       status: 'OpeningStatusOpen',
+      stake: new BN(2_000),
     },
     {
       id: '221',
@@ -40,6 +41,7 @@ Default.args = {
       applicants: { current: 8, total: 10 },
       hiring: { current: 1, total: 1 },
       status: 'OpeningStatusOpen',
+      stake: new BN(2_000),
     },
   ],
 }

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplicationStep.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplicationStep.tsx
@@ -1,18 +1,31 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo } from 'react'
+import * as Yup from 'yup'
 
 import { RowGapBlock } from '../../../common/components/page/PageContent'
+import { useForm } from '../../../common/hooks/useForm'
 import { ApplicationQuestionInput } from '../../components/ApplicationQuestionInput'
 import { ApplicationQuestion } from '../../types'
 
 interface ApplicationStepProps {
   questions: ApplicationQuestion[]
-  onChange: (isValid: boolean, answers: string[]) => void
+  onChange: (isValid: boolean, answers: Record<number, string>) => void
+}
+
+const validationSchemaFromQuestions = (questions: ApplicationQuestion[]) => {
+  const shapeDefinition = questions.reduce(
+    (schema, question, index) => ({
+      [index]: Yup.string().required(),
+      ...schema,
+    }),
+    {}
+  )
+  return Yup.object().shape(shapeDefinition)
 }
 
 export const ApplicationStep = ({ questions, onChange }: ApplicationStepProps) => {
-  const [answers, setAnswers] = useState<string[]>(questions.map(() => ''))
-
-  useEffect(() => onChange(true, [...answers]), [JSON.stringify(answers)])
+  const schema = useMemo(() => validationSchemaFromQuestions(questions), [JSON.stringify(questions)])
+  const { fields, changeField, validation } = useForm<Record<number, string>>({}, schema)
+  useEffect(() => onChange(validation.isValid, fields), [JSON.stringify(fields)])
 
   return (
     <RowGapBlock gap={24}>
@@ -20,17 +33,13 @@ export const ApplicationStep = ({ questions, onChange }: ApplicationStepProps) =
       <RowGapBlock gap={20}>
         {questions
           .sort((a, b) => a.index - b.index)
-          .map((question) => (
+          .map((question, index) => (
             <ApplicationQuestionInput
               type={question.type}
               question={question.question}
+              index={question.index}
               key={question.index}
-              onChange={(value) =>
-                setAnswers((answers) => {
-                  answers.splice(question.index, 1, value)
-                  return [...answers]
-                })
-              }
+              onChange={(value) => changeField(index, value)}
             />
           ))}
       </RowGapBlock>

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplicationStep.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplicationStep.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { RowGapBlock } from '../../../common/components/page/PageContent'
 import { ApplicationQuestionInput } from '../../components/ApplicationQuestionInput'
@@ -12,7 +12,7 @@ interface ApplicationStepProps {
 export const ApplicationStep = ({ questions, onChange }: ApplicationStepProps) => {
   const [answers, setAnswers] = useState<string[]>(questions.map(() => ''))
 
-  useMemo(() => onChange(true, [...answers]), [JSON.stringify(answers)])
+  useEffect(() => onChange(true, [...answers]), [JSON.stringify(answers)])
 
   return (
     <RowGapBlock gap={24}>

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
@@ -1,3 +1,4 @@
+import BN from 'bn.js'
 import React, { useMemo, useState } from 'react'
 
 import { FailureModal } from '../../../common/components/FailureModal'
@@ -18,13 +19,22 @@ export const ApplyForRoleModal = () => {
   const { active } = useMyMemberships()
   const signer = active?.controllerAccount
   const onDone = (result: boolean) => setState(result ? 'SUCCESS' : 'ERROR')
+  const stake = new BN(10_000)
 
   if (state === 'PREPARE') {
     return <ApplyForRolePrepareModal onSubmit={() => setState('AUTHORIZE')} />
   }
 
   if (state === 'AUTHORIZE' && signer) {
-    return <ApplyForRoleSignModal onClose={hideModal} onDone={onDone} transaction={transaction} signer={signer} />
+    return (
+      <ApplyForRoleSignModal
+        onClose={hideModal}
+        onDone={onDone}
+        transaction={transaction}
+        signer={signer}
+        stake={stake}
+      />
+    )
   }
 
   if (state === 'SUCCESS') {

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react'
 
+import { FailureModal } from '../../../common/components/FailureModal'
 import { useApi } from '../../../common/hooks/useApi'
 import { useModal } from '../../../common/hooks/useModal'
 import { ModalState } from '../../../common/types'
@@ -7,6 +8,7 @@ import { useMyMemberships } from '../../../memberships/hooks/useMyMemberships'
 
 import { ApplyForRolePrepareModal } from './ApplyForRolePrepareModal'
 import { ApplyForRoleSignModal } from './ApplyForRoleSignModal'
+import { ApplyForRoleSuccessModal } from './ApplyForRoleSuccessModal'
 
 export const ApplyForRoleModal = () => {
   const [state, setState] = useState<ModalState>('PREPARE')
@@ -15,23 +17,19 @@ export const ApplyForRoleModal = () => {
   const transaction = useMemo(() => api?.tx?.membershipWorkingGroup.applyOnOpening({}), [api])
   const { active } = useMyMemberships()
   const signer = active?.controllerAccount
+  const onDone = (result: boolean) => setState(result ? 'SUCCESS' : 'ERROR')
 
   if (state === 'PREPARE') {
-    return (
-      <ApplyForRolePrepareModal
-        onSubmit={() => {
-          setState('AUTHORIZE')
-          hideModal()
-        }}
-      />
-    )
+    return <ApplyForRolePrepareModal onSubmit={() => setState('AUTHORIZE')} />
   }
 
   if (state === 'AUTHORIZE' && signer) {
-    return (
-      <ApplyForRoleSignModal onClose={hideModal} onDone={() => undefined} transaction={transaction} signer={signer} />
-    )
+    return <ApplyForRoleSignModal onClose={hideModal} onDone={onDone} transaction={transaction} signer={signer} />
   }
 
-  return null
+  if (state === 'SUCCESS') {
+    return <ApplyForRoleSuccessModal onClose={hideModal} />
+  }
+
+  return <FailureModal onClose={hideModal}>There was a problem with applying for an opening.</FailureModal>
 }

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
@@ -1,13 +1,20 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 
+import { useApi } from '../../../common/hooks/useApi'
 import { useModal } from '../../../common/hooks/useModal'
 import { ModalState } from '../../../common/types'
+import { useMyMemberships } from '../../../memberships/hooks/useMyMemberships'
 
 import { ApplyForRolePrepareModal } from './ApplyForRolePrepareModal'
+import { ApplyForRoleSignModal } from './ApplyForRoleSignModal'
 
 export const ApplyForRoleModal = () => {
   const [state, setState] = useState<ModalState>('PREPARE')
   const { hideModal } = useModal()
+  const { api } = useApi()
+  const transaction = useMemo(() => api?.tx?.membershipWorkingGroup.applyOnOpening({}), [api])
+  const { active } = useMyMemberships()
+  const signer = active?.controllerAccount
 
   if (state === 'PREPARE') {
     return (
@@ -17,6 +24,12 @@ export const ApplyForRoleModal = () => {
           hideModal()
         }}
       />
+    )
+  }
+
+  if (state === 'AUTHORIZE' && signer) {
+    return (
+      <ApplyForRoleSignModal onClose={hideModal} onDone={() => undefined} transaction={transaction} signer={signer} />
     )
   }
 

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRolePrepareModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRolePrepareModal.tsx
@@ -77,7 +77,7 @@ export const ApplyForRolePrepareModal = ({ onSubmit }: Props) => {
       },
     })
   }
-  const onApplicationStepChange = (isValid: boolean, answers: string[]) => {
+  const onApplicationStepChange = (isValid: boolean, answers: Record<number, string>) => {
     dispatch({
       type: 'STEP',
       data: {
@@ -88,7 +88,6 @@ export const ApplyForRolePrepareModal = ({ onSubmit }: Props) => {
     })
   }
 
-  console.log(state)
   const isValid = state[step].isValid
 
   return (

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRolePrepareModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRolePrepareModal.tsx
@@ -11,17 +11,18 @@ import {
   StepperModalWrapper,
 } from '../../../common/components/StepperModal'
 import { useModal } from '../../../common/hooks/useModal'
+import { useMyMemberships } from '../../../memberships/hooks/useMyMemberships'
 import { OpeningFormPreview } from '../../components/OpeningFormPreview'
 import { useOpeningQuestions } from '../../hooks/useOpeningQuestions'
 
-import { ApplyForRoleModalCall } from '.'
+import { ApplyForRoleModalCall, OpeningParams } from '.'
 import { ApplicationStep } from './ApplicationStep'
 import { StakeStep, StakeStepForm } from './StakeStep'
 
 const steps = [{ title: 'Stake' }, { title: 'Form' }, { title: 'Submit application' }]
 
 interface Props {
-  onSubmit: () => void
+  onSubmit: (params: OpeningParams) => void
 }
 
 type ActionStepInfo = {
@@ -48,6 +49,7 @@ const stepsReducer: Reducer<Record<number, { data: any; isValid: boolean }>, Act
 }
 
 export const ApplyForRolePrepareModal = ({ onSubmit }: Props) => {
+  const { active } = useMyMemberships()
   const {
     hideModal,
     modalData: { opening },
@@ -61,11 +63,22 @@ export const ApplyForRolePrepareModal = ({ onSubmit }: Props) => {
 
   const nextStep = useCallback(() => {
     if (step >= 1) {
-      onSubmit()
+      const stakeForm = state[0].data as StakeStepForm
+      onSubmit({
+        opening_id: opening.id,
+        member_id: active?.id,
+        role_account_id: active?.controllerAccount,
+        reward_account_id: active?.rootAccount,
+        description: JSON.stringify(state[1].data), // TODO This should be applicaiton metedata
+        stake_parameters: {
+          stake: stakeForm.amount,
+          stake_account_id: stakeForm.account?.address,
+        },
+      })
     } else {
       setStep((step) => step + 1)
     }
-  }, [step])
+  }, [step, JSON.stringify(state)])
 
   const onStakeStepChange = (isValid: boolean, fields: StakeStepForm) => {
     dispatch({

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRolePrepareModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRolePrepareModal.tsx
@@ -54,7 +54,7 @@ export const ApplyForRolePrepareModal = ({ onSubmit }: Props) => {
             <OpeningFormPreview opening={opening} />
           </StepDescriptionColumn>
           <StepperBody>
-            {step === 0 && <StakeStep onChange={onStakeStepChange} />}
+            {step === 0 && <StakeStep onChange={onStakeStepChange} opening={opening} />}
             {step === 1 && <ApplicationStep questions={questions} onChange={onApplicationStepChange} />}
           </StepperBody>
         </StepperModalWrapper>

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleSignModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleSignModal.tsx
@@ -1,5 +1,6 @@
 import { SubmittableExtrinsic } from '@polkadot/api/types'
 import { ISubmittableResult } from '@polkadot/types/types'
+import BN from 'bn.js'
 import React, { useEffect, useState } from 'react'
 
 import { SelectedAccount } from '../../../accounts/components/SelectAccount'
@@ -19,9 +20,10 @@ interface SignProps {
   onDone: onTransactionDone
   transaction: SubmittableExtrinsic<'rxjs', ISubmittableResult> | undefined
   signer: Address
+  stake: BN
 }
 
-export const ApplyForRoleSignModal = ({ onClose, onDone, transaction, signer }: SignProps) => {
+export const ApplyForRoleSignModal = ({ onClose, onDone, transaction, signer, stake }: SignProps) => {
   const { allAccounts } = useAccounts()
   const signerAccount = accountOrNamed(allAccounts, signer, 'ControllerAccount')
   const { paymentInfo, send, status } = useSignAndSendTransaction({
@@ -45,7 +47,10 @@ export const ApplyForRoleSignModal = ({ onClose, onDone, transaction, signer }: 
   return (
     <TransactionModal status={status} onClose={onClose}>
       <ModalBody>
-        <TextMedium>You intend to apply to an opening...</TextMedium>
+        <TextMedium>You intend to apply for a role.</TextMedium>
+        <TextMedium>
+          You intend to stake <TokenValue value={stake} />.
+        </TextMedium>
         <TextMedium>
           Fees of <TokenValue value={partialFee?.toBn()} /> will be applied to the transaction.
         </TextMedium>
@@ -55,6 +60,11 @@ export const ApplyForRoleSignModal = ({ onClose, onDone, transaction, signer }: 
       </ModalBody>
       <ModalFooter>
         <BalanceInfoNarrow>
+          <InfoTitle>Stake:</InfoTitle>
+          <InfoValue>
+            <TokenValue value={stake} />
+          </InfoValue>
+          <Help helperText={'Lorem ipsum dolor sit amet consectetur, adipisicing elit.'} absolute />
           <InfoTitle>Transaction fee:</InfoTitle>
           <InfoValue>
             <TokenValue value={partialFee?.toBn()} />

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleSignModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleSignModal.tsx
@@ -62,7 +62,7 @@ export const ApplyForRoleSignModal = ({ onClose, onDone, transaction, signer }: 
           <Help helperText={'Lorem ipsum dolor sit amet consectetur, adipisicing elit.'} absolute />
         </BalanceInfoNarrow>
         <ButtonPrimary size="medium" onClick={send} disabled={signDisabled}>
-          Sign and create a member
+          Sign transaction and Stake
         </ButtonPrimary>
       </ModalFooter>
     </TransactionModal>

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleSignModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleSignModal.tsx
@@ -1,0 +1,70 @@
+import { SubmittableExtrinsic } from '@polkadot/api/types'
+import { ISubmittableResult } from '@polkadot/types/types'
+import React, { useEffect, useState } from 'react'
+
+import { SelectedAccount } from '../../../accounts/components/SelectAccount'
+import { useAccounts } from '../../../accounts/hooks/useAccounts'
+import { useBalance } from '../../../accounts/hooks/useBalance'
+import { accountOrNamed } from '../../../accounts/model/accountOrNamed'
+import { ButtonPrimary } from '../../../common/components/buttons'
+import { Help } from '../../../common/components/Help'
+import { BalanceInfoNarrow, InfoTitle, InfoValue, ModalBody, ModalFooter, Row } from '../../../common/components/Modal'
+import { TransactionModal } from '../../../common/components/TransactionModal'
+import { TextMedium, TokenValue } from '../../../common/components/typography'
+import { useSignAndSendTransaction } from '../../../common/hooks/useSignAndSendTransaction'
+import { Address, onTransactionDone } from '../../../common/types'
+
+interface SignProps {
+  onClose: () => void
+  onDone: onTransactionDone
+  transaction: SubmittableExtrinsic<'rxjs', ISubmittableResult> | undefined
+  signer: Address
+}
+
+export const ApplyForRoleSignModal = ({ onClose, onDone, transaction, signer }: SignProps) => {
+  const { allAccounts } = useAccounts()
+  const signerAccount = accountOrNamed(allAccounts, signer, 'ControllerAccount')
+  const { paymentInfo, send, status } = useSignAndSendTransaction({
+    transaction,
+    signer: signer,
+    onDone,
+  })
+  const [hasFunds, setHasFunds] = useState(false)
+  const balance = useBalance(signer)
+  const transferable = balance?.transferable
+  const partialFee = paymentInfo?.partialFee
+
+  useEffect(() => {
+    if (transferable && partialFee) {
+      setHasFunds(transferable.gte(partialFee))
+    }
+  }, [partialFee?.toString(), transferable?.toString()])
+
+  const signDisabled = status !== 'READY' || !hasFunds
+
+  return (
+    <TransactionModal status={status} onClose={onClose}>
+      <ModalBody>
+        <TextMedium>You intend to apply to an opening...</TextMedium>
+        <TextMedium>
+          Fees of <TokenValue value={partialFee?.toBn()} /> will be applied to the transaction.
+        </TextMedium>
+        <Row>
+          <SelectedAccount account={signerAccount} />
+        </Row>
+      </ModalBody>
+      <ModalFooter>
+        <BalanceInfoNarrow>
+          <InfoTitle>Transaction fee:</InfoTitle>
+          <InfoValue>
+            <TokenValue value={partialFee?.toBn()} />
+          </InfoValue>
+          <Help helperText={'Lorem ipsum dolor sit amet consectetur, adipisicing elit.'} absolute />
+        </BalanceInfoNarrow>
+        <ButtonPrimary size="medium" onClick={send} disabled={signDisabled}>
+          Sign and create a member
+        </ButtonPrimary>
+      </ModalFooter>
+    </TransactionModal>
+  )
+}

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleSuccessModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleSuccessModal.tsx
@@ -1,0 +1,31 @@
+import React, { ReactNode } from 'react'
+
+import { SuccessIcon } from '../../../common/components/icons'
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '../../../common/components/Modal'
+import { TextMedium } from '../../../common/components/typography'
+
+interface Props {
+  onClose: () => void
+}
+
+type SuccessModalProps = { onClose: () => void; children: ReactNode }
+
+const SuccessModal = ({ onClose, children }: SuccessModalProps) => {
+  return (
+    <Modal modalSize="m" modalHeight="s" onClose={onClose}>
+      <ModalHeader onClick={onClose} title="Success" icon={<SuccessIcon />} />
+      {children}
+    </Modal>
+  )
+}
+
+export const ApplyForRoleSuccessModal = ({ onClose }: Props) => {
+  return (
+    <SuccessModal onClose={onClose}>
+      <ModalBody>
+        <TextMedium>You have just successfully applier for a role.</TextMedium>
+      </ModalBody>
+      <ModalFooter />
+    </SuccessModal>
+  )
+}

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/StakeStep.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/StakeStep.tsx
@@ -15,7 +15,7 @@ import { formatTokenValue } from '../../../common/model/formatters'
 import { AccountSchema } from '../../../memberships/model/validation'
 import { WorkingGroupOpening } from '../../types'
 
-interface StakeStepForm {
+export interface StakeStepForm {
   account?: Account
   amount?: string
 }

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/StakeStep.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/StakeStep.tsx
@@ -13,6 +13,7 @@ import { useForm } from '../../../common/hooks/useForm'
 import { useNumberInput } from '../../../common/hooks/useNumberInput'
 import { formatTokenValue } from '../../../common/model/formatters'
 import { AccountSchema } from '../../../memberships/model/validation'
+import { WorkingGroupOpening } from '../../types'
 
 interface StakeStepForm {
   account?: Account
@@ -24,21 +25,21 @@ const StakeStepFormSchema = Yup.object().shape({
   amount: Yup.number().required(),
 })
 
-const MIN_STAKE = 10_000
-
 interface StakeStepProps {
+  opening: WorkingGroupOpening
   onChange: (isValid: boolean, fields: StakeStepForm) => void
 }
 
-export function StakeStep({ onChange }: StakeStepProps) {
+export function StakeStep({ onChange, opening }: StakeStepProps) {
   const [amount, setAmount] = useNumberInput(0)
+  const minStake = opening.stake
   const schema = useMemo(() => {
     StakeStepFormSchema.fields.amount = StakeStepFormSchema.fields.amount.min(
-      MIN_STAKE,
+      minStake.toNumber(),
       'You need at least ${min} stake'
     )
     return StakeStepFormSchema
-  }, [MIN_STAKE])
+  }, [minStake.toString()])
 
   const initializer = {
     account: undefined,
@@ -72,9 +73,9 @@ export function StakeStep({ onChange }: StakeStepProps) {
           <RowGapBlock gap={8}>
             <h4>Stake</h4>
             <TextMedium>
-              You must stake at least <ValueInJoys>{formatTokenValue(MIN_STAKE)}</ValueInJoys> to apply for this role.
-              This stake will be returned to you when the hiring process is complete, whether or not you are hired, and
-              will also be used to rank applications.
+              You must stake at least <ValueInJoys>{formatTokenValue(minStake.toNumber())}</ValueInJoys> to apply for
+              this role. This stake will be returned to you when the hiring process is complete, whether or not you are
+              hired, and will also be used to rank applications.
             </TextMedium>
           </RowGapBlock>
           <InputComponent

--- a/packages/ui/src/working-groups/types/WorkingGroupOpening.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroupOpening.ts
@@ -25,6 +25,7 @@ export interface WorkingGroupOpening {
     total: number
   }
   status: Status
+  stake: BN
 }
 
 export const asWorkingGroupOpening = (fields: WorkingGroupOpeningFieldsFragment): WorkingGroupOpening => ({
@@ -47,6 +48,7 @@ export const asWorkingGroupOpening = (fields: WorkingGroupOpeningFieldsFragment)
   shortDescription: fields.metadata.shortDescription,
   description: fields.metadata.description,
   status: fields.status.__typename,
+  stake: new BN(fields.stakeAmount),
 })
 
 export type ApplicationQuestionType = 'TEXT' | 'TEXTAREA'

--- a/packages/ui/test/_mocks/members/index.ts
+++ b/packages/ui/test/_mocks/members/index.ts
@@ -1,4 +1,4 @@
-import { Member } from '../../../src/memberships/types'
+import { asMember, Member } from '../../../src/memberships/types'
 import { mockMembers } from '../../../src/mocks/data'
 
 export type Members = 'alice' | 'bob'
@@ -9,5 +9,5 @@ export const getMember = (handle: Members): Member => {
   delete member.registeredAtTime
   delete member.invitedById
   delete member.about
-  return member
+  return asMember(member)
 }

--- a/packages/ui/test/_mocks/server/index.ts
+++ b/packages/ui/test/_mocks/server/index.ts
@@ -1,7 +1,7 @@
 import { Server } from 'miragejs'
 
 import { seedBlocks } from '../../../src/mocks/data'
-import { makeServer } from '../../../src/mocks/server'
+import { fixAssociations, makeServer } from '../../../src/mocks/server'
 
 interface MockServer {
   server?: Server
@@ -12,6 +12,7 @@ export function setupMockServer(): MockServer {
 
   beforeEach(() => {
     mock.server = makeServer('test')
+    fixAssociations((mock.server as unknown) as any)
     seedBlocks(mock.server)
   })
 

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -2,7 +2,8 @@ import { cryptoWaitReady } from '@polkadot/util-crypto'
 import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 
-import { Account } from '../../../src/accounts/types'
+import { AccountsContext } from '../../../src/accounts/providers/accounts/context'
+import { UseAccounts } from '../../../src/accounts/providers/accounts/provider'
 import { ApiContext } from '../../../src/common/providers/api/context'
 import { ModalContext } from '../../../src/common/providers/modal/context'
 import { UseModal } from '../../../src/common/providers/modal/types'
@@ -18,17 +19,10 @@ import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/provid
 import { setupMockServer } from '../../_mocks/server'
 import { stubApi, stubDefaultBalances } from '../../_mocks/transactions'
 
-const useAccounts: { hasAccounts: boolean; allAccounts: Account[] } = {
+const useAccounts: UseAccounts = {
   hasAccounts: false,
   allAccounts: [],
 }
-
-jest.mock('../../../src/accounts/hooks/useAccounts', () => {
-  return {
-    useAccounts: () => useAccounts,
-  }
-})
-
 describe('UI: ApplyForRoleModal', () => {
   const api = stubApi()
   const useModal: UseModal<any> = {
@@ -90,9 +84,11 @@ describe('UI: ApplyForRoleModal', () => {
       <ModalContext.Provider value={useModal}>
         <MockQueryNodeProviders>
           <MockKeyringProvider>
-            <ApiContext.Provider value={api}>
-              <ApplyForRoleModal />
-            </ApiContext.Provider>
+            <AccountsContext.Provider value={useAccounts}>
+              <ApiContext.Provider value={api}>
+                <ApplyForRoleModal />
+              </ApiContext.Provider>
+            </AccountsContext.Provider>
           </MockKeyringProvider>
         </MockQueryNodeProviders>
       </ModalContext.Provider>

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -64,7 +64,7 @@ describe('UI: ApplyForRoleModal', () => {
     it('Empty fields', async () => {
       renderModal()
 
-      const button = await screen.findByRole('button', { name: /Next step/i })
+      const button = await getNextStepButton()
       expect(button).toBeDisabled()
     })
 
@@ -75,7 +75,7 @@ describe('UI: ApplyForRoleModal', () => {
       const input = await screen.findByLabelText(/Select amount for staking/i)
       await fireEvent.change(input, { target: { value: '50' } })
 
-      const button = await screen.findByRole('button', { name: /Next step/i })
+      const button = await getNextStepButton()
       expect(button).toBeDisabled()
     })
 
@@ -83,14 +83,35 @@ describe('UI: ApplyForRoleModal', () => {
       renderModal()
 
       await selectAccount('Select account for Staking', 'alice')
-
       const input = await screen.findByLabelText(/Select amount for staking/i)
       await fireEvent.change(input, { target: { value: '2000' } })
 
-      const button = await screen.findByRole('button', { name: /Next step/i })
+      const button = await getNextStepButton()
       expect(button).not.toBeDisabled()
     })
   })
+
+  describe('Application form step', () => {
+    beforeEach(async () => {
+      await renderModal()
+      await fillStakeStep()
+    })
+
+    it('Empty form', async () => {
+      const button = await getNextStepButton()
+      expect(button).not.toBeDisabled()
+    })
+  })
+
+  async function getNextStepButton() {
+    return await screen.findByRole('button', { name: /Next step/i })
+  }
+
+  async function fillStakeStep() {
+    await selectAccount('Select account for Staking', 'alice')
+    const input = await screen.findByLabelText(/Select amount for staking/i)
+    await fireEvent.change(input, { target: { value: '2000' } })
+  }
 
   function renderModal() {
     return render(

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -23,6 +23,7 @@ const useAccounts: UseAccounts = {
   hasAccounts: false,
   allAccounts: [],
 }
+
 describe('UI: ApplyForRoleModal', () => {
   const api = stubApi()
   const useModal: UseModal<any> = {
@@ -60,21 +61,33 @@ describe('UI: ApplyForRoleModal', () => {
   })
 
   describe('Stake step', () => {
-    it('Validates fields', async () => {
+    it('Empty fields', async () => {
       renderModal()
 
       const button = await screen.findByRole('button', { name: /Next step/i })
       expect(button).toBeDisabled()
+    })
+
+    it('Too low stake', async () => {
+      renderModal()
+
+      await selectAccount('Select account for Staking', 'alice')
+      const input = await screen.findByLabelText(/Select amount for staking/i)
+      await fireEvent.change(input, { target: { value: '50' } })
+
+      const button = await screen.findByRole('button', { name: /Next step/i })
+      expect(button).toBeDisabled()
+    })
+
+    it('Valid fields', async () => {
+      renderModal()
 
       await selectAccount('Select account for Staking', 'alice')
 
       const input = await screen.findByLabelText(/Select amount for staking/i)
-      await fireEvent.change(input, { target: { value: '50' } })
-
-      expect(button).toBeDisabled()
-
       await fireEvent.change(input, { target: { value: '2000' } })
 
+      const button = await screen.findByRole('button', { name: /Next step/i })
       expect(button).not.toBeDisabled()
     })
   })

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -79,7 +79,7 @@ describe('UI: ApplyForRoleModal', () => {
 
       expect(button).toBeDisabled()
 
-      await fireEvent.change(input, { target: { value: '500000' } })
+      await fireEvent.change(input, { target: { value: '2000' } })
 
       expect(button).not.toBeDisabled()
     })

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -189,20 +189,20 @@ describe('UI: ApplyForRoleModal', () => {
       expect((await screen.findByText(/^Transaction fee:/i))?.nextSibling?.textContent).toBe('25')
     })
 
-    it.skip('Success step', async () => {
+    it('Success step', async () => {
       stubTransactionSuccess(tx, [])
       await fillSteps()
 
-      fireEvent.click(screen.getByText(/^sign and update a member$/i))
+      fireEvent.click(screen.getByText(/^Sign transaction and Stake$/i))
 
       expect(await screen.findByText('Success')).toBeDefined()
     })
 
-    it.skip('Failure step', async () => {
+    it('Failure step', async () => {
       stubTransactionFailure(tx)
       await fillSteps()
 
-      fireEvent.click(screen.getByText(/^sign and update a member$/i))
+      fireEvent.click(screen.getByText(/^Sign transaction and Stake$/i))
 
       expect(await screen.findByText('Failure')).toBeDefined()
     })


### PR DESCRIPTION
See #419 & #418.

The sign & send transaction works, but since we do not have any openings on the blockchain we can't verify if it is OK.

The follow-ups for this PR include:

- [x] add an issue for proper transaction failure states to display #478
- [x] improve the stepper abstraction and types - ATM I've used a local reducer and used magic numbers for steps #479
- [x] update the success step with proper values to close #419
- [x] map working group id/title to proper extrinsic, ATM I've used `membershipsWorkingGroup` to check proper mappings. #480