### PR TITLE
⇅ Add members sorting

### DIFF
--- a/packages/ui/src/app/pages/Members/Members.tsx
+++ b/packages/ui/src/app/pages/Members/Members.tsx
@@ -3,20 +3,22 @@ import React, { useReducer } from 'react'
 import { Loading } from '../../../common/components/Loading'
 import { PageHeader } from '../../../common/components/page/PageHeader'
 import { PageTitle } from '../../../common/components/page/PageTitle'
-import { MemberList, MemberListOrder } from '../../../memberships/components/MemberList'
-import { useMembers } from '../../../memberships/hooks/useMembers'
+import { MemberList } from '../../../memberships/components/MemberList'
+import { MemberListOrder, useMembers } from '../../../memberships/hooks/useMembers'
 import { AppPage } from '../../components/AppPage'
+
+type SortKey = MemberListOrder['sortBy']
 
 export const Members = () => {
   const crumbs = [{ href: '#', text: 'Members' }]
   const [order, dispatchSort] = useReducer(
-    (order: MemberListOrder, sortBy: MemberListOrder['sortBy']): MemberListOrder => ({
+    (order: MemberListOrder, sortBy: SortKey): MemberListOrder => ({
       sortBy: sortBy,
       isDescending: sortBy === order.sortBy && !order.isDescending,
     }),
     { sortBy: 'id', isDescending: false }
   )
-  const { members, isLoading } = useMembers()
+  const { members, isLoading } = useMembers({ order })
 
   return (
     <AppPage crumbs={crumbs}>

--- a/packages/ui/src/app/pages/Members/Members.tsx
+++ b/packages/ui/src/app/pages/Members/Members.tsx
@@ -4,20 +4,18 @@ import { Loading } from '../../../common/components/Loading'
 import { PageHeader } from '../../../common/components/page/PageHeader'
 import { PageTitle } from '../../../common/components/page/PageTitle'
 import { MemberList } from '../../../memberships/components/MemberList'
-import { MemberListOrder, useMembers } from '../../../memberships/hooks/useMembers'
+import { MemberListOrder, MemberListSortKey, useMembers } from '../../../memberships/hooks/useMembers'
 import { AppPage } from '../../components/AppPage'
 
-type SortKey = MemberListOrder['sortBy']
+const sortReducer = (order: MemberListOrder, sortBy: MemberListSortKey): MemberListOrder => ({
+  sortBy: sortBy,
+  isDescending: sortBy === order.sortBy && !order.isDescending,
+})
 
 export const Members = () => {
   const crumbs = [{ href: '#', text: 'Members' }]
-  const [order, dispatchSort] = useReducer(
-    (order: MemberListOrder, sortBy: SortKey): MemberListOrder => ({
-      sortBy: sortBy,
-      isDescending: sortBy === order.sortBy && !order.isDescending,
-    }),
-    { sortBy: 'id', isDescending: false }
-  )
+  const [order, dispatchSort] = useReducer(sortReducer, { sortBy: 'id', isDescending: false })
+
   const { members, isLoading } = useMembers({ order })
 
   return (

--- a/packages/ui/src/app/pages/Members/Members.tsx
+++ b/packages/ui/src/app/pages/Members/Members.tsx
@@ -1,21 +1,28 @@
-import React from 'react'
+import React, { useReducer } from 'react'
 
 import { Loading } from '../../../common/components/Loading'
 import { PageHeader } from '../../../common/components/page/PageHeader'
 import { PageTitle } from '../../../common/components/page/PageTitle'
-import { MemberList } from '../../../memberships/components/MemberList'
+import { MemberList, MemberListOrder } from '../../../memberships/components/MemberList'
 import { useMembers } from '../../../memberships/hooks/useMembers'
 import { AppPage } from '../../components/AppPage'
 
 export const Members = () => {
   const crumbs = [{ href: '#', text: 'Members' }]
+  const [order, dispatchSort] = useReducer(
+    (order: MemberListOrder, sortBy: MemberListOrder['sortBy']): MemberListOrder => ({
+      sortBy: sortBy,
+      isDescending: sortBy === order.sortBy && !order.isDescending,
+    }),
+    { sortBy: 'id', isDescending: false }
+  )
   const { members, isLoading } = useMembers()
 
   return (
     <AppPage crumbs={crumbs}>
       <PageHeader>
         <PageTitle>Members</PageTitle>
-        {isLoading ? <Loading /> : <MemberList members={members} />}
+        {isLoading ? <Loading /> : <MemberList members={members} order={order} onSort={dispatchSort} />}
       </PageHeader>
     </AppPage>
   )

--- a/packages/ui/src/app/pages/Members/Members.tsx
+++ b/packages/ui/src/app/pages/Members/Members.tsx
@@ -1,16 +1,21 @@
 import React from 'react'
 
+import { Loading } from '../../../common/components/Loading'
 import { PageHeader } from '../../../common/components/page/PageHeader'
 import { PageTitle } from '../../../common/components/page/PageTitle'
+import { MemberList } from '../../../memberships/components/MemberList'
+import { useMembers } from '../../../memberships/hooks/useMembers'
 import { AppPage } from '../../components/AppPage'
 
 export const Members = () => {
   const crumbs = [{ href: '#', text: 'Members' }]
+  const { members, isLoading } = useMembers()
 
   return (
     <AppPage crumbs={crumbs}>
       <PageHeader>
         <PageTitle>Members</PageTitle>
+        {isLoading ? <Loading /> : <MemberList members={members} />}
       </PageHeader>
     </AppPage>
   )

--- a/packages/ui/src/memberships/components/MemberList/Members.tsx
+++ b/packages/ui/src/memberships/components/MemberList/Members.tsx
@@ -1,29 +1,56 @@
-import React from 'react'
+import React, { Dispatch, ReactNode } from 'react'
 
 import { List, ListItem } from '../../../common/components/List'
 import { ListHeader, ListHeaders } from '../../../common/components/List/ListHeader'
+import { HeaderText, SortIconDown, SortIconUp } from '../../../common/components/SortedListHeaders'
 import { Member } from '../../types'
 import { MemberListItem } from '../MemberListItem'
 import { colLayoutByType } from '../MemberListItem/Fileds'
 
-export const MemberList = ({ members }: { members: Member[] }) => (
-  <div>
-    <ListHeaders colLayout={colLayoutByType('Member')}>
-      <ListHeader>Member ID</ListHeader>
-      <ListHeader>Member</ListHeader>
-      <ListHeader>Concil Member</ListHeader>
-      <ListHeader>Active Roles</ListHeader>
-      <ListHeader>Slashed</ListHeader>
-      <ListHeader>Terminated</ListHeader>
-      <ListHeader>Total Balance</ListHeader>
-      <ListHeader>Total Staked</ListHeader>
-    </ListHeaders>
-    <List>
-      {members.map((member) => (
-        <ListItem key={member.handle}>
-          <MemberListItem member={member} />
-        </ListItem>
-      ))}
-    </List>
-  </div>
-)
+type SortKey = keyof Member
+export interface MemberListOrder {
+  sortBy: SortKey
+  isDescending: boolean
+}
+
+interface MemberListProps {
+  members: Member[]
+  order?: MemberListOrder
+  onSort?: Dispatch<keyof Member>
+}
+
+export const MemberList = ({ members, order, onSort }: MemberListProps) => {
+  const SortHeader =
+    order && onSort && members.length > 1
+      ? ({ children, sortKey }: { children: ReactNode; sortKey: SortKey }) => (
+          <ListHeader onClick={() => onSort(sortKey)}>
+            <HeaderText>
+              {children}
+              {order.sortBy === sortKey && (order.isDescending ? <SortIconDown /> : <SortIconUp />)}
+            </HeaderText>
+          </ListHeader>
+        )
+      : ListHeader
+
+  return (
+    <div>
+      <ListHeaders colLayout={colLayoutByType('Member')}>
+        <SortHeader sortKey="id">Member ID</SortHeader>
+        <SortHeader sortKey="handle">Member</SortHeader>
+        <ListHeader>Concil Member</ListHeader>
+        <ListHeader>Active Roles</ListHeader>
+        <ListHeader>Slashed</ListHeader>
+        <ListHeader>Terminated</ListHeader>
+        <ListHeader>Total Balance</ListHeader>
+        <ListHeader>Total Staked</ListHeader>
+      </ListHeaders>
+      <List>
+        {members.map((member) => (
+          <ListItem key={member.handle}>
+            <MemberListItem member={member} />
+          </ListItem>
+        ))}
+      </List>
+    </div>
+  )
+}

--- a/packages/ui/src/memberships/components/MemberList/Members.tsx
+++ b/packages/ui/src/memberships/components/MemberList/Members.tsx
@@ -3,20 +3,16 @@ import React, { Dispatch, ReactNode } from 'react'
 import { List, ListItem } from '../../../common/components/List'
 import { ListHeader, ListHeaders } from '../../../common/components/List/ListHeader'
 import { HeaderText, SortIconDown, SortIconUp } from '../../../common/components/SortedListHeaders'
+import { MemberListOrder } from '../../hooks/useMembers'
 import { Member } from '../../types'
 import { MemberListItem } from '../MemberListItem'
 import { colLayoutByType } from '../MemberListItem/Fileds'
 
-type SortKey = keyof Member
-export interface MemberListOrder {
-  sortBy: SortKey
-  isDescending: boolean
-}
-
+type SortKey = MemberListOrder['sortBy']
 interface MemberListProps {
   members: Member[]
   order?: MemberListOrder
-  onSort?: Dispatch<keyof Member>
+  onSort?: Dispatch<SortKey>
 }
 
 export const MemberList = ({ members, order, onSort }: MemberListProps) => {

--- a/packages/ui/src/memberships/hooks/useMembers.ts
+++ b/packages/ui/src/memberships/hooks/useMembers.ts
@@ -1,0 +1,20 @@
+import { useGetMembersQuery } from '../queries'
+import { asMember, Member } from '../types'
+
+interface UseWorkingGroups {
+  isLoading: boolean
+  members: Member[]
+}
+
+export const useMembers = (): UseWorkingGroups => {
+  const { data, loading, error } = useGetMembersQuery()
+
+  if (error) {
+    console.error(error)
+  }
+
+  return {
+    isLoading: loading,
+    members: data?.memberships.map(asMember) ?? [],
+  }
+}

--- a/packages/ui/src/memberships/hooks/useMembers.ts
+++ b/packages/ui/src/memberships/hooks/useMembers.ts
@@ -1,13 +1,25 @@
+import { MembershipOrderByInput } from '../../common/api/queries'
 import { useGetMembersQuery } from '../queries'
 import { asMember, Member } from '../types'
 
-interface UseWorkingGroups {
+type SortKey = 'id' | 'handle'
+export interface MemberListOrder {
+  sortBy: SortKey
+  isDescending: boolean
+}
+
+interface UseMemberProps {
+  order: MemberListOrder
+}
+interface UseMembers {
   isLoading: boolean
   members: Member[]
 }
 
-export const useMembers = (): UseWorkingGroups => {
-  const { data, loading, error } = useGetMembersQuery()
+export const useMembers = ({ order }: UseMemberProps): UseMembers => {
+  const { data, loading, error } = useGetMembersQuery({
+    variables: { orderBy: orderToGqlInput(order) },
+  })
 
   if (error) {
     console.error(error)
@@ -17,4 +29,16 @@ export const useMembers = (): UseWorkingGroups => {
     isLoading: loading,
     members: data?.memberships.map(asMember) ?? [],
   }
+}
+
+const { EntryAsc, EntryDesc, HandleAsc, HandleDesc } = MembershipOrderByInput
+const orderToGqlInput = ({ sortBy, isDescending }: MemberListOrder): MembershipOrderByInput => {
+  switch (sortBy) {
+    case 'id':
+      return isDescending ? EntryDesc : EntryAsc
+    case 'handle':
+      return isDescending ? HandleDesc : HandleAsc
+  }
+
+  throw new Error(`Unsupported sort key: "${sortBy}" for Member Order`)
 }

--- a/packages/ui/src/memberships/hooks/useMembers.ts
+++ b/packages/ui/src/memberships/hooks/useMembers.ts
@@ -2,9 +2,9 @@ import { MembershipOrderByInput } from '../../common/api/queries'
 import { useGetMembersQuery } from '../queries'
 import { asMember, Member } from '../types'
 
-type SortKey = 'id' | 'handle'
+export type MemberListSortKey = 'id' | 'handle'
 export interface MemberListOrder {
-  sortBy: SortKey
+  sortBy: MemberListSortKey
   isDescending: boolean
 }
 

--- a/packages/ui/src/memberships/queries/__generated__/members.generated.tsx
+++ b/packages/ui/src/memberships/queries/__generated__/members.generated.tsx
@@ -22,6 +22,7 @@ export type MemberFieldsFragment = {
 export type GetMembersQueryVariables = Types.Exact<{
   rootAccount_in?: Types.Maybe<Array<Types.Scalars['String']> | Types.Scalars['String']>
   controllerAccount_in?: Types.Maybe<Array<Types.Scalars['String']> | Types.Scalars['String']>
+  orderBy?: Types.Maybe<Types.MembershipOrderByInput>
 }>
 
 export type GetMembersQuery = {
@@ -84,8 +85,11 @@ export const MemberWithDetailsFragmentDoc = gql`
   ${BlockFieldsFragmentDoc}
 `
 export const GetMembersDocument = gql`
-  query GetMembers($rootAccount_in: [String!], $controllerAccount_in: [String!]) {
-    memberships(where: { rootAccount_in: $rootAccount_in, controllerAccount_in: $controllerAccount_in }) {
+  query GetMembers($rootAccount_in: [String!], $controllerAccount_in: [String!], $orderBy: MembershipOrderByInput) {
+    memberships(
+      where: { rootAccount_in: $rootAccount_in, controllerAccount_in: $controllerAccount_in }
+      orderBy: $orderBy
+    ) {
       ...MemberFields
     }
   }
@@ -106,6 +110,7 @@ export const GetMembersDocument = gql`
  *   variables: {
  *      rootAccount_in: // value for 'rootAccount_in'
  *      controllerAccount_in: // value for 'controllerAccount_in'
+ *      orderBy: // value for 'orderBy'
  *   },
  * });
  */

--- a/packages/ui/src/memberships/queries/members.graphql
+++ b/packages/ui/src/memberships/queries/members.graphql
@@ -11,8 +11,11 @@ fragment MemberFields on Membership {
   inviteCount
 }
 
-query GetMembers($rootAccount_in: [String!], $controllerAccount_in: [String!]) {
-  memberships(where: {rootAccount_in: $rootAccount_in, controllerAccount_in: $controllerAccount_in}) {
+query GetMembers($rootAccount_in: [String!], $controllerAccount_in: [String!], $orderBy: MembershipOrderByInput) {
+  memberships(
+    where: { rootAccount_in: $rootAccount_in, controllerAccount_in: $controllerAccount_in }
+    orderBy: $orderBy
+  ) {
     ...MemberFields
   }
 }
@@ -29,16 +32,13 @@ fragment MemberWithDetails on Membership {
 }
 
 query GetMember($id: ID!) {
-  membership(where: {id: $id}) {
+  membership(where: { id: $id }) {
     ...MemberWithDetails
   }
 }
 
 query SearchMembers($text: String!, $limit: Int) {
-  memberships(where: {
-    name_contains: $text
-    handle_contains: $text
-  }, limit: $limit) {
+  memberships(where: { name_contains: $text, handle_contains: $text }, limit: $limit) {
     ...MemberFields
   }
 }


### PR DESCRIPTION
Should close #433

I followed the `packages/ui/src/common/api/schemas/schema.graphql` but Apollo generates the `GetMembersQueryVariables` type with `orderBy` at the root (along with `rootAccount_in` and `controllerAccount_in`)