### PR TITLE
🚓 Correct `Textarea` CSS syntax

### DIFF
--- a/packages/ui/src/common/components/forms/InputComponent.tsx
+++ b/packages/ui/src/common/components/forms/InputComponent.tsx
@@ -230,9 +230,8 @@ const StyledNumberInput = styled(Input)`
 `
 
 const Textarea = styled.textarea`
-  ${InputStyles} {
-    resize: none;
-  }
+  ${InputStyles}
+  resize: none;
 `
 
 export const InputElement = styled.div<InputElementProps>`


### PR DESCRIPTION
Incorrect CSS syntax in Textarea component. Firefox powers through it and uses the default `resize` style, but in Chrome the site breaks completely as soon as the component tries to render.