### PR TITLE
🏗️ Display "Reward per x blocks"

### DIFF
--- a/packages/ui/src/app/pages/WorkingGroups/WorkingGroupsOpening.tsx
+++ b/packages/ui/src/app/pages/WorkingGroups/WorkingGroupsOpening.tsx
@@ -125,7 +125,7 @@ export const WorkingGroupOpening = () => {
         <Statistics>
           <TokenValueStat title="Current budget" tooltipText="Lorem ipsum..." value={opening.budget} />
           <DurationStatistics title="Opening Expected duration" value={opening.expectedEnding} />
-          <TokenValueStat title="Reward per 3600 blocks" value={opening.reward.value} />
+          <TokenValueStat title="Reward per 3600 blocks" value={opening.reward.payout} />
           <NumericValueStat title="Hiring limit" value={opening.hiring.total} />
         </Statistics>
         <ContentWithSidepanel>

--- a/packages/ui/src/memberships/components/MemberProfile/MemberRoleToggle.stories.tsx
+++ b/packages/ui/src/memberships/components/MemberProfile/MemberRoleToggle.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, Story } from '@storybook/react'
 import React from 'react'
 
 import { TemplateBlock, ModalBlock, WhiteBlock } from '@/common/components/storybookParts/previewStyles'
+import { getReward } from '@/working-groups/model/getReward'
 
 import { MemberRoleToggle, MemberRoleToggleProps } from './MemberRoleToggle'
 
@@ -29,7 +30,7 @@ Default.args = {
     group: { id: '3', name: 'membership' },
     isLeader: false,
     membership: { id: '0', controllerAccount: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY' },
-    rewardPerBlock: 13923,
+    reward: getReward(2, 'membership'),
     stake: 192837021,
     roleAccount: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
     rewardAccount: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY',

--- a/packages/ui/src/memberships/components/MemberProfile/MemberRoleToggle.tsx
+++ b/packages/ui/src/memberships/components/MemberProfile/MemberRoleToggle.tsx
@@ -51,7 +51,7 @@ export const MemberRoleToggle = ({ role }: MemberRoleToggleProps) => {
                     <SidePaneLabel text="Reward" />
                     <SidePaneColumn>
                       <SidePaneText>
-                        <TokenValue value={role.reward.value} /> / {role.reward.interval} blocks
+                        <TokenValue value={role.reward.payout} /> / {role.reward.blockInterval} blocks
                       </SidePaneText>
                     </SidePaneColumn>
                   </SidePaneRow>

--- a/packages/ui/src/memberships/components/MemberProfile/MemberRoleToggle.tsx
+++ b/packages/ui/src/memberships/components/MemberProfile/MemberRoleToggle.tsx
@@ -51,7 +51,7 @@ export const MemberRoleToggle = ({ role }: MemberRoleToggleProps) => {
                     <SidePaneLabel text="Reward" />
                     <SidePaneColumn>
                       <SidePaneText>
-                        <TokenValue value={role.rewardPerBlock} /> / 3600 blocks
+                        <TokenValue value={role.reward.value} /> / {role.reward.interval} blocks
                       </SidePaneText>
                     </SidePaneColumn>
                   </SidePaneRow>

--- a/packages/ui/src/working-groups/components/ApplicationsList.tsx
+++ b/packages/ui/src/working-groups/components/ApplicationsList.tsx
@@ -56,9 +56,9 @@ const ApplicationListItem = ({ application }: { application: WorkingGroupApplica
       <OACItemSummary>
         <OpenItemSummaryColumn>
           <TextInlineBig>
-            <TokenValue value={application.opening?.reward} />
+            <TokenValue value={application.opening.reward.value} />
           </TextInlineBig>
-          <OACSubscriptionWide>Reward per blocks.</OACSubscriptionWide>
+          <OACSubscriptionWide>Reward per {application.opening.reward.interval} blocks.</OACSubscriptionWide>
         </OpenItemSummaryColumn>
         <OpenItemSummaryColumn>
           <TextInlineBig>

--- a/packages/ui/src/working-groups/components/ApplicationsList.tsx
+++ b/packages/ui/src/working-groups/components/ApplicationsList.tsx
@@ -56,9 +56,9 @@ const ApplicationListItem = ({ application }: { application: WorkingGroupApplica
       <OACItemSummary>
         <OpenItemSummaryColumn>
           <TextInlineBig>
-            <TokenValue value={application.opening.reward.value} />
+            <TokenValue value={application.opening.reward.payout} />
           </TextInlineBig>
-          <OACSubscriptionWide>Reward per {application.opening.reward.interval} blocks.</OACSubscriptionWide>
+          <OACSubscriptionWide>Reward per {application.opening.reward.blockInterval} blocks.</OACSubscriptionWide>
         </OpenItemSummaryColumn>
         <OpenItemSummaryColumn>
           <TextInlineBig>

--- a/packages/ui/src/working-groups/components/OpeningFormPreview.tsx
+++ b/packages/ui/src/working-groups/components/OpeningFormPreview.tsx
@@ -63,9 +63,9 @@ export const OpeningFormPreview = React.memo(({ opening }: OpeningFormPreviewPro
           <Label>Reward</Label>
           <TextMedium lighter>
             <TextInlineHuge>
-              <TokenValue value={opening.reward.value} />
+              <TokenValue value={opening.reward.payout} />
             </TextInlineHuge>{' '}
-            per {opening.reward.interval} blocks
+            per {opening.reward.blockInterval} blocks
           </TextMedium>
         </RowGapBlock>
       </Row>

--- a/packages/ui/src/working-groups/components/OpeningsList/OpeningDetails.tsx
+++ b/packages/ui/src/working-groups/components/OpeningsList/OpeningDetails.tsx
@@ -32,9 +32,9 @@ export const OpeningDetails = ({ opening }: Props) => {
         <Statistics withMargin>
           <StatsBlock size="m" centered spacing="s">
             <TextBig>
-              <TokenValue value={opening.reward.value} />
+              <TokenValue value={opening.reward.payout} />
             </TextBig>
-            <Subscription>Reward per {opening.reward.interval} blocks</Subscription>
+            <Subscription>Reward per {opening.reward.blockInterval} blocks</Subscription>
           </StatsBlock>
           <StatsBlock size="m" centered spacing="s">
             <TwoColumnsStatistic>
@@ -54,7 +54,7 @@ export const OpeningDetails = ({ opening }: Props) => {
           </StatsBlock>
           <StatsBlock size="m" centered spacing="s">
             <TextBig>
-              <TokenValue value={opening.reward.value} />
+              <TokenValue value={opening.reward.payout} />
             </TextBig>
             <Subscription>Minimum Stake Required</Subscription>
           </StatsBlock>

--- a/packages/ui/src/working-groups/components/OpeningsList/OpeningListItem.tsx
+++ b/packages/ui/src/working-groups/components/OpeningsList/OpeningListItem.tsx
@@ -33,9 +33,9 @@ export const OpeningListItem = ({ opening }: Props) => (
     <OACItemSummary>
       <OpenItemSummaryColumn>
         <TextInlineBig>
-          <TokenValue value={opening.reward.value} />
+          <TokenValue value={opening.reward.payout} />
         </TextInlineBig>
-        <OACSubscriptionWide>Reward per 3600 blocks.</OACSubscriptionWide>
+        <OACSubscriptionWide>Reward per {opening.reward.blockInterval} blocks.</OACSubscriptionWide>
       </OpenItemSummaryColumn>
       <OpenItemSummaryColumn>
         <Fraction numerator={opening.applicants.current} denominator={opening.applicants.total} sameSize />

--- a/packages/ui/src/working-groups/components/OpeningsList/UpcomingOpeningDetails.tsx
+++ b/packages/ui/src/working-groups/components/OpeningsList/UpcomingOpeningDetails.tsx
@@ -28,9 +28,9 @@ export const UpcomingOpeningDetails = ({ opening }: UpcomingProps) => {
         <Statistics withMargin>
           <StatsBlock size="m" centered spacing="s">
             <TextBig>
-              <TokenValue value={opening.reward.value} />
+              <TokenValue value={opening.reward.payout} />
             </TextBig>
-            <Subscription>Reward per 3600 blocks</Subscription>
+            <Subscription>Reward per {opening.reward.blockInterval} blocks</Subscription>
           </StatsBlock>
           <StatsBlock size="m" centered spacing="s">
             <TwoColumnsStatistic>
@@ -44,7 +44,7 @@ export const UpcomingOpeningDetails = ({ opening }: UpcomingProps) => {
           </StatsBlock>
           <StatsBlock size="m" centered spacing="s">
             <TextBig>
-              <TokenValue value={opening.reward.value} />
+              <TokenValue value={opening.reward.payout} />
             </TextBig>
             <Subscription>Minimum Stake Required</Subscription>
           </StatsBlock>

--- a/packages/ui/src/working-groups/components/OpeningsList/UpcomingOpeningListItem.tsx
+++ b/packages/ui/src/working-groups/components/OpeningsList/UpcomingOpeningListItem.tsx
@@ -29,9 +29,9 @@ export const UpcomingOpeningListItem = ({ opening }: UpcomingProps) => (
     <OACItemSummary>
       <OpenItemSummaryColumn>
         <TextInlineBig>
-          <TokenValue value={opening.reward.value} />
+          <TokenValue value={opening.reward.payout} />
         </TextInlineBig>
-        <OACSubscriptionWide>Reward per 3600 blocks.</OACSubscriptionWide>
+        <OACSubscriptionWide>Reward per {opening.reward.blockInterval} blocks.</OACSubscriptionWide>
       </OpenItemSummaryColumn>
       <OpenItemSummaryColumn>.</OpenItemSummaryColumn>
       <OpenItemSummaryColumn>

--- a/packages/ui/src/working-groups/components/Roles/RolesList.stories.tsx
+++ b/packages/ui/src/working-groups/components/Roles/RolesList.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, Story } from '@storybook/react'
 import React from 'react'
 
 import { RolesList, RolesListProps } from '@/working-groups/components/Roles/RolesList'
+import { getReward } from '@/working-groups/model/getReward'
 
 export default {
   title: 'WorkingGroup/RolesList',
@@ -18,7 +19,7 @@ Default.args = {
       group: { id: '0', name: 'forum' },
       membership: { id: '0', controllerAccount: '5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY' },
       status: 'WorkerStatusActive',
-      rewardPerBlock: 100,
+      reward: getReward(1, 'forum'),
       earnedTotal: 1000,
       stake: 1000,
       isLeader: false,

--- a/packages/ui/src/working-groups/components/Roles/RolesList.tsx
+++ b/packages/ui/src/working-groups/components/Roles/RolesList.tsx
@@ -50,9 +50,9 @@ const RolesListItem = ({ worker }: { worker: Worker }) => {
       <OACItemSummary>
         <OpenItemSummaryColumn>
           <TextInlineBig>
-            <TokenValue value={new BN(worker.reward.value)} />
+            <TokenValue value={new BN(worker.reward.payout)} />
           </TextInlineBig>
-          <OACSubscriptionWide>Reward per {worker.reward.interval} blocks</OACSubscriptionWide>
+          <OACSubscriptionWide>Reward per {worker.reward.blockInterval} blocks</OACSubscriptionWide>
         </OpenItemSummaryColumn>
         <OpenItemSummaryColumn>
           <TextInlineBig>

--- a/packages/ui/src/working-groups/components/Roles/RolesList.tsx
+++ b/packages/ui/src/working-groups/components/Roles/RolesList.tsx
@@ -50,9 +50,9 @@ const RolesListItem = ({ worker }: { worker: Worker }) => {
       <OACItemSummary>
         <OpenItemSummaryColumn>
           <TextInlineBig>
-            <TokenValue value={new BN(worker.rewardPerBlock)} />
+            <TokenValue value={new BN(worker.reward.value)} />
           </TextInlineBig>
-          <OACSubscriptionWide>Reward per 3600 block.</OACSubscriptionWide>
+          <OACSubscriptionWide>Reward per {worker.reward.interval} blocks</OACSubscriptionWide>
         </OpenItemSummaryColumn>
         <OpenItemSummaryColumn>
           <TextInlineBig>

--- a/packages/ui/src/working-groups/model/getReward.ts
+++ b/packages/ui/src/working-groups/model/getReward.ts
@@ -1,11 +1,16 @@
 import BN from 'bn.js'
 
-import { GroupName, GroupRewardPeriods } from '../types'
+import { GroupName, GroupRewardPeriods, KnownWorkingGroups } from '../types'
 import { Reward } from '../types/Reward'
 
 export function getReward(rewardPerBlock: number, groupName: string): Reward {
-  return {
-    payout: GroupRewardPeriods[groupName as GroupName].mul(new BN(rewardPerBlock)),
-    blockInterval: GroupRewardPeriods[groupName as GroupName].toNumber(),
-  }
+  return KnownWorkingGroups.includes(groupName as GroupName)
+    ? {
+        payout: GroupRewardPeriods[groupName as GroupName].mul(new BN(rewardPerBlock)),
+        blockInterval: GroupRewardPeriods[groupName as GroupName].toNumber(),
+      }
+    : {
+        payout: new BN(0),
+        blockInterval: 14400,
+      }
 }

--- a/packages/ui/src/working-groups/model/getReward.ts
+++ b/packages/ui/src/working-groups/model/getReward.ts
@@ -1,0 +1,10 @@
+import BN from 'bn.js'
+
+import { GroupName, GroupRewardPeriods } from '../types'
+
+export function getReward(rewardPerBlock: number, groupName: string) {
+  return {
+    value: GroupRewardPeriods[groupName as GroupName].mul(new BN(rewardPerBlock)),
+    interval: GroupRewardPeriods[groupName as GroupName].toNumber(),
+  }
+}

--- a/packages/ui/src/working-groups/model/getReward.ts
+++ b/packages/ui/src/working-groups/model/getReward.ts
@@ -1,16 +1,18 @@
 import BN from 'bn.js'
 
-import { GroupName, GroupRewardPeriods, KnownWorkingGroups } from '../types'
+import { GroupRewardPeriods, isKnownGroupName } from '../types'
 import { Reward } from '../types/Reward'
 
 export function getReward(rewardPerBlock: number, groupName: string): Reward {
-  return KnownWorkingGroups.includes(groupName as GroupName)
-    ? {
-        payout: GroupRewardPeriods[groupName as GroupName].mul(new BN(rewardPerBlock)),
-        blockInterval: GroupRewardPeriods[groupName as GroupName].toNumber(),
-      }
-    : {
-        payout: new BN(7),
-        blockInterval: 1,
-      }
+  if (isKnownGroupName(groupName)) {
+    return {
+      payout: GroupRewardPeriods[groupName].mul(new BN(rewardPerBlock)),
+      blockInterval: GroupRewardPeriods[groupName].toNumber(),
+    }
+  }
+
+  return {
+    payout: new BN(rewardPerBlock),
+    blockInterval: 1,
+  }
 }

--- a/packages/ui/src/working-groups/model/getReward.ts
+++ b/packages/ui/src/working-groups/model/getReward.ts
@@ -10,7 +10,7 @@ export function getReward(rewardPerBlock: number, groupName: string): Reward {
         blockInterval: GroupRewardPeriods[groupName as GroupName].toNumber(),
       }
     : {
-        payout: new BN(0),
-        blockInterval: 14400,
+        payout: new BN(7),
+        blockInterval: 1,
       }
 }

--- a/packages/ui/src/working-groups/model/getReward.ts
+++ b/packages/ui/src/working-groups/model/getReward.ts
@@ -1,10 +1,11 @@
 import BN from 'bn.js'
 
 import { GroupName, GroupRewardPeriods } from '../types'
+import { Reward } from '../types/Reward'
 
-export function getReward(rewardPerBlock: number, groupName: string) {
+export function getReward(rewardPerBlock: number, groupName: string): Reward {
   return {
-    value: GroupRewardPeriods[groupName as GroupName].mul(new BN(rewardPerBlock)),
-    interval: GroupRewardPeriods[groupName as GroupName].toNumber(),
+    payout: GroupRewardPeriods[groupName as GroupName].mul(new BN(rewardPerBlock)),
+    blockInterval: GroupRewardPeriods[groupName as GroupName].toNumber(),
   }
 }

--- a/packages/ui/src/working-groups/types/Reward.ts
+++ b/packages/ui/src/working-groups/types/Reward.ts
@@ -1,0 +1,6 @@
+import BN from 'bn.js'
+
+export interface Reward {
+  value: BN
+  interval: number
+}

--- a/packages/ui/src/working-groups/types/Reward.ts
+++ b/packages/ui/src/working-groups/types/Reward.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js'
 
 export interface Reward {
-  value: BN
-  interval: number
+  payout: BN
+  blockInterval: number
 }

--- a/packages/ui/src/working-groups/types/Worker.ts
+++ b/packages/ui/src/working-groups/types/Worker.ts
@@ -3,13 +3,17 @@ import { Member } from '@/memberships/types'
 import { WorkerFieldsFragment } from '@/working-groups/queries'
 import { WorkingGroup } from '@/working-groups/types/WorkingGroup'
 
+import { getReward } from '../model/getReward'
+
+import { Reward } from './Reward'
+
 export interface Worker {
   id: string
   membership: Pick<Member, 'id' | 'controllerAccount'>
   group: Pick<WorkingGroup, 'id' | 'name'>
   status: string
   isLeader: boolean
-  rewardPerBlock: number
+  reward: Reward
   earnedTotal: number
   stake: number
 }
@@ -35,7 +39,7 @@ export const asWorker = (fields: WorkerFieldsFragment): Worker => ({
   },
   status: fields.status.__typename,
   isLeader: fields.isLead,
-  rewardPerBlock: fields.rewardPerBlock,
+  reward: getReward(fields.rewardPerBlock, fields.group.name),
   earnedTotal: 1000,
   stake: fields.stake,
 })

--- a/packages/ui/src/working-groups/types/WorkingGroup.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroup.ts
@@ -41,7 +41,9 @@ export const asWorkingGroup = (group: WorkingGroupFieldsFragment): WorkingGroup 
   }
 }
 
-export type GroupName = 'forum' | 'storage' | 'content' | 'membership'
+export const KnownWorkingGroups = ['forum', 'storage', 'content', 'membership'] as const
+
+export type GroupName = typeof KnownWorkingGroups[number]
 
 export const GroupRewardPeriods: Record<GroupName, BN> = {
   forum: new BN(14400 + 10),

--- a/packages/ui/src/working-groups/types/WorkingGroup.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroup.ts
@@ -40,3 +40,12 @@ export const asWorkingGroup = (group: WorkingGroupFieldsFragment): WorkingGroup 
     budget: new BN(group.budget),
   }
 }
+
+export type GroupName = 'forum' | 'storage' | 'content' | 'membership'
+
+export const GroupRewardPeriods: Record<GroupName, BN> = {
+  forum: new BN(14400 + 10),
+  storage: new BN(14400 + 20),
+  content: new BN(14400 + 30),
+  membership: new BN(14400 + 40),
+}

--- a/packages/ui/src/working-groups/types/WorkingGroup.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroup.ts
@@ -41,9 +41,13 @@ export const asWorkingGroup = (group: WorkingGroupFieldsFragment): WorkingGroup 
   }
 }
 
-export const KnownWorkingGroups = ['forum', 'storage', 'content', 'membership'] as const
+const KnownWorkingGroups = ['forum', 'storage', 'content', 'membership'] as const
 
 export type GroupName = typeof KnownWorkingGroups[number]
+
+export const isKnownGroupName = (name: string): name is GroupName => {
+  return KnownWorkingGroups.includes(name as GroupName)
+}
 
 export const GroupRewardPeriods: Record<GroupName, BN> = {
   forum: new BN(14400 + 10),

--- a/packages/ui/src/working-groups/types/WorkingGroupApplication.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroupApplication.ts
@@ -1,8 +1,9 @@
-import BN from 'bn.js'
-
 import { asBlock, Block } from '../../common/types'
 import { Member } from '../../memberships/types'
+import { getReward } from '../model/getReward'
 import { WorkingGroupApplicationFieldsFragment } from '../queries'
+
+import { Reward } from './Reward'
 
 export interface WorkingGroupApplication {
   id: string
@@ -10,7 +11,7 @@ export interface WorkingGroupApplication {
     id: string
     type: string
     groupName: string
-    reward: BN
+    reward: Reward
   }
   applicant?: Member
   roleAccount?: string
@@ -27,7 +28,7 @@ export const asApplication = (application: WorkingGroupApplicationFieldsFragment
     id: application.opening.id,
     type: application.opening.type,
     groupName: application.opening.group.name,
-    reward: new BN(application.opening.rewardPerBlock),
+    reward: getReward(application.opening.rewardPerBlock, application.opening.group.name),
   },
   status: application.status.__typename,
   stakingAccount: application.stakingAccount,

--- a/packages/ui/src/working-groups/types/WorkingGroupOpening.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroupOpening.ts
@@ -3,11 +3,14 @@ import BN from 'bn.js'
 import { asBlock, Block } from '@/common/types'
 import { asMember, Member } from '@/memberships/types'
 
+import { getReward } from '../model/getReward'
 import {
   ApplicationQuestionFieldsFragment,
   UpcomingWorkingGroupOpeningFieldsFragment,
   WorkingGroupOpeningFieldsFragment,
 } from '../queries'
+
+import { Reward } from './Reward'
 
 type WorkingGroupOpeningType = 'LEADER' | 'REGULAR'
 type Status = 'OpeningStatusUpcoming' | 'OpeningStatusOpen' | 'OpeningStatusFilled' | 'OpeningStatusCancelled'
@@ -24,10 +27,7 @@ export interface BaseOpening {
   createdAtBlock: Block
   stake: BN
   budget: number
-  reward: {
-    value: BN
-    interval: number
-  }
+  reward: Reward
 }
 
 export interface UpcomingWorkingGroupOpening extends BaseOpening {
@@ -64,10 +64,7 @@ const asBaseOpening = (fields: UpcomingWorkingGroupOpeningFieldsFragment | Worki
   groupName: fields.group.name,
   budget: fields.group.budget,
   createdAtBlock: asBlock(fields.createdAtBlock),
-  reward: {
-    value: fields.rewardPerBlock,
-    interval: 1,
-  },
+  reward: getReward(fields.rewardPerBlock, fields.group.name),
   expectedEnding: fields.metadata.expectedEnding,
   shortDescription: fields.metadata.shortDescription || '',
   description: fields.metadata?.description ?? '',

--- a/packages/ui/src/working-groups/types/groupExtrinsics.ts
+++ b/packages/ui/src/working-groups/types/groupExtrinsics.ts
@@ -1,6 +1,6 @@
 import { AugmentedSubmittables } from '@polkadot/api/types'
 
-export type GroupName = 'forum' | 'storage' | 'content' | 'membership'
+import { GroupName } from '.'
 
 type groupSubmittableSet = keyof AugmentedSubmittables<'rxjs'> &
   ('forumWorkingGroup' | 'storageWorkingGroup' | 'contentDirectoryWorkingGroup' | 'membershipWorkingGroup')

--- a/packages/ui/test/working-groups/modals/constants.ts
+++ b/packages/ui/test/working-groups/modals/constants.ts
@@ -1,3 +1,5 @@
+import BN from 'bn.js'
+
 import { Worker } from '@/working-groups/types'
 
 import { alice } from '../../_mocks/keyring'
@@ -12,7 +14,10 @@ export const WORKER: Worker = {
     id: '1',
   },
   isLeader: false,
-  rewardPerBlock: 100,
+  reward: {
+    value: new BN(1000),
+    interval: 14410,
+  },
   earnedTotal: 2000,
   stake: 2000,
   status: '',

--- a/packages/ui/test/working-groups/modals/constants.ts
+++ b/packages/ui/test/working-groups/modals/constants.ts
@@ -1,5 +1,4 @@
-import BN from 'bn.js'
-
+import { getReward } from '@/working-groups/model/getReward'
 import { Worker } from '@/working-groups/types'
 
 import { alice } from '../../_mocks/keyring'
@@ -14,10 +13,7 @@ export const WORKER: Worker = {
     id: '1',
   },
   isLeader: false,
-  reward: {
-    value: new BN(1000),
-    interval: 14410,
-  },
+  reward: getReward(2, 'forum'),
   earnedTotal: 2000,
   stake: 2000,
   status: '',

--- a/packages/ui/test/working-groups/model/getReward.test.ts
+++ b/packages/ui/test/working-groups/model/getReward.test.ts
@@ -11,8 +11,8 @@ describe('getReward', () => {
 
   it('Not a known group name', () => {
     expect(getReward(1, 'incorrect')).toEqual({
-      payout: new BN(0),
-      blockInterval: 14400,
+      payout: new BN(7),
+      blockInterval: 1,
     })
   })
 })

--- a/packages/ui/test/working-groups/model/getReward.test.ts
+++ b/packages/ui/test/working-groups/model/getReward.test.ts
@@ -10,8 +10,8 @@ describe('getReward', () => {
   })
 
   it('Not a known group name', () => {
-    expect(getReward(1, 'incorrect')).toEqual({
-      payout: new BN(7),
+    expect(getReward(10, 'incorrect')).toEqual({
+      payout: new BN(10),
       blockInterval: 1,
     })
   })

--- a/packages/ui/test/working-groups/model/getRewardAmount.test.ts
+++ b/packages/ui/test/working-groups/model/getRewardAmount.test.ts
@@ -1,10 +1,10 @@
 import { getReward } from '@/working-groups/model/getReward'
 
-describe('getRewardAmount', () => {
+describe('getReward', () => {
   it('Example use', () => {
     const reward = getReward(1, 'forum')
-    expect(reward.value.toNumber()).toEqual(14410)
-    expect(reward.interval).toEqual(14410)
+    expect(reward.payout.toNumber()).toEqual(14410)
+    expect(reward.blockInterval).toEqual(14410)
   })
 
   it('Not a group name', () => {

--- a/packages/ui/test/working-groups/model/getRewardAmount.test.ts
+++ b/packages/ui/test/working-groups/model/getRewardAmount.test.ts
@@ -1,3 +1,5 @@
+import BN from 'bn.js'
+
 import { getReward } from '@/working-groups/model/getReward'
 
 describe('getReward', () => {
@@ -7,7 +9,10 @@ describe('getReward', () => {
     expect(reward.blockInterval).toEqual(14410)
   })
 
-  it('Not a group name', () => {
-    expect(() => getReward(1, 'incorrect')).toThrow(TypeError)
+  it('Not a known group name', () => {
+    expect(getReward(1, 'incorrect')).toEqual({
+      payout: new BN(0),
+      blockInterval: 14400,
+    })
   })
 })

--- a/packages/ui/test/working-groups/model/getRewardAmount.test.ts
+++ b/packages/ui/test/working-groups/model/getRewardAmount.test.ts
@@ -2,8 +2,8 @@ import { getReward } from '@/working-groups/model/getReward'
 
 describe('getReward', () => {
   it('Example use', () => {
-    const reward = getReward(1, 'forum')
-    expect(reward.payout.toNumber()).toEqual(14410)
+    const reward = getReward(2, 'forum')
+    expect(reward.payout.toNumber()).toEqual(28820)
     expect(reward.blockInterval).toEqual(14410)
   })
 

--- a/packages/ui/test/working-groups/model/getRewardAmount.test.ts
+++ b/packages/ui/test/working-groups/model/getRewardAmount.test.ts
@@ -1,0 +1,13 @@
+import { getReward } from '@/working-groups/model/getReward'
+
+describe('getRewardAmount', () => {
+  it('Example use', () => {
+    const reward = getReward(1, 'forum')
+    expect(reward.value.toNumber()).toEqual(14410)
+    expect(reward.interval).toEqual(14410)
+  })
+
+  it('Not a group name', () => {
+    expect(() => getReward(1, 'incorrect')).toThrow(TypeError)
+  })
+})

--- a/packages/ui/test/working-groups/pages/MyApplications.test.tsx
+++ b/packages/ui/test/working-groups/pages/MyApplications.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react'
-import BN from 'bn.js'
 import React from 'react'
 import { HashRouter } from 'react-router-dom'
+
+import { getReward } from '@/working-groups/model/getReward'
 
 import { MyApplications } from '../../../src/app/pages/WorkingGroups/MyApplications'
 import { Block } from '../../../src/common/types'
@@ -26,7 +27,7 @@ const currentApplication: WorkingGroupApplication = {
     id: '2',
     type: 'LEADER',
     groupName: 'Storage',
-    reward: new BN(200),
+    reward: getReward(1, 'storage'),
   },
   createdAtBlock: block,
   status: 'ApplicationStatusPending',
@@ -39,7 +40,7 @@ const pastApplication: WorkingGroupApplication = {
     id: '2',
     type: 'REGULAR',
     groupName: 'Forum',
-    reward: new BN(100),
+    reward: getReward(1, 'forum'),
   },
   createdAtBlock: block,
   status: 'ApplicationStatusRejected',


### PR DESCRIPTION
Closes #678 

A couple of considerations:
* Right now group name is cast from `string` to `GroupName` type inside the `getReward` function; I think it could be beneficial to use `GroupName` in every instance of group name in objects from the Working Groups domain. I added a simple test to illustrate the case - also in the end the names will be known and finite. 
* Values in `GroupRewardPeriods` are taken from Joystream node code cited in the issue. I'm not 100% sure if they're correct (maybe I'm not imagining the scale of numbers right though)