### PR TITLE
🎺 Display blocks until next payout

### DIFF
--- a/packages/ui/src/app/pages/WorkingGroups/MyRoles/MyRoles.tsx
+++ b/packages/ui/src/app/pages/WorkingGroups/MyRoles/MyRoles.tsx
@@ -12,6 +12,7 @@ import { MyStakeStat } from '@/working-groups/components/MyStakeStat'
 import { RolesList } from '@/working-groups/components/Roles/RolesList'
 import { useMyWorkers } from '@/working-groups/hooks/useMyWorkers'
 
+import { NextPayoutStat } from '../../../../working-groups/components/NextPayoutStat'
 import { WorkingGroupsTabs } from '../components/WorkingGroupsTabs'
 
 export const MyRoles = () => {
@@ -50,7 +51,7 @@ export const MyRoles = () => {
           <MyEarningsStat />
           <MyStakeStat />
           <TokenValueStat title="Total owed reward" value={150000} />
-          <TokenValueStat title="Next payout in" value={150000} />
+          <NextPayoutStat workers={workers} />
         </Statistics>
         {displayRoles()}
       </MainPanel>

--- a/packages/ui/src/common/hooks/useCurrentBlockNumber.ts
+++ b/packages/ui/src/common/hooks/useCurrentBlockNumber.ts
@@ -1,5 +1,5 @@
-import { useApi } from "./useApi";
-import { useObservable } from "./useObservable";
+import { useApi } from './useApi'
+import { useObservable } from './useObservable'
 
 export function useCurrentBlockNumber() {
   const { api } = useApi()

--- a/packages/ui/src/common/hooks/useCurrentBlockNumber.ts
+++ b/packages/ui/src/common/hooks/useCurrentBlockNumber.ts
@@ -1,0 +1,7 @@
+import { useApi } from "./useApi";
+import { useObservable } from "./useObservable";
+
+export function useCurrentBlockNumber() {
+  const { api } = useApi()
+  return useObservable(api?.rpc.chain.getBlock(), [api])?.block.header.number.toBn()
+}

--- a/packages/ui/src/common/hooks/useCurrentBlockNumber.ts
+++ b/packages/ui/src/common/hooks/useCurrentBlockNumber.ts
@@ -3,5 +3,5 @@ import { useObservable } from './useObservable'
 
 export function useCurrentBlockNumber() {
   const { api } = useApi()
-  return useObservable(api?.rpc.chain.getBlock(), [api])?.block.header.number.toBn()
+  return useObservable(api?.rpc.chain.subscribeNewHeads(), [api])?.number.toBn()
 }

--- a/packages/ui/src/working-groups/components/NextPayoutStat.tsx
+++ b/packages/ui/src/working-groups/components/NextPayoutStat.tsx
@@ -1,0 +1,20 @@
+import React, { useMemo } from 'react'
+
+import { TokenValueStat } from '../../common/components/statistics'
+import { useCurrentBlockNumber } from '../../common/hooks/useCurrentBlockNumber'
+import { getNextPayout } from '../model/getNextPayout'
+import { Worker } from '../types'
+
+interface Props {
+  workers: Worker[]
+}
+
+export const NextPayoutStat = ({ workers }: Props) => {
+  const blockNumber = useCurrentBlockNumber()
+  const nextPayout = useMemo(() => blockNumber && getNextPayout(workers, blockNumber), [
+    workers.length,
+    blockNumber?.toNumber(),
+  ])
+
+  return <TokenValueStat title={'Next payout in'} value={nextPayout ?? 0} />
+}

--- a/packages/ui/src/working-groups/model/getNextPayout.ts
+++ b/packages/ui/src/working-groups/model/getNextPayout.ts
@@ -5,16 +5,13 @@ import { GroupRewardPeriods, isKnownGroupName, Worker } from '../types'
 export function getNextPayout(workers: Pick<Worker, 'group'>[], blockNumber: BN) {
   const blocksUntilNext = (interval: BN) => interval.sub(blockNumber.mod(interval))
 
-  const nextPayoutPerGroup = workers
-    .map((worker) => worker.group.name)
-    .filter(distinct)
+  const userGroups = [...new Set(workers.map((worker) => worker.group.name))]
+  const nextPayoutPerGroup = userGroups
     .filter(isKnownGroupName)
     .map((name) => GroupRewardPeriods[name])
     .map(blocksUntilNext)
 
-  return nextPayoutPerGroup.length
-    ? nextPayoutPerGroup.reduce((closest, time) => (closest = BN.min(closest, time)))
-    : undefined
+  if (nextPayoutPerGroup.length) {
+    return nextPayoutPerGroup.reduce((closest, time) => (closest = BN.min(closest, time)))
+  }
 }
-
-const distinct = (name: string, index: number, all: string[]) => index === all.indexOf(name)

--- a/packages/ui/src/working-groups/model/getNextPayout.ts
+++ b/packages/ui/src/working-groups/model/getNextPayout.ts
@@ -1,0 +1,20 @@
+import BN from 'bn.js'
+
+import { GroupRewardPeriods, isKnownGroupName, Worker } from '../types'
+
+export function getNextPayout(workers: Pick<Worker, 'group'>[], blockNumber: BN) {
+  const blocksUntilNext = (interval: BN) => interval.sub(blockNumber.mod(interval))
+
+  const nextPayoutPerGroup = workers
+    .map((worker) => worker.group.name)
+    .filter(distinct)
+    .filter(isKnownGroupName)
+    .map((name) => GroupRewardPeriods[name])
+    .map(blocksUntilNext)
+
+  return nextPayoutPerGroup.length
+    ? nextPayoutPerGroup.reduce((closest, time) => (closest = BN.min(closest, time)))
+    : undefined
+}
+
+const distinct = (name: string, index: number, all: string[]) => index === all.indexOf(name)

--- a/packages/ui/test/working-groups/model/getNextPayout.test.ts
+++ b/packages/ui/test/working-groups/model/getNextPayout.test.ts
@@ -1,0 +1,45 @@
+import BN from 'bn.js'
+
+import { getNextPayout } from '../../../src/working-groups/model/getNextPayout'
+
+describe('getNextPayout', () => {
+  it('Single role', () => {
+    const blockNumber = new BN(14400)
+    const workers = ['forum'].map(toWorkerFragment)
+    expect(getNextPayout(workers, blockNumber)?.toNumber()).toEqual(10)
+  })
+
+  it('No roles', () => {
+    const blockNumber = new BN(14400)
+    const workers = [].map(toWorkerFragment)
+    expect(getNextPayout(workers, blockNumber)).toBeUndefined()
+  })
+
+  it('Multiple roles', () => {
+    const blockNumber = new BN(14400)
+    const workers1 = ['forum', 'storage', 'content'].map(toWorkerFragment)
+    expect(getNextPayout(workers1, blockNumber)?.toNumber()).toEqual(10)
+    const workers2 = ['storage', 'content'].map(toWorkerFragment)
+    expect(getNextPayout(workers2, blockNumber)?.toNumber()).toEqual(20)
+  })
+
+  it('Later block', () => {
+    const blockNumber = new BN(14400 * 2)
+    const workers = ['forum', 'storage', 'content'].map(toWorkerFragment)
+    expect(getNextPayout(workers, blockNumber)?.toNumber()).toEqual(20)
+  })
+
+  const toWorkerFragment = (groupName: string) => ({
+    group: {
+      id: '',
+      name: groupName,
+    },
+  })
+})
+
+/*  Payout intervals in blocks:
+    forum: 14400 + 10
+    storage: 14400 + 20
+    content: 14400 + 30
+    membership: 14400 + 40
+*/

--- a/packages/ui/test/working-groups/model/getNextPayout.test.ts
+++ b/packages/ui/test/working-groups/model/getNextPayout.test.ts
@@ -36,10 +36,3 @@ describe('getNextPayout', () => {
     },
   })
 })
-
-/*  Payout intervals in blocks:
-    forum: 14400 + 10
-    storage: 14400 + 20
-    content: 14400 + 30
-    membership: 14400 + 40
-*/


### PR DESCRIPTION
See: #685 
Right now it says (blocks) JOY, I feel like setting up styles (currently hard-coded for JOY token values) is worthy of a separate PR