### PR TITLE
🌽 Use an easier-parsed type in OpeningsListProps

### DIFF
--- a/packages/ui/src/working-groups/components/OpeningsList/OpeningsList.tsx
+++ b/packages/ui/src/working-groups/components/OpeningsList/OpeningsList.tsx
@@ -6,7 +6,7 @@ import { UpcomingWorkingGroupOpening, WorkingGroupOpening } from '@/working-grou
 import { OpeningsListRow } from './OpeningsListRow'
 
 export interface OpeningsListProps {
-  openings: WorkingGroupOpening[] | UpcomingWorkingGroupOpening[]
+  openings: Array<WorkingGroupOpening | UpcomingWorkingGroupOpening>
 }
 
 export const OpeningsList = ({ openings }: OpeningsListProps) => {


### PR DESCRIPTION
Just a small change that helps the TS engine parse the type of `opening` in line 15 (VSCode's TS engine says that type of `opening` is implicitly `any`)