### PR TITLE
🤖 Run prettier after ESLint

### DIFF
--- a/packages/ui/codegen.config.yml
+++ b/packages/ui/codegen.config.yml
@@ -13,10 +13,6 @@ config:
 
 generates:
   src/common/api/queries/__generated__/baseTypes.generated.ts:
-    hooks:
-      afterOneFileWrite:
-        - prettier --write
-        - eslint --fix
     plugins:
       - typescript
   src/common/api/queries/__generated__/:
@@ -25,10 +21,6 @@ generates:
       baseTypesPath: baseTypes.generated.ts
       folder: __generated__
       extension: .generated.tsx
-    hooks:
-      afterOneFileWrite:
-        - prettier --write
-        - eslint --fix
     plugins:
       - typescript-operations
       - typescript-react-apollo

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,9 +4,9 @@
   "license": "GPL-3.0-only",
   "scripts": {
     "build": "node --max_old_space_size=4096 ./node_modules/.bin/webpack --mode production --progress",
-    "queries:generate": "graphql-codegen --config codegen.config.yml",
+    "queries:generate": "graphql-codegen --config codegen.config.yml && yarn lint:fix",
     "lint": "yarn lint:prettier --check && yarn lint:eslint",
-    "lint:fix": "yarn lint:prettier --write && yarn lint:eslint --fix",
+    "lint:fix": " yarn lint:eslint --fix && yarn lint:prettier --write",
     "lint:eslint": "eslint './{src,test}/**/*.{ts,tsx}'",
     "lint:prettier": "yarn prettier './{src,test}/**/*.{ts,tsx,html}'",
     "start": "NODE_OPTIONS=--max_old_space_size=8192 webpack serve --mode development --progress",


### PR DESCRIPTION
Fixes the problem with inconsistent linter after generating graphl hooks using graphql codegen or when running lint:fix tasks once.