### PR TITLE
🪗 Optimize queries

### DIFF
--- a/packages/ui/src/memberships/hooks/useMemberRoles.ts
+++ b/packages/ui/src/memberships/hooks/useMemberRoles.ts
@@ -1,12 +1,12 @@
 import { useMemo } from 'react'
 
-import { useGetWorkersQuery } from '@/working-groups/queries'
+import { useGetDetailedWorkersQuery } from '@/working-groups/queries'
 import { asWorkerWithDetails } from '@/working-groups/types'
 
 export const useMemberRoles = (membershipId: string) => {
   const params = { variables: { where: { membership_eq: membershipId } } }
 
-  const { data, loading } = useGetWorkersQuery(params)
+  const { data, loading } = useGetDetailedWorkersQuery(params)
   const workers = useMemo(() => (data && data.workers.map(asWorkerWithDetails)) || [], [data, loading])
 
   return { workers, isLoading: loading }

--- a/packages/ui/src/working-groups/components/Roles/RolesList.stories.tsx
+++ b/packages/ui/src/working-groups/components/Roles/RolesList.stories.tsx
@@ -22,7 +22,6 @@ Default.args = {
       reward: getReward(1, 'forum'),
       earnedTotal: 1000,
       stake: 1000,
-      minStake: 400,
       isLeader: false,
       owedReward: 1000,
     },

--- a/packages/ui/src/working-groups/components/WorkingGroupListItem.tsx
+++ b/packages/ui/src/working-groups/components/WorkingGroupListItem.tsx
@@ -2,13 +2,13 @@ import React from 'react'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { ButtonBareGhost } from '../../common/components/buttons'
-import { Arrow } from '../../common/components/icons'
-import { TextMedium, ValueInJoys } from '../../common/components/typography'
-import { Subscription } from '../../common/components/typography/Subscription'
-import { BorderRad, Colors, Fonts, Overflow, Transitions } from '../../common/constants'
-import { Avatar } from '../../memberships/components/Avatar'
-import { useMember } from '../../memberships/hooks/useMembership'
+import { ButtonBareGhost } from '@/common/components/buttons'
+import { Arrow } from '@/common/components/icons'
+import { TextMedium, ValueInJoys } from '@/common/components/typography'
+import { Subscription } from '@/common/components/typography/Subscription'
+import { BorderRad, Colors, Fonts, Overflow, Transitions } from '@/common/constants'
+import { Avatar } from '@/memberships/components/Avatar'
+import { useMember } from '@/memberships/hooks/useMembership'
 import { WorkingGroup } from '../types'
 
 import { WorkingGroupImage, WorkingGroupImageTag } from './WorkingGroupImage'
@@ -34,7 +34,7 @@ export function WorkingGroupListItem({ group }: WorkingGroupProps) {
       </GroupContentBlock>
       <GroupStats>
         <StatsColumn>
-          <StatsValue>{group.workers?.length ?? 0}</StatsValue>
+          <StatsValue>{group.workerIds?.length ?? 0}</StatsValue>
           <Subscription>Workers</Subscription>
         </StatsColumn>
         <StatsColumn>

--- a/packages/ui/src/working-groups/components/WorkingGroupListItem.tsx
+++ b/packages/ui/src/working-groups/components/WorkingGroupListItem.tsx
@@ -9,6 +9,7 @@ import { Subscription } from '@/common/components/typography/Subscription'
 import { BorderRad, Colors, Fonts, Overflow, Transitions } from '@/common/constants'
 import { Avatar } from '@/memberships/components/Avatar'
 import { useMember } from '@/memberships/hooks/useMembership'
+
 import { WorkingGroup } from '../types'
 
 import { WorkingGroupImage, WorkingGroupImageTag } from './WorkingGroupImage'

--- a/packages/ui/src/working-groups/hooks/useOpening.ts
+++ b/packages/ui/src/working-groups/hooks/useOpening.ts
@@ -1,13 +1,13 @@
 import { useMemo } from 'react'
 
 import { useGetWorkingGroupOpeningQuery } from '../queries'
-import { asWorkingGroupOpening } from '../types'
+import { asWorkingGroupDetailedOpening } from '../types'
 
 export const useOpening = (id: string) => {
   const { loading, data } = useGetWorkingGroupOpeningQuery({ variables: { where: { id } } })
 
   const rawOpening = data?.workingGroupOpeningByUniqueInput
-  const opening = useMemo(() => rawOpening && asWorkingGroupOpening(rawOpening), [rawOpening?.id])
+  const opening = useMemo(() => rawOpening && asWorkingGroupDetailedOpening(rawOpening), [rawOpening?.id])
 
   return {
     isLoading: loading,

--- a/packages/ui/src/working-groups/queries/__generated__/workingGroups.generated.tsx
+++ b/packages/ui/src/working-groups/queries/__generated__/workingGroups.generated.tsx
@@ -23,22 +23,26 @@ export type WorkerFieldsFragment = {
   rewardPerBlock: any
   missingRewardAmount?: Types.Maybe<any>
   stake: any
-  roleAccount: string
-  rewardAccount: string
-  stakeAccount: string
   membership: { __typename: 'Membership' } & MemberFieldsFragment
   group: { __typename: 'WorkingGroup'; id: string; name: string }
   status:
     | { __typename: 'WorkerStatusActive' }
     | { __typename: 'WorkerStatusLeft' }
     | { __typename: 'WorkerStatusTerminated' }
+}
+
+export type WorkerDetailedFieldsFragment = {
+  __typename: 'Worker'
+  roleAccount: string
+  rewardAccount: string
+  stakeAccount: string
   application: {
     __typename: 'WorkingGroupApplication'
     id: string
     openingId: string
     opening: { __typename: 'WorkingGroupOpening'; stakeAmount: any }
   }
-}
+} & WorkerFieldsFragment
 
 export type WorkingGroupFieldsFragment = {
   __typename: 'WorkingGroup'
@@ -89,13 +93,22 @@ export type GetWorkersQueryVariables = Types.Exact<{
 
 export type GetWorkersQuery = { __typename: 'Query'; workers: Array<{ __typename: 'Worker' } & WorkerFieldsFragment> }
 
+export type GetDetailedWorkersQueryVariables = Types.Exact<{
+  where?: Types.Maybe<Types.WorkerWhereInput>
+}>
+
+export type GetDetailedWorkersQuery = {
+  __typename: 'Query'
+  workers: Array<{ __typename: 'Worker' } & WorkerDetailedFieldsFragment>
+}
+
 export type GetWorkerQueryVariables = Types.Exact<{
   where: Types.WorkerWhereUniqueInput
 }>
 
 export type GetWorkerQuery = {
   __typename: 'Query'
-  workerByUniqueInput?: Types.Maybe<{ __typename: 'Worker' } & WorkerFieldsFragment>
+  workerByUniqueInput?: Types.Maybe<{ __typename: 'Worker' } & WorkerDetailedFieldsFragment>
 }
 
 export type GetRewardsQueryVariables = Types.Exact<{
@@ -333,6 +346,12 @@ export const WorkerFieldsFragmentDoc = gql`
     rewardPerBlock
     missingRewardAmount
     stake
+  }
+  ${MemberFieldsFragmentDoc}
+`
+export const WorkerDetailedFieldsFragmentDoc = gql`
+  fragment WorkerDetailedFields on Worker {
+    ...WorkerFields
     roleAccount
     rewardAccount
     stakeAccount
@@ -344,7 +363,7 @@ export const WorkerFieldsFragmentDoc = gql`
       }
     }
   }
-  ${MemberFieldsFragmentDoc}
+  ${WorkerFieldsFragmentDoc}
 `
 export const WorkingGroupMetdataFieldsFragmentDoc = gql`
   fragment WorkingGroupMetdataFields on WorkingGroupMetadata {
@@ -627,13 +646,59 @@ export function useGetWorkersLazyQuery(
 export type GetWorkersQueryHookResult = ReturnType<typeof useGetWorkersQuery>
 export type GetWorkersLazyQueryHookResult = ReturnType<typeof useGetWorkersLazyQuery>
 export type GetWorkersQueryResult = Apollo.QueryResult<GetWorkersQuery, GetWorkersQueryVariables>
+export const GetDetailedWorkersDocument = gql`
+  query getDetailedWorkers($where: WorkerWhereInput) {
+    workers(where: $where) {
+      ...WorkerDetailedFields
+    }
+  }
+  ${WorkerDetailedFieldsFragmentDoc}
+`
+
+/**
+ * __useGetDetailedWorkersQuery__
+ *
+ * To run a query within a React component, call `useGetDetailedWorkersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetDetailedWorkersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetDetailedWorkersQuery({
+ *   variables: {
+ *      where: // value for 'where'
+ *   },
+ * });
+ */
+export function useGetDetailedWorkersQuery(
+  baseOptions?: Apollo.QueryHookOptions<GetDetailedWorkersQuery, GetDetailedWorkersQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useQuery<GetDetailedWorkersQuery, GetDetailedWorkersQueryVariables>(GetDetailedWorkersDocument, options)
+}
+export function useGetDetailedWorkersLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<GetDetailedWorkersQuery, GetDetailedWorkersQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions }
+  return Apollo.useLazyQuery<GetDetailedWorkersQuery, GetDetailedWorkersQueryVariables>(
+    GetDetailedWorkersDocument,
+    options
+  )
+}
+export type GetDetailedWorkersQueryHookResult = ReturnType<typeof useGetDetailedWorkersQuery>
+export type GetDetailedWorkersLazyQueryHookResult = ReturnType<typeof useGetDetailedWorkersLazyQuery>
+export type GetDetailedWorkersQueryResult = Apollo.QueryResult<
+  GetDetailedWorkersQuery,
+  GetDetailedWorkersQueryVariables
+>
 export const GetWorkerDocument = gql`
   query getWorker($where: WorkerWhereUniqueInput!) {
     workerByUniqueInput(where: $where) {
-      ...WorkerFields
+      ...WorkerDetailedFields
     }
   }
-  ${WorkerFieldsFragmentDoc}
+  ${WorkerDetailedFieldsFragmentDoc}
 `
 
 /**

--- a/packages/ui/src/working-groups/queries/__generated__/workingGroups.generated.tsx
+++ b/packages/ui/src/working-groups/queries/__generated__/workingGroups.generated.tsx
@@ -139,6 +139,15 @@ export type WorkingGroupOpeningFieldsFragment = {
   unstakingPeriod: number
   group: { __typename: 'WorkingGroup'; name: string; budget: any; leaderId?: Types.Maybe<string> }
   metadata: { __typename: 'WorkingGroupOpeningMetadata' } & WorkingGroupOpeningMetadataFieldsFragment
+  status:
+    | { __typename: 'OpeningStatusOpen' }
+    | { __typename: 'OpeningStatusFilled' }
+    | { __typename: 'OpeningStatusCancelled' }
+  applications: Array<{ __typename: 'WorkingGroupApplication'; id: string }>
+}
+
+export type WorkingGroupOpeningDetailedFieldsFragment = {
+  __typename: 'WorkingGroupOpening'
   applications: Array<{
     __typename: 'WorkingGroupApplication'
     id: string
@@ -150,11 +159,7 @@ export type WorkingGroupOpeningFieldsFragment = {
       | { __typename: 'ApplicationStatusCancelled' }
     applicant: { __typename: 'Membership' } & MemberFieldsFragment
   }>
-  status:
-    | { __typename: 'OpeningStatusOpen' }
-    | { __typename: 'OpeningStatusFilled' }
-    | { __typename: 'OpeningStatusCancelled' }
-}
+} & WorkingGroupOpeningFieldsFragment
 
 export type WorkingGroupOpeningFieldsConnectionFragment = {
   __typename: 'WorkingGroupOpeningConnection'
@@ -202,7 +207,7 @@ export type GetWorkingGroupOpeningQueryVariables = Types.Exact<{
 export type GetWorkingGroupOpeningQuery = {
   __typename: 'Query'
   workingGroupOpeningByUniqueInput?: Types.Maybe<
-    { __typename: 'WorkingGroupOpening' } & WorkingGroupOpeningFieldsFragment
+    { __typename: 'WorkingGroupOpening' } & WorkingGroupOpeningDetailedFieldsFragment
   >
 }
 
@@ -433,6 +438,19 @@ export const WorkingGroupOpeningFieldsFragmentDoc = gql`
     metadata {
       ...WorkingGroupOpeningMetadataFields
     }
+    status {
+      __typename
+    }
+    unstakingPeriod
+    applications {
+      id
+    }
+  }
+  ${WorkingGroupOpeningMetadataFieldsFragmentDoc}
+`
+export const WorkingGroupOpeningDetailedFieldsFragmentDoc = gql`
+  fragment WorkingGroupOpeningDetailedFields on WorkingGroupOpening {
+    ...WorkingGroupOpeningFields
     applications {
       id
       status {
@@ -445,12 +463,8 @@ export const WorkingGroupOpeningFieldsFragmentDoc = gql`
         __typename
       }
     }
-    status {
-      __typename
-    }
-    unstakingPeriod
   }
-  ${WorkingGroupOpeningMetadataFieldsFragmentDoc}
+  ${WorkingGroupOpeningFieldsFragmentDoc}
   ${MemberFieldsFragmentDoc}
 `
 export const WorkingGroupOpeningFieldsConnectionFragmentDoc = gql`
@@ -881,10 +895,10 @@ export type GetWorkingGroupOpeningsQueryResult = Apollo.QueryResult<
 export const GetWorkingGroupOpeningDocument = gql`
   query getWorkingGroupOpening($where: WorkingGroupOpeningWhereUniqueInput!) {
     workingGroupOpeningByUniqueInput(where: $where) {
-      ...WorkingGroupOpeningFields
+      ...WorkingGroupOpeningDetailedFields
     }
   }
-  ${WorkingGroupOpeningFieldsFragmentDoc}
+  ${WorkingGroupOpeningDetailedFieldsFragmentDoc}
 `
 
 /**

--- a/packages/ui/src/working-groups/queries/__generated__/workingGroups.generated.tsx
+++ b/packages/ui/src/working-groups/queries/__generated__/workingGroups.generated.tsx
@@ -46,7 +46,7 @@ export type WorkingGroupFieldsFragment = {
   name: string
   budget: any
   metadata?: Types.Maybe<{ __typename: 'WorkingGroupMetadata' } & WorkingGroupMetdataFieldsFragment>
-  workers: Array<{ __typename: 'Worker' } & WorkerFieldsFragment>
+  workers: Array<{ __typename: 'Worker'; id: string }>
   leader?: Types.Maybe<{ __typename: 'Worker'; membership: { __typename: 'Membership'; id: string } }>
 }
 
@@ -316,14 +316,6 @@ export type GetUpcomingWorkingGroupOpeningsQuery = {
   >
 }
 
-export const WorkingGroupMetdataFieldsFragmentDoc = gql`
-  fragment WorkingGroupMetdataFields on WorkingGroupMetadata {
-    about
-    description
-    status
-    statusMessage
-  }
-`
 export const WorkerFieldsFragmentDoc = gql`
   fragment WorkerFields on Worker {
     id
@@ -354,6 +346,14 @@ export const WorkerFieldsFragmentDoc = gql`
   }
   ${MemberFieldsFragmentDoc}
 `
+export const WorkingGroupMetdataFieldsFragmentDoc = gql`
+  fragment WorkingGroupMetdataFields on WorkingGroupMetadata {
+    about
+    description
+    status
+    statusMessage
+  }
+`
 export const WorkingGroupFieldsFragmentDoc = gql`
   fragment WorkingGroupFields on WorkingGroup {
     id
@@ -363,7 +363,7 @@ export const WorkingGroupFieldsFragmentDoc = gql`
       ...WorkingGroupMetdataFields
     }
     workers {
-      ...WorkerFields
+      id
     }
     leader {
       membership {
@@ -372,7 +372,6 @@ export const WorkingGroupFieldsFragmentDoc = gql`
     }
   }
   ${WorkingGroupMetdataFieldsFragmentDoc}
-  ${WorkerFieldsFragmentDoc}
 `
 export const BudgetSpendingEventFieldsFragmentDoc = gql`
   fragment BudgetSpendingEventFields on BudgetSpendingEvent {

--- a/packages/ui/src/working-groups/queries/workingGroups.graphql
+++ b/packages/ui/src/working-groups/queries/workingGroups.graphql
@@ -133,22 +133,29 @@ fragment WorkingGroupOpeningFields on WorkingGroupOpening {
   metadata {
     ... WorkingGroupOpeningMetadataFields
   }
+  status {
+    __typename
+  }
+  unstakingPeriod
+  applications {
+    id
+  }
+}
+
+fragment WorkingGroupOpeningDetailedFields on WorkingGroupOpening {
+  ... WorkingGroupOpeningFields
   applications {
     id
     status {
       __typename
     }
     applicant {
-      ...MemberFields
+      ... MemberFields
     }
     status {
       __typename
     }
   }
-  status {
-    __typename
-  }
-  unstakingPeriod
 }
 
 fragment WorkingGroupOpeningFieldsConnection on WorkingGroupOpeningConnection {
@@ -181,7 +188,7 @@ query getWorkingGroupOpenings($groupId_eq: ID) {
 
 query getWorkingGroupOpening($where: WorkingGroupOpeningWhereUniqueInput!) {
   workingGroupOpeningByUniqueInput(where: $where) {
-    ... WorkingGroupOpeningFields
+    ... WorkingGroupOpeningDetailedFields
   }
 }
 
@@ -195,7 +202,7 @@ query GetWorkingGroupOpeningQuestions($id: ID!) {
   workingGroupOpeningByUniqueInput(where: {id: $id}) {
     metadata {
       applicationFormQuestions {
-        ...ApplicationQuestionFields
+        ... ApplicationQuestionFields
       }
     }
   }

--- a/packages/ui/src/working-groups/queries/workingGroups.graphql
+++ b/packages/ui/src/working-groups/queries/workingGroups.graphql
@@ -44,7 +44,7 @@ fragment WorkingGroupFields on WorkingGroup {
     ...WorkingGroupMetdataFields
   }
   workers {
-    ...WorkerFields
+    id
   }
   leader {
     membership {

--- a/packages/ui/src/working-groups/queries/workingGroups.graphql
+++ b/packages/ui/src/working-groups/queries/workingGroups.graphql
@@ -21,6 +21,10 @@ fragment WorkerFields on Worker {
   rewardPerBlock
   missingRewardAmount
   stake
+}
+
+fragment WorkerDetailedFields on Worker {
+  ...WorkerFields
   roleAccount
   rewardAccount
   stakeAccount
@@ -86,9 +90,15 @@ query getWorkers ($where: WorkerWhereInput) {
   }
 }
 
+query getDetailedWorkers ($where: WorkerWhereInput) {
+  workers(where: $where) {
+    ...WorkerDetailedFields
+  }
+}
+
 query getWorker ($where: WorkerWhereUniqueInput!) {
   workerByUniqueInput(where: $where) {
-    ...WorkerFields
+    ...WorkerDetailedFields
   }
 }
 

--- a/packages/ui/src/working-groups/types/Worker.ts
+++ b/packages/ui/src/working-groups/types/Worker.ts
@@ -1,6 +1,6 @@
 import { Address, asBlock, Block } from '@/common/types'
 import { Member } from '@/memberships/types'
-import { WorkerFieldsFragment } from '@/working-groups/queries'
+import { WorkerDetailedFieldsFragment, WorkerFieldsFragment } from '@/working-groups/queries'
 import { WorkingGroup } from '@/working-groups/types/WorkingGroup'
 
 import { getReward } from '../model/getReward'
@@ -17,7 +17,6 @@ export interface Worker {
   owedReward: number
   earnedTotal: number
   stake: number
-  minStake: number
 }
 
 export interface WorkerWithDetails extends Worker {
@@ -27,6 +26,7 @@ export interface WorkerWithDetails extends Worker {
   rewardAccount: Address
   stakeAccount: Address
   hiredAtBlock: Block
+  minStake: number
 }
 
 export const asWorker = (fields: WorkerFieldsFragment): Worker => ({
@@ -45,15 +45,15 @@ export const asWorker = (fields: WorkerFieldsFragment): Worker => ({
   earnedTotal: 1000,
   stake: fields.stake,
   owedReward: fields.missingRewardAmount,
-  minStake: fields.application.opening.stakeAmount,
 })
 
-export const asWorkerWithDetails = (fields: WorkerFieldsFragment): WorkerWithDetails => ({
+export const asWorkerWithDetails = (fields: WorkerDetailedFieldsFragment): WorkerWithDetails => ({
   ...asWorker(fields),
   applicationId: fields.application.id,
   openingId: fields.application.openingId,
   roleAccount: fields.roleAccount,
   rewardAccount: fields.rewardAccount,
   stakeAccount: fields.stakeAccount,
+  minStake: fields.application.opening.stakeAmount,
   hiredAtBlock: asBlock(),
 })

--- a/packages/ui/src/working-groups/types/WorkingGroup.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroup.ts
@@ -1,11 +1,6 @@
 import BN from 'bn.js'
 
-import { Member } from '../../memberships/types'
-import { WorkerFieldsFragment, WorkingGroupFieldsFragment } from '../queries'
-
-interface Worker {
-  membership: Pick<Member, 'id'>
-}
+import { WorkingGroupFieldsFragment } from '../queries'
 
 export interface WorkingGroup {
   id: string
@@ -20,12 +15,6 @@ export interface WorkingGroup {
   budget: BN
 }
 
-type WorkerFields = { __typename: 'Worker' } & WorkerFieldsFragment
-
-const asWorker = (worker: WorkerFields) => ({
-  membership: worker.membership,
-})
-
 export const asWorkingGroup = (group: WorkingGroupFieldsFragment): WorkingGroup => {
   return {
     id: group.id,
@@ -35,7 +24,7 @@ export const asWorkingGroup = (group: WorkingGroupFieldsFragment): WorkingGroup 
     description: group.metadata?.description ?? '',
     status: group.metadata?.status ?? '',
     statusMessage: group.metadata?.statusMessage ?? '',
-    workerIds: group.workers.map(w => w.id) ?? [],
+    workerIds: group.workers.map((w) => w.id) ?? [],
     leaderId: group.leader?.membership.id,
     budget: new BN(group.budget),
   }

--- a/packages/ui/src/working-groups/types/WorkingGroup.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroup.ts
@@ -13,7 +13,7 @@ export interface WorkingGroup {
   image?: string
   about?: string
   leaderId?: string
-  workers?: Worker[]
+  workerIds?: string[]
   status?: string
   description?: string
   statusMessage?: string
@@ -35,7 +35,7 @@ export const asWorkingGroup = (group: WorkingGroupFieldsFragment): WorkingGroup 
     description: group.metadata?.description ?? '',
     status: group.metadata?.status ?? '',
     statusMessage: group.metadata?.statusMessage ?? '',
-    workers: group.workers?.map(asWorker) ?? [],
+    workerIds: group.workers.map(w => w.id) ?? [],
     leaderId: group.leader?.membership.id,
     budget: new BN(group.budget),
   }

--- a/packages/ui/src/working-groups/types/WorkingGroupOpening.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroupOpening.ts
@@ -7,6 +7,7 @@ import { getReward } from '../model/getReward'
 import {
   ApplicationQuestionFieldsFragment,
   UpcomingWorkingGroupOpeningFieldsFragment,
+  WorkingGroupOpeningDetailedFieldsFragment,
   WorkingGroupOpeningFieldsFragment,
 } from '../queries'
 
@@ -40,10 +41,6 @@ export interface WorkingGroupOpening extends BaseOpening {
   budget: number
   type: WorkingGroupOpeningType
   status: Status
-  applications: {
-    member: Member
-    status: string
-  }[]
   applicants: {
     current: number
     total: number
@@ -53,6 +50,13 @@ export interface WorkingGroupOpening extends BaseOpening {
     total: number
   }
   unstakingPeriod: number
+}
+
+export interface WorkingGroupDetailedOpening extends WorkingGroupOpening {
+  applications: {
+    member: Member
+    status: string
+  }[]
 }
 
 export const isUpcomingOpening = (opening: BaseOpening): opening is UpcomingWorkingGroupOpening =>
@@ -87,12 +91,6 @@ export const asWorkingGroupOpening = (fields: WorkingGroupOpeningFieldsFragment)
   type: fields.type as WorkingGroupOpeningType,
   status: fields.status.__typename,
   leaderId: fields.group.leaderId,
-  applications: fields.applications.length
-    ? fields.applications.map((application) => ({
-        member: asMember(application.applicant),
-        status: application.status.__typename,
-      }))
-    : [],
   applicants: {
     current: 0,
     total: fields.applications?.length || 0,
@@ -102,6 +100,18 @@ export const asWorkingGroupOpening = (fields: WorkingGroupOpeningFieldsFragment)
     total: fields.metadata?.hiringLimit ?? 0,
   },
   unstakingPeriod: fields.unstakingPeriod,
+})
+
+export const asWorkingGroupDetailedOpening = (
+  fields: WorkingGroupOpeningDetailedFieldsFragment
+): WorkingGroupDetailedOpening => ({
+  ...asWorkingGroupOpening(fields),
+  applications: fields.applications.length
+    ? fields.applications.map((application) => ({
+        member: asMember(application.applicant),
+        status: application.status.__typename,
+      }))
+    : [],
 })
 
 export type ApplicationQuestionType = 'TEXT' | 'TEXTAREA'


### PR DESCRIPTION
See #769 
Updated two kinds of queries so far, workers and working groups.
I think Openings have potential to be slimmed down as well, seeing that the multiple openings query gets an entire list of applicants. They're already a bit complicated though, being inherited from BaseOpening interface