### PR TITLE
✂️ Decrease Prettier's log level

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,7 @@
     "queries:generate": "graphql-codegen --config codegen.config.yml && yarn lint:fix",
     "queries": "yarn queries:patch && yarn queries:generate",
     "lint": "yarn lint:prettier --check && yarn lint:eslint",
-    "lint:fix": "yarn lint:eslint --fix && yarn lint:prettier --write",
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:prettier --write --loglevel warn",
     "lint:eslint": "eslint './{src,test}/**/*.{ts,tsx}'",
     "lint:prettier": "yarn prettier './{src,test}/**/*.{ts,tsx,html}'",
     "start": "NODE_OPTIONS=--max_old_space_size=8192 webpack serve --mode development --progress",


### PR DESCRIPTION
Rationale: now that we run Prettier after ESLint, ESLint warnings and errors get completely drowned out by Prettier output in terminal. `useWorkers.ts` taking 2ms to check isn't critical information and no-one reads that stuff anyway.