### PR TITLE
🌶️ Remove Node 12.x from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: ['12.x', '14.x']
+        node: ['14.x']
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Protobuf (or one of its dependencies) suddenly broke Node 12.x compatibility. I tried forcing specific versions of `protobufjs` and `google-protobuf` but couldn't manage to get it working. Let's remove 12.x support for now, to keep CI working