### PR TITLE
🔫 Select components - assorted fixes

### DIFF
--- a/packages/ui/src/accounts/components/SelectAccount/SelectAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/SelectAccount.tsx
@@ -27,19 +27,17 @@ interface Props {
 export const SelectAccount = React.memo(({ onChange, filter, selected }: Props) => {
   const { allAccounts } = useMyAccounts()
   const options = allAccounts.filter(filter || (() => true))
-  const [selectedOption, setSelectedOption] = useState(selected)
   const [search, setSearch] = useState('')
 
   const filteredOptions = useMemo(() => filterByText(options, search), [search, options])
   const keyring = useKeyring()
 
-  useEffect(() => setSelectedOption(selected), [selected])
   useEffect(() => {
     filteredOptions.length === 0 &&
       isValidAddress(search, keyring) &&
-      (!selectedOption || selectedOption.address !== search) &&
-      setSelectedOption(accountOrNamed(allAccounts, search, 'Unsaved account'))
-  }, [filteredOptions, search, selectedOption])
+      (!selected || selected.address !== search) &&
+      onChange(accountOrNamed(allAccounts, search, 'Unsaved account'))
+  }, [filteredOptions, search, selected])
 
   const change = (selected: Account, close: () => void) => {
     onChange(selected)
@@ -48,7 +46,7 @@ export const SelectAccount = React.memo(({ onChange, filter, selected }: Props) 
 
   return (
     <Select
-      selected={selectedOption}
+      selected={selected}
       onChange={change}
       disabled={false}
       renderSelected={renderSelected}

--- a/packages/ui/src/accounts/components/SelectAccount/SelectAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/SelectAccount.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react'
 
+import { useKeyring } from '@/common/hooks/useKeyring'
+import { Address } from '@/common/types'
+
 import { Select, SelectedOption } from '../../../common/components/selects'
-import { useKeyring } from '../../../common/hooks/useKeyring'
-import { Address } from '../../../common/types'
 import { useMyAccounts } from '../../hooks/useMyAccounts'
 import { accountOrNamed } from '../../model/accountOrNamed'
 import { isValidAddress } from '../../model/isValidAddress'

--- a/packages/ui/src/accounts/modals/TransferModal/TransferFormModal.tsx
+++ b/packages/ui/src/accounts/modals/TransferModal/TransferFormModal.tsx
@@ -55,7 +55,11 @@ export function TransferFormModal({ from, to, onClose, onAccept, title }: Props)
             disabled={!!from}
             borderless={!!from}
           >
-            {from ? <SelectedAccount account={from} /> : <SelectAccount filter={filterSender} onChange={setSender} />}
+            {from ? (
+              <SelectedAccount account={from} />
+            ) : (
+              <SelectAccount filter={filterSender} onChange={setSender} selected={sender} />
+            )}
           </InputComponent>
         </Row>
         <TransactionAmount>
@@ -93,7 +97,11 @@ export function TransferFormModal({ from, to, onClose, onAccept, title }: Props)
             disabled={!!to}
             borderless={!!to}
           >
-            {to ? <SelectedAccount account={to} /> : <SelectAccount filter={filterRecipient} onChange={setRecipient} />}
+            {to ? (
+              <SelectedAccount account={to} />
+            ) : (
+              <SelectAccount filter={filterRecipient} onChange={setRecipient} selected={recipient} />
+            )}
           </InputComponent>
         </Row>
       </ModalBody>

--- a/packages/ui/src/common/components/selects/select.tsx
+++ b/packages/ui/src/common/components/selects/select.tsx
@@ -66,6 +66,10 @@ export const Select = <T extends any, V extends any = T>({
     isOpen && textInput.current?.focus()
   }, [isOpen])
 
+  useEffect(() => {
+    isOpen && toggleOpen()
+  }, [selected])
+
   const onToggleClick: React.MouseEventHandler = (evt) => {
     stopEvent(evt)
     !disabled && toggleOpen()

--- a/packages/ui/src/common/components/selects/select.tsx
+++ b/packages/ui/src/common/components/selects/select.tsx
@@ -21,7 +21,6 @@ export const Select = <T extends any, V extends any = T>({
   const [filterInput, setFilterInput] = useState('')
   const search = filterInput
   const [isOpen, toggleOpen] = useToggle()
-  const [selectedOption, setSelectedOption] = useState<V | undefined>(selected)
   const selectNode = useRef<HTMLDivElement>(null)
   const textInput = useRef<HTMLInputElement>(null)
 
@@ -38,12 +37,6 @@ export const Select = <T extends any, V extends any = T>({
     },
     [toggleOpen, onChange]
   )
-
-  useEffect(() => {
-    if (isDefined(selected)) {
-      setSelectedOption(selected)
-    }
-  }, [selected])
 
   useEffect(() => {
     const clickListener = (event: MouseEvent) => {
@@ -93,7 +86,7 @@ export const Select = <T extends any, V extends any = T>({
       <Toggle onClick={isOpen ? undefined : onToggleClick} isOpen={isOpen} disabled={disabled}>
         <SelectToggleButton isOpen={isOpen} disabled={disabled} onToggleClick={onToggleClick} />
 
-        {onSearch && (isOpen || !isDefined(selectedOption)) ? (
+        {onSearch && (isOpen || !isDefined(selected)) ? (
           <EmptyOption
             ref={textInput}
             type="text"
@@ -104,7 +97,7 @@ export const Select = <T extends any, V extends any = T>({
             onChange={(t) => setFilterInput(t.target.value)}
           />
         ) : (
-          isDefined(selectedOption) && renderSelected(selectedOption)
+          isDefined(selected) && renderSelected(selected)
         )}
       </Toggle>
       {isOpen && renderList(onOptionClick, toggleOpen)}

--- a/packages/ui/src/memberships/components/SelectMember/SelectMember.tsx
+++ b/packages/ui/src/memberships/components/SelectMember/SelectMember.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo, useState } from 'react'
 
-import { Select, SelectedOption } from '../../../common/components/selects'
-import { useDebounce } from '../../../common/hooks/useDebounce'
+import { Select, SelectedOption } from '@/common/components/selects'
+import { useDebounce } from '@/common/hooks/useDebounce'
+
 import { useSearchMembersQuery } from '../../queries'
 import { asMember, Member } from '../../types'
 import { MemberInfo } from '../MemberInfo'

--- a/packages/ui/src/memberships/modals/BuyMembershipModal/BuyMembershipFormModal.tsx
+++ b/packages/ui/src/memberships/modals/BuyMembershipModal/BuyMembershipFormModal.tsx
@@ -134,7 +134,11 @@ export const BuyMembershipFormModal = ({ onClose, onSubmit, membershipPrice }: C
 
           <Row>
             <InputComponent label="Root account" required inputSize="l" tooltipText="Something about root accounts">
-              <SelectAccount filter={filterRoot} onChange={(account) => changeField('rootAccount', account)} />
+              <SelectAccount
+                filter={filterRoot}
+                onChange={(account) => changeField('rootAccount', account)}
+                selected={rootAccount}
+              />
             </InputComponent>
           </Row>
 
@@ -148,6 +152,7 @@ export const BuyMembershipFormModal = ({ onClose, onSubmit, membershipPrice }: C
               <SelectAccount
                 filter={filterController}
                 onChange={(account) => changeField('controllerAccount', account)}
+                selected={controllerAccount}
               />
             </InputComponent>
           </Row>

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/StakeStep.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/StakeStep.tsx
@@ -63,7 +63,7 @@ export function StakeStep({ onChange, opening }: StakeStepProps) {
             <TextMedium>First please select an account for staking.</TextMedium>
           </RowGapBlock>
           <InputComponent label="Select account for Staking" required inputSize="l">
-            <SelectAccount onChange={(account) => changeField('account', account)} />
+            <SelectAccount onChange={(account) => changeField('account', account)} selected={fields.account} />
           </InputComponent>
         </RowGapBlock>
       </Row>

--- a/packages/ui/src/working-groups/modals/ChangeAccountModal/ChangeAccountSelectModal.tsx
+++ b/packages/ui/src/working-groups/modals/ChangeAccountModal/ChangeAccountSelectModal.tsx
@@ -37,7 +37,7 @@ export const ChangeAccountSelectModal: FC<Props> = ({ account, onClose, onAccept
           disabled={from}
           borderless={from}
         >
-          <SelectAccount filter={filterSelectedAccount} onChange={setSelectedAccount} />
+          <SelectAccount filter={filterSelectedAccount} onChange={setSelectedAccount} selected={selectedAccount} />
         </InputComponent>
       </ModalBody>
       <ModalFooter>


### PR DESCRIPTION
Turns out account selectors didn't display selected accounts because the selected account was given to them by the form they're in via props. It makes sense since the form state should be the "master index" of all values filled in ­— so I've made sure to avoid confusion by completely removing the selected item from select components' state - it can only be supplied by props now. The select components' main job is to pass the correct data back to form upon selection.
I have also noticed that "unsaved accounts" weren't being passed back to the form (while their internal state made them display the account, meaning that displayed values were inconsistent with the form state) so I fixed that as well. This use case is a bit odd/specific to the Account Selector, so I went ahead and added a test case for it, as well as a click-selection sanity check.
Closes #855 