### PR TITLE
🧬 Adapt activity text to context

### DIFF
--- a/packages/ui/src/app/pages/Proposals/PastProposals.tsx
+++ b/packages/ui/src/app/pages/Proposals/PastProposals.tsx
@@ -17,9 +17,9 @@ import { ProposalsTabs } from './components/ProposalsTabs'
 
 export const PastProposals = () => {
   const searchSlot = useRef<HTMLDivElement>(null)
-  const [filters, setFilters] = useState(ProposalEmptyFilter)
+  const [, setFilters] = useState(ProposalEmptyFilter)
 
-  const { types, stages } = usePastProposals({ filters })
+  const { types, stages } = usePastProposals()
   const { isLoading, proposals } = useProposals({ status: 'past' })
 
   const activities = useActivities()

--- a/packages/ui/src/common/components/Activities/Activities.stories.tsx
+++ b/packages/ui/src/common/components/Activities/Activities.stories.tsx
@@ -2,6 +2,10 @@ import { Meta, Story } from '@storybook/react'
 import BN from 'bn.js'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
+import styled from 'styled-components'
+
+import { ActivitiesBlock } from '@/common/components/Activities/ActivitiesBlock'
+import { Activity } from '@/common/types'
 
 import { ModalContext } from '../../providers/modal/context'
 import { TemplateBlock } from '../storybookParts/previewStyles'
@@ -10,7 +14,7 @@ import { Activities, ActivitiesProps } from './Activities'
 
 export default {
   title: 'Common/Activities',
-  component: Activities,
+  component: ActivitiesBlock,
 } as Meta
 
 const Template: Story<ActivitiesProps> = (args) => (
@@ -23,167 +27,180 @@ const Template: Story<ActivitiesProps> = (args) => (
         modalData: {},
       }}
     >
-      <TemplateBlock>
-        <Activities {...args} />
-      </TemplateBlock>
+      <TemplateScroll>
+        <ActivitiesBlock {...args} />
+      </TemplateScroll>
     </ModalContext.Provider>
   </MemoryRouter>
 )
 
+const TemplateScroll = styled(TemplateBlock)`
+  overflow: scroll;
+  height: 100vh;
+`
+
+const activities: Activity[] = [
+  {
+    id: '1',
+    createdAt: '2021-03-09T10:28:04.155Z',
+    eventType: 'AppliedOnOpening',
+    member: {
+      handle: 'xXproGamerDarknessXx',
+      id: '1',
+    },
+    opening: {
+      title: 'Forum Worker',
+      id: '2',
+      type: 'REGULAR',
+      groupName: 'forum',
+    },
+  },
+  {
+    id: '2',
+    createdAt: '2021-05-09T10:28:04.155Z',
+    eventType: 'ApplicationWithdrawn',
+    member: {
+      handle: 'andy00',
+      id: '1',
+    },
+    opening: {
+      title: 'Forum Worker',
+      id: '2',
+      type: 'REGULAR',
+      groupName: 'forum',
+    },
+  },
+  {
+    id: '3',
+    createdAt: '2021-05-19T10:28:04.155Z',
+    eventType: 'BudgetSpending',
+    amount: new BN('10000'),
+    groupName: 'Forum',
+  },
+  {
+    id: '4',
+    createdAt: '2021-05-20T10:28:04.155Z',
+    eventType: 'BudgetSet',
+    groupName: 'Forum',
+    newBudget: new BN(100000),
+  },
+  {
+    id: '5',
+    createdAt: '2021-05-23T10:28:04.155Z',
+    eventType: 'LeaderSet',
+    member: {
+      id: '3',
+      handle: 'Kyle_1994',
+    },
+    groupName: 'storage',
+  },
+  {
+    id: '6',
+    createdAt: '2021-05-24T10:28:04.155Z',
+    eventType: 'StatusTextChanged',
+    groupName: 'storage',
+  },
+  {
+    id: '7',
+    createdAt: '2021-05-25T10:28:04.155Z',
+    eventType: 'OpeningAdded',
+    opening: {
+      id: '3',
+      title: 'Forum Working Group Regular',
+      type: 'REGULAR',
+      groupName: 'forum',
+    },
+  },
+  {
+    id: '8',
+    createdAt: '2021-05-25T10:28:04.155Z',
+    eventType: 'OpeningCanceled',
+    opening: {
+      id: '3',
+      title: 'Forum Working Group Regular',
+      type: 'REGULAR',
+      groupName: 'forum',
+    },
+  },
+  {
+    id: '9',
+    createdAt: '2021-05-26T19:28:04.155Z',
+    eventType: 'StakeSlashed',
+    groupName: 'Forum',
+    member: {
+      id: '6',
+      handle: 'stefan0',
+    },
+  },
+  {
+    id: '10',
+    createdAt: '2021-05-26T19:28:04.155Z',
+    eventType: 'StakeIncreased',
+    member: {
+      id: '6',
+      handle: 'stefan0',
+    },
+    amount: new BN(1000),
+  },
+  {
+    id: '11',
+    createdAt: '2021-05-26T19:28:04.155Z',
+    eventType: 'StakeDecreased',
+    member: {
+      id: '6',
+      handle: 'stefan0',
+    },
+    amount: new BN(1000),
+  },
+  {
+    id: '12',
+    createdAt: '2021-05-26T19:28:04.155Z',
+    eventType: 'WorkerExited',
+    member: {
+      id: '7',
+      handle: 'mr_guy',
+    },
+  },
+  {
+    id: '13',
+    createdAt: '2021-05-25T10:28:04.155Z',
+    eventType: 'OpeningAdded',
+    opening: {
+      id: '3',
+      title: 'Forum Working Group Leader',
+      type: 'LEADER',
+      groupName: 'forum',
+    },
+  },
+  {
+    id: '14',
+    createdAt: '2021-05-25T10:28:04.155Z',
+    eventType: 'OpeningCanceled',
+    opening: {
+      id: '3',
+      title: 'Forum Working Group Leader',
+      type: 'LEADER',
+      groupName: 'forum',
+    },
+  },
+  {
+    id: '15',
+    createdAt: '2021-05-25T10:28:04.155Z',
+    eventType: 'WorkerStartedLeaving',
+    member: {
+      id: '8',
+      handle: 'johann',
+    },
+  },
+]
+
 export const Default = Template.bind({})
 Default.args = {
-  activities: [
-    {
-      id: '1',
-      createdAt: '2021-03-09T10:28:04.155Z',
-      eventType: 'AppliedOnOpening',
-      member: {
-        handle: 'xXproGamerDarknessXx',
-        id: '1',
-      },
-      opening: {
-        title: 'Forum Worker',
-        id: '2',
-        type: 'REGULAR',
-        groupName: 'forum',
-      },
-    },
-    {
-      id: '2',
-      createdAt: '2021-05-09T10:28:04.155Z',
-      eventType: 'ApplicationWithdrawn',
-      member: {
-        handle: 'andy00',
-        id: '1',
-      },
-      opening: {
-        title: 'Forum Worker',
-        id: '2',
-        type: 'REGULAR',
-        groupName: 'forum',
-      },
-    },
-    {
-      id: '3',
-      createdAt: '2021-05-19T10:28:04.155Z',
-      eventType: 'BudgetSpending',
-      amount: new BN('10000'),
-      groupName: 'Forum',
-    },
-    {
-      id: '4',
-      createdAt: '2021-05-20T10:28:04.155Z',
-      eventType: 'BudgetSet',
-      groupName: 'Forum',
-      newBudget: new BN(100000),
-    },
-    {
-      id: '5',
-      createdAt: '2021-05-23T10:28:04.155Z',
-      eventType: 'LeaderSet',
-      member: {
-        id: '3',
-        handle: 'Kyle_1994',
-      },
-      groupName: 'storage',
-    },
-    {
-      id: '6',
-      createdAt: '2021-05-24T10:28:04.155Z',
-      eventType: 'StatusTextChanged',
-      groupName: 'storage',
-    },
-    {
-      id: '7',
-      createdAt: '2021-05-25T10:28:04.155Z',
-      eventType: 'OpeningAdded',
-      opening: {
-        id: '3',
-        title: 'Forum Working Group Regular',
-        type: 'REGULAR',
-        groupName: 'forum',
-      },
-    },
-    {
-      id: '8',
-      createdAt: '2021-05-25T10:28:04.155Z',
-      eventType: 'OpeningCanceled',
-      opening: {
-        id: '3',
-        title: 'Forum Working Group Regular',
-        type: 'REGULAR',
-        groupName: 'forum',
-      },
-    },
-    {
-      id: '9',
-      createdAt: '2021-05-26T19:28:04.155Z',
-      eventType: 'StakeSlashed',
-      groupName: 'Forum',
-      member: {
-        id: '6',
-        handle: 'stefan0',
-      },
-    },
-    {
-      id: '10',
-      createdAt: '2021-05-26T19:28:04.155Z',
-      eventType: 'StakeIncreased',
-      member: {
-        id: '6',
-        handle: 'stefan0',
-      },
-      amount: new BN(1000),
-    },
-    {
-      id: '11',
-      createdAt: '2021-05-26T19:28:04.155Z',
-      eventType: 'StakeDecreased',
-      member: {
-        id: '6',
-        handle: 'stefan0',
-      },
-      amount: new BN(1000),
-    },
-    {
-      id: '12',
-      createdAt: '2021-05-26T19:28:04.155Z',
-      eventType: 'WorkerExited',
-      member: {
-        id: '7',
-        handle: 'mr_guy',
-      },
-    },
-    {
-      id: '13',
-      createdAt: '2021-05-25T10:28:04.155Z',
-      eventType: 'OpeningAdded',
-      opening: {
-        id: '3',
-        title: 'Forum Working Group Leader',
-        type: 'LEADER',
-        groupName: 'forum',
-      },
-    },
-    {
-      id: '14',
-      createdAt: '2021-05-25T10:28:04.155Z',
-      eventType: 'OpeningCanceled',
-      opening: {
-        id: '3',
-        title: 'Forum Working Group Leader',
-        type: 'LEADER',
-        groupName: 'forum',
-      },
-    },
-    {
-      id: '15',
-      createdAt: '2021-05-25T10:28:04.155Z',
-      eventType: 'WorkerStartedLeaving',
-      member: {
-        id: '8',
-        handle: 'johann',
-      },
-    },
-  ],
+  activities,
+}
+
+export const MemberCentric = Template.bind({})
+MemberCentric.args = {
+  activities,
+  isOwn: true,
 }

--- a/packages/ui/src/common/components/Activities/Activities.stories.tsx
+++ b/packages/ui/src/common/components/Activities/Activities.stories.tsx
@@ -10,7 +10,7 @@ import { Activity } from '@/common/types'
 import { ModalContext } from '../../providers/modal/context'
 import { TemplateBlock } from '../storybookParts/previewStyles'
 
-import { Activities, ActivitiesProps } from './Activities'
+import { ActivitiesProps } from './Activities'
 
 export default {
   title: 'Common/Activities',

--- a/packages/ui/src/common/components/Activities/Activities.tsx
+++ b/packages/ui/src/common/components/Activities/Activities.tsx
@@ -8,14 +8,15 @@ import { ActivityContent } from './ActivityContent'
 
 export interface ActivitiesProps {
   activities: Activity[]
+  isOwn?: boolean
 }
 
-export const Activities = ({ activities }: ActivitiesProps) => {
+export const Activities = ({ activities, isOwn }: ActivitiesProps) => {
   return (
     <ActivitiesList>
       {activities.map((activity) => (
         <ActivityComponent activity={activity} key={activity.eventType + activity.id}>
-          <ActivityContent activity={activity} />
+          <ActivityContent activity={activity} isOwn={isOwn} />
         </ActivityComponent>
       ))}
     </ActivitiesList>

--- a/packages/ui/src/common/components/Activities/ActivitiesBlock.tsx
+++ b/packages/ui/src/common/components/Activities/ActivitiesBlock.tsx
@@ -12,14 +12,15 @@ export interface ActivitiesBlockProps {
   activities: Activity[]
   label?: string
   warning?: WarningProps
+  isOwn?: boolean
 }
 
-export const ActivitiesBlock = ({ activities, label, warning }: ActivitiesBlockProps) => {
+export const ActivitiesBlock = ({ activities, label, warning, isOwn }: ActivitiesBlockProps) => {
   return (
     <ContentWithTabs>
       {label && <Label>{label}</Label>}
       {warning && <Warning {...warning} />}
-      <Activities activities={activities} />
+      <Activities activities={activities} isOwn={isOwn} />
     </ContentWithTabs>
   )
 }

--- a/packages/ui/src/common/components/Activities/ActivityContent.tsx
+++ b/packages/ui/src/common/components/Activities/ActivityContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { ActivityCategory } from '@/common/types/Activity'
 import { ApplicationWithdrawnContent } from '@/working-groups/components/Activities/ApplicationWithdrawnContent'
 import { AppliedOnOpeningContent } from '@/working-groups/components/Activities/AppliedOnOpeningContent'
 import { BudgetSetContent } from '@/working-groups/components/Activities/BudgetSetContent'
@@ -15,38 +16,27 @@ import { WorkerStartedLeavingContent } from '@/working-groups/components/Activit
 
 import { Activity } from '../../types'
 
-interface Props {
+export interface ActivityContentProps {
   activity: Activity
 }
 
-export const ActivityContent = React.memo(({ activity }: Props) => {
-  switch (activity.eventType) {
-    case 'AppliedOnOpening':
-      return <AppliedOnOpeningContent activity={activity} />
-    case 'BudgetSpending':
-      return <BudgetSpendingContent activity={activity} />
-    case 'ApplicationWithdrawn':
-      return <ApplicationWithdrawnContent activity={activity} />
-    case 'BudgetSet':
-      return <BudgetSetContent activity={activity} />
-    case 'LeaderSet':
-      return <LeaderSetContent activity={activity} />
-    case 'StatusTextChanged':
-      return <StatusTextChangedContent activity={activity} />
-    case 'OpeningAdded':
-      return <OpeningAddedContent activity={activity} />
-    case 'OpeningCanceled':
-      return <OpeningCanceledContent activity={activity} />
-    case 'StakeSlashed':
-      return <StakeSlashedContent activity={activity} />
-    case 'StakeDecreased':
-    case 'StakeIncreased':
-      return <StakeChangedContent activity={activity} />
-    case 'WorkerExited':
-      return <WorkerExitedContent activity={activity} />
-    case 'WorkerStartedLeaving':
-      return <WorkerStartedLeavingContent activity={activity} />
-    default:
-      return <div />
-  }
+const ActivityMap: Record<ActivityCategory, React.FC<ActivityContentProps>> = {
+  AppliedOnOpening: AppliedOnOpeningContent,
+  ApplicationWithdrawn: ApplicationWithdrawnContent,
+  BudgetSpending: BudgetSpendingContent,
+  BudgetSet: BudgetSetContent,
+  LeaderSet: LeaderSetContent,
+  StatusTextChanged: StatusTextChangedContent,
+  OpeningAdded: OpeningAddedContent,
+  OpeningCanceled: OpeningCanceledContent,
+  StakeSlashed: StakeSlashedContent,
+  StakeDecreased: StakeChangedContent,
+  StakeIncreased: StakeChangedContent,
+  WorkerExited: WorkerExitedContent,
+  WorkerStartedLeaving: WorkerStartedLeavingContent,
+}
+
+export const ActivityContent = React.memo(({ activity }: ActivityContentProps) => {
+  const Content = ActivityMap[activity.eventType]
+  return <Content activity={activity} />
 })

--- a/packages/ui/src/common/components/Activities/ActivityContent.tsx
+++ b/packages/ui/src/common/components/Activities/ActivityContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
 
 import { ActivityCategory } from '@/common/types/Activity'
 import { ApplicationWithdrawnContent } from '@/working-groups/components/Activities/ApplicationWithdrawnContent'
@@ -21,7 +21,11 @@ export interface ActivityContentProps {
   isOwn?: boolean
 }
 
-const ActivityMap: Record<ActivityCategory, React.FC<ActivityContentProps>> = {
+export interface ActivityContentComponent {
+  (props: ActivityContentProps): ReactElement<any, any> | null
+}
+
+const ActivityMap: Record<ActivityCategory, ActivityContentComponent> = {
   AppliedOnOpening: AppliedOnOpeningContent,
   ApplicationWithdrawn: ApplicationWithdrawnContent,
   BudgetSpending: BudgetSpendingContent,

--- a/packages/ui/src/common/components/Activities/ActivityContent.tsx
+++ b/packages/ui/src/common/components/Activities/ActivityContent.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react'
 
-import { ActivityCategory } from '@/common/types/Activity'
+import { Activity, ActivityCategory, BaseActivity } from '@/common/types/Activity'
 import { ApplicationWithdrawnContent } from '@/working-groups/components/Activities/ApplicationWithdrawnContent'
 import { AppliedOnOpeningContent } from '@/working-groups/components/Activities/AppliedOnOpeningContent'
 import { BudgetSetContent } from '@/working-groups/components/Activities/BudgetSetContent'
@@ -14,18 +14,11 @@ import { StatusTextChangedContent } from '@/working-groups/components/Activities
 import { WorkerExitedContent } from '@/working-groups/components/Activities/WorkerExitedContent'
 import { WorkerStartedLeavingContent } from '@/working-groups/components/Activities/WorkerStartedLeavingContent'
 
-import { Activity } from '../../types'
-
-export interface ActivityContentProps {
-  activity: Activity
-  isOwn?: boolean
+export interface ActivityContentComponent<Activity extends BaseActivity> {
+  (props: { activity: Activity; isOwn?: boolean }): ReactElement | null
 }
 
-export interface ActivityContentComponent {
-  (props: ActivityContentProps): ReactElement<any, any> | null
-}
-
-const ActivityMap: Record<ActivityCategory, ActivityContentComponent> = {
+const ActivityMap: Record<ActivityCategory, ActivityContentComponent<any>> = {
   AppliedOnOpening: AppliedOnOpeningContent,
   ApplicationWithdrawn: ApplicationWithdrawnContent,
   BudgetSpending: BudgetSpendingContent,
@@ -41,7 +34,7 @@ const ActivityMap: Record<ActivityCategory, ActivityContentComponent> = {
   WorkerStartedLeaving: WorkerStartedLeavingContent,
 }
 
-export const ActivityContent = React.memo(({ activity, isOwn }: ActivityContentProps) => {
+export const ActivityContent = React.memo(({ activity, isOwn }: { activity: Activity; isOwn?: boolean }) => {
   const Content = ActivityMap[activity.eventType]
   return <Content activity={activity} isOwn={isOwn} />
 })

--- a/packages/ui/src/common/components/Activities/ActivityContent.tsx
+++ b/packages/ui/src/common/components/Activities/ActivityContent.tsx
@@ -18,6 +18,7 @@ import { Activity } from '../../types'
 
 export interface ActivityContentProps {
   activity: Activity
+  isOwn?: boolean
 }
 
 const ActivityMap: Record<ActivityCategory, React.FC<ActivityContentProps>> = {
@@ -36,7 +37,7 @@ const ActivityMap: Record<ActivityCategory, React.FC<ActivityContentProps>> = {
   WorkerStartedLeaving: WorkerStartedLeavingContent,
 }
 
-export const ActivityContent = React.memo(({ activity }: ActivityContentProps) => {
+export const ActivityContent = React.memo(({ activity, isOwn }: ActivityContentProps) => {
   const Content = ActivityMap[activity.eventType]
-  return <Content activity={activity} />
+  return <Content activity={activity} isOwn={isOwn} />
 })

--- a/packages/ui/src/common/components/ModalLink.tsx
+++ b/packages/ui/src/common/components/ModalLink.tsx
@@ -32,7 +32,6 @@ export type IModalLink<Call> = React.FC<ModalLinkProps<Call>>
 const ModalLinkItem = styled(Link)`
   font-size: 14px;
   line-height: 20px;
-  font-weight: 400;
   text-decoration: none;
   color: ${Colors.Black[900]};
   font-weight: 700;

--- a/packages/ui/src/common/components/Notifications/Notifications.tsx
+++ b/packages/ui/src/common/components/Notifications/Notifications.tsx
@@ -5,7 +5,6 @@ import { useOutsideClick } from '@/common/hooks/useOutsideClick'
 import { useMemberNotifications } from '@/memberships/hooks/useMemberNotifications'
 
 import { Colors, RemoveScrollbar, Shadows, Transitions } from '../../constants'
-import { useActivities } from '../../hooks/useActivities'
 import { ActivitiesList } from '../Activities'
 import { ActivitiesBlock } from '../Activities/ActivitiesBlock'
 import { ActivityItem } from '../Activities/ActivityComponent'

--- a/packages/ui/src/common/components/Notifications/Notifications.tsx
+++ b/packages/ui/src/common/components/Notifications/Notifications.tsx
@@ -28,7 +28,7 @@ export const Notifications = ({ onClose, isNotificationsPanelOpen }: Props) => {
         <CloseButton onClick={onClose} />
       </NotificationsHeader>
       <NotificationsBody>
-        <ActivitiesBlock activities={activities} />
+        <ActivitiesBlock activities={activities} isOwn />
       </NotificationsBody>
     </NotificationsPanel>
   )

--- a/packages/ui/src/proposals/hooks/usePastProposals.ts
+++ b/packages/ui/src/proposals/hooks/usePastProposals.ts
@@ -1,12 +1,7 @@
-import { ProposalFiltersState } from '@/proposals/components/ProposalFilters'
 import { proposalDetails } from '@/proposals/model/proposalDetails'
 import { proposalStatuses } from '@/proposals/model/proposalStatus'
 
-interface UsePastProposalsProps {
-  filters: ProposalFiltersState
-}
-
-export const usePastProposals = ({ filters }: UsePastProposalsProps) => {
+export const usePastProposals = () => {
   const stages = proposalStatuses
   const types = proposalDetails
 

--- a/packages/ui/src/working-groups/components/Activities/ApplicationWithdrawnContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/ApplicationWithdrawnContent.tsx
@@ -6,8 +6,11 @@ import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 
 import { ApplicationWithdrawnActivity } from '../../types'
 
-export const ApplicationWithdrawnContent: ActivityContentComponent = ({ activity, isOwn }) => {
-  const { member, opening } = activity as ApplicationWithdrawnActivity
+export const ApplicationWithdrawnContent: ActivityContentComponent<ApplicationWithdrawnActivity> = ({
+  activity,
+  isOwn,
+}) => {
+  const { member, opening } = activity
   return (
     <>
       {isOwn ? (

--- a/packages/ui/src/working-groups/components/Activities/ApplicationWithdrawnContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/ApplicationWithdrawnContent.tsx
@@ -11,15 +11,14 @@ export const ApplicationWithdrawnContent: ActivityContentComponent<ApplicationWi
   isOwn,
 }) => {
   const { member, opening } = activity
-  return (
+  return isOwn ? (
     <>
-      {isOwn ? (
-        <>You have </>
-      ) : (
-        <>
-          <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has{' '}
-        </>
-      )}
+      You have withdrawn application from "
+      <ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>" opening.
+    </>
+  ) : (
+    <>
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has{' '}
       withdrawn application from "
       <ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>" opening.
     </>

--- a/packages/ui/src/working-groups/components/Activities/ApplicationWithdrawnContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/ApplicationWithdrawnContent.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 
 import { ApplicationWithdrawnActivity } from '../../types'
 
-export const ApplicationWithdrawnContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
+export const ApplicationWithdrawnContent: ActivityContentComponent = ({ activity, isOwn }) => {
   const { member, opening } = activity as ApplicationWithdrawnActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/ApplicationWithdrawnContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/ApplicationWithdrawnContent.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 
 import { ApplicationWithdrawnActivity } from '../../types'
 
-interface Props {
-  activity: ApplicationWithdrawnActivity
+export const ApplicationWithdrawnContent: React.FC<ActivityContentProps> = ({ activity }) => {
+  const { member, opening } = activity as ApplicationWithdrawnActivity
+  return (
+    <>
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has
+      withdrawn application from "
+      <ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>" opening.
+    </>
+  )
 }
-
-export const ApplicationWithdrawnContent = ({ activity: { member, opening } }: Props) => (
-  <>
-    <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has withdrawn
-    application from "
-    <ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>" opening.
-  </>
-)

--- a/packages/ui/src/working-groups/components/Activities/ApplicationWithdrawnContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/ApplicationWithdrawnContent.tsx
@@ -6,11 +6,17 @@ import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 
 import { ApplicationWithdrawnActivity } from '../../types'
 
-export const ApplicationWithdrawnContent: React.FC<ActivityContentProps> = ({ activity }) => {
+export const ApplicationWithdrawnContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
   const { member, opening } = activity as ApplicationWithdrawnActivity
   return (
     <>
-      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has
+      {isOwn ? (
+        <>You have </>
+      ) : (
+        <>
+          <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has{' '}
+        </>
+      )}
       withdrawn application from "
       <ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>" opening.
     </>

--- a/packages/ui/src/working-groups/components/Activities/AppliedOnOpeningContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/AppliedOnOpeningContent.tsx
@@ -8,16 +8,15 @@ import { AppliedOnOpeningActivity } from '../../types'
 
 export const AppliedOnOpeningContent: ActivityContentComponent<AppliedOnOpeningActivity> = ({ activity, isOwn }) => {
   const { member, opening } = activity
-  return (
+  return isOwn ? (
     <>
-      {isOwn ? (
-        <>You have applied on the opening </>
-      ) : (
-        <>
-          <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has
-          applied on the opening{' '}
-        </>
-      )}
+      You have applied on the opening{' '}
+      <ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>.
+    </>
+  ) : (
+    <>
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has applied
+      on the opening{' '}
       <ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>.
     </>
   )

--- a/packages/ui/src/working-groups/components/Activities/AppliedOnOpeningContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/AppliedOnOpeningContent.tsx
@@ -6,12 +6,18 @@ import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 
 import { AppliedOnOpeningActivity } from '../../types'
 
-export const AppliedOnOpeningContent: React.FC<ActivityContentProps> = ({ activity }) => {
+export const AppliedOnOpeningContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
   const { member, opening } = activity as AppliedOnOpeningActivity
   return (
     <>
-      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has applied
-      on the opening{' '}
+      {isOwn ? (
+        <>You have applied on the opening </>
+      ) : (
+        <>
+          <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has
+          applied on the opening{' '}
+        </>
+      )}
       <ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>.
     </>
   )

--- a/packages/ui/src/working-groups/components/Activities/AppliedOnOpeningContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/AppliedOnOpeningContent.tsx
@@ -6,8 +6,8 @@ import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 
 import { AppliedOnOpeningActivity } from '../../types'
 
-export const AppliedOnOpeningContent: ActivityContentComponent = ({ activity, isOwn }) => {
-  const { member, opening } = activity as AppliedOnOpeningActivity
+export const AppliedOnOpeningContent: ActivityContentComponent<AppliedOnOpeningActivity> = ({ activity, isOwn }) => {
+  const { member, opening } = activity
   return (
     <>
       {isOwn ? (

--- a/packages/ui/src/working-groups/components/Activities/AppliedOnOpeningContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/AppliedOnOpeningContent.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 
 import { AppliedOnOpeningActivity } from '../../types'
 
-export const AppliedOnOpeningContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
+export const AppliedOnOpeningContent: ActivityContentComponent = ({ activity, isOwn }) => {
   const { member, opening } = activity as AppliedOnOpeningActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/AppliedOnOpeningContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/AppliedOnOpeningContent.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 
 import { AppliedOnOpeningActivity } from '../../types'
 
-interface Props {
-  activity: AppliedOnOpeningActivity
+export const AppliedOnOpeningContent: React.FC<ActivityContentProps> = ({ activity }) => {
+  const { member, opening } = activity as AppliedOnOpeningActivity
+  return (
+    <>
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has applied
+      on the opening{' '}
+      <ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>.
+    </>
+  )
 }
-
-export const AppliedOnOpeningContent = ({ activity: { member, opening } }: Props) => (
-  <>
-    <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has applied
-    on the opening{' '}
-    <ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>.
-  </>
-)

--- a/packages/ui/src/working-groups/components/Activities/BudgetSetContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/BudgetSetContent.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { TokenValue } from '@/common/components/typography'
 
 import { BudgetSetActivity } from '../../types'
 
-interface Props {
-  activity: BudgetSetActivity
-}
-export const BudgetSetContent = React.memo(({ activity }: Props) => (
-  <>
-    {activity.groupName} Working Group Lead has changed the group budget to <TokenValue value={activity.newBudget} />.
-  </>
-))
+export const BudgetSetContent: React.FC<ActivityContentProps> = React.memo(({ activity }) => {
+  const { groupName, newBudget } = activity as BudgetSetActivity
+  return (
+    <>
+      {groupName} Working Group Lead has changed the group budget to <TokenValue value={newBudget} />.
+    </>
+  )
+})

--- a/packages/ui/src/working-groups/components/Activities/BudgetSetContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/BudgetSetContent.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { TokenValue } from '@/common/components/typography'
 
 import { BudgetSetActivity } from '../../types'
 
-export const BudgetSetContent: React.FC<ActivityContentProps> = React.memo(({ activity }) => {
+export const BudgetSetContent: ActivityContentComponent = React.memo(({ activity }) => {
   const { groupName, newBudget } = activity as BudgetSetActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/BudgetSetContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/BudgetSetContent.tsx
@@ -5,8 +5,8 @@ import { TokenValue } from '@/common/components/typography'
 
 import { BudgetSetActivity } from '../../types'
 
-export const BudgetSetContent: ActivityContentComponent = React.memo(({ activity }) => {
-  const { groupName, newBudget } = activity as BudgetSetActivity
+export const BudgetSetContent: ActivityContentComponent<BudgetSetActivity> = React.memo(({ activity }) => {
+  const { groupName, newBudget } = activity
   return (
     <>
       {groupName} Working Group Lead has changed the group budget to <TokenValue value={newBudget} />.

--- a/packages/ui/src/working-groups/components/Activities/BudgetSpendingContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/BudgetSpendingContent.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { TokenValue } from '@/common/components/typography'
 
 import { BudgetSpendingActivity } from '../../types'
 
-interface Props {
-  activity: BudgetSpendingActivity
-}
-
-export const BudgetSpendingContent = React.memo(({ activity }: Props) => (
-  <>
-    {activity.groupName} Lead spent <TokenValue value={activity.amount} /> from the budget.
-  </>
-))
+export const BudgetSpendingContent: React.FC<ActivityContentProps> = React.memo(({ activity }) => {
+  const { groupName, amount } = activity as BudgetSpendingActivity
+  return (
+    <>
+      {groupName} Lead spent <TokenValue value={amount} /> from the budget.
+    </>
+  )
+})

--- a/packages/ui/src/working-groups/components/Activities/BudgetSpendingContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/BudgetSpendingContent.tsx
@@ -5,8 +5,9 @@ import { TokenValue } from '@/common/components/typography'
 
 import { BudgetSpendingActivity } from '../../types'
 
-export const BudgetSpendingContent: ActivityContentComponent = React.memo(({ activity }) => {
-  const { groupName, amount } = activity as BudgetSpendingActivity
+export const BudgetSpendingContent: ActivityContentComponent<BudgetSpendingActivity> = React.memo(({ activity }) => {
+  const { groupName, amount } = activity
+
   return (
     <>
       {groupName} Lead spent <TokenValue value={amount} /> from the budget.

--- a/packages/ui/src/working-groups/components/Activities/BudgetSpendingContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/BudgetSpendingContent.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { TokenValue } from '@/common/components/typography'
 
 import { BudgetSpendingActivity } from '../../types'
 
-export const BudgetSpendingContent: React.FC<ActivityContentProps> = React.memo(({ activity }) => {
+export const BudgetSpendingContent: ActivityContentComponent = React.memo(({ activity }) => {
   const { groupName, amount } = activity as BudgetSpendingActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/LeaderSetContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/LeaderSetContent.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 
 import { LeaderSetActivity } from '../../types'
 
-export const LeaderSetContent: React.FC<ActivityContentProps> = ({ activity }) => {
+export const LeaderSetContent: ActivityContentComponent = ({ activity }) => {
   const { member, groupName } = activity as LeaderSetActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/LeaderSetContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/LeaderSetContent.tsx
@@ -1,18 +1,18 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 
 import { LeaderSetActivity } from '../../types'
 
-interface Props {
-  activity: LeaderSetActivity
+export const LeaderSetContent: React.FC<ActivityContentProps> = ({ activity }) => {
+  const { member, groupName } = activity as LeaderSetActivity
+  return (
+    <>
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has been
+      appointed Leader of the{' '}
+      <ActivityRouterLink to={`/working-groups/${groupName}`}>{groupName} Working Group</ActivityRouterLink>.
+    </>
+  )
 }
-
-export const LeaderSetContent = ({ activity: { member, groupName } }: Props) => (
-  <>
-    <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has been
-    appointed Leader of the{' '}
-    <ActivityRouterLink to={`/working-groups/${groupName}`}>{groupName} Working Group</ActivityRouterLink>.
-  </>
-)

--- a/packages/ui/src/working-groups/components/Activities/LeaderSetContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/LeaderSetContent.tsx
@@ -3,11 +3,10 @@ import React from 'react'
 import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
+import { LeaderSetActivity } from '@/working-groups/types'
 
-import { LeaderSetActivity } from '../../types'
-
-export const LeaderSetContent: ActivityContentComponent = ({ activity }) => {
-  const { member, groupName } = activity as LeaderSetActivity
+export const LeaderSetContent: ActivityContentComponent<LeaderSetActivity> = ({ activity }) => {
+  const { member, groupName } = activity
   return (
     <>
       <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has been

--- a/packages/ui/src/working-groups/components/Activities/OpeningAddedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/OpeningAddedContent.tsx
@@ -4,8 +4,8 @@ import { ActivityContentComponent } from '@/common/components/Activities/Activit
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { OpeningAddedActivity } from '@/working-groups/types'
 
-export const OpeningAddedContent: ActivityContentComponent = ({ activity }) => {
-  const { opening } = activity as OpeningAddedActivity
+export const OpeningAddedContent: ActivityContentComponent<OpeningAddedActivity> = ({ activity }) => {
+  const { opening } = activity
   return (
     <>
       Opening "<ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>"

--- a/packages/ui/src/working-groups/components/Activities/OpeningAddedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/OpeningAddedContent.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { OpeningAddedActivity } from '@/working-groups/types'
 
-export const OpeningAddedContent: React.FC<ActivityContentProps> = ({ activity }) => {
+export const OpeningAddedContent: ActivityContentComponent = ({ activity }) => {
   const { opening } = activity as OpeningAddedActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/OpeningAddedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/OpeningAddedContent.tsx
@@ -1,16 +1,16 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { OpeningAddedActivity } from '@/working-groups/types'
 
-interface Props {
-  activity: OpeningAddedActivity
+export const OpeningAddedContent: React.FC<ActivityContentProps> = ({ activity }) => {
+  const { opening } = activity as OpeningAddedActivity
+  return (
+    <>
+      Opening "<ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>"
+      for a {opening.type === 'REGULAR' && 'Non-'}Lead has been created by the{' '}
+      {opening.type === 'REGULAR' ? `${opening.groupName} Leader` : 'Council'}.
+    </>
+  )
 }
-
-export const OpeningAddedContent = ({ activity: { opening } }: Props) => (
-  <>
-    Opening "<ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>" for
-    a {opening.type === 'REGULAR' && 'Non-'}Lead has been created by the{' '}
-    {opening.type === 'REGULAR' ? `${opening.groupName} Leader` : 'Council'}.
-  </>
-)

--- a/packages/ui/src/working-groups/components/Activities/OpeningCanceledContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/OpeningCanceledContent.tsx
@@ -1,14 +1,10 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { OpeningCanceledActivity } from '@/working-groups/types'
 
-interface Props {
-  activity: OpeningCanceledActivity
-}
-
-export const OpeningCanceledContent: React.FC<ActivityContentProps> = ({ activity }) => {
+export const OpeningCanceledContent: ActivityContentComponent = ({ activity }) => {
   const { opening } = activity as OpeningCanceledActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/OpeningCanceledContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/OpeningCanceledContent.tsx
@@ -4,8 +4,8 @@ import { ActivityContentComponent } from '@/common/components/Activities/Activit
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { OpeningCanceledActivity } from '@/working-groups/types'
 
-export const OpeningCanceledContent: ActivityContentComponent = ({ activity }) => {
-  const { opening } = activity as OpeningCanceledActivity
+export const OpeningCanceledContent: ActivityContentComponent<OpeningCanceledActivity> = ({ activity }) => {
+  const { opening } = activity
 
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/OpeningCanceledContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/OpeningCanceledContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 import { OpeningCanceledActivity } from '@/working-groups/types'
 
@@ -7,10 +8,13 @@ interface Props {
   activity: OpeningCanceledActivity
 }
 
-export const OpeningCanceledContent = ({ activity: { opening } }: Props) => (
-  <>
-    Opening "<ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>" for
-    a {opening.type === 'REGULAR' && 'Non-'}Lead has been cancelled by the{' '}
-    {opening.type === 'REGULAR' ? `${opening.groupName} Leader` : 'Council'}.
-  </>
-)
+export const OpeningCanceledContent: React.FC<ActivityContentProps> = ({ activity }) => {
+  const { opening } = activity as OpeningCanceledActivity
+  return (
+    <>
+      Opening "<ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>"
+      for a {opening.type === 'REGULAR' && 'Non-'}Lead has been cancelled by the{' '}
+      {opening.type === 'REGULAR' ? `${opening.groupName} Leader` : 'Council'}.
+    </>
+  )
+}

--- a/packages/ui/src/working-groups/components/Activities/OpeningCanceledContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/OpeningCanceledContent.tsx
@@ -6,10 +6,11 @@ import { OpeningCanceledActivity } from '@/working-groups/types'
 
 export const OpeningCanceledContent: ActivityContentComponent = ({ activity }) => {
   const { opening } = activity as OpeningCanceledActivity
+
   return (
     <>
       Opening "<ActivityRouterLink to={`/working-groups/openings/${opening.id}`}>{opening.title}</ActivityRouterLink>"
-      for a {opening.type === 'REGULAR' && 'Non-'}Lead has been cancelled by the{' '}
+      for a {opening.type === 'REGULAR' && 'Non-'}Lead has been cancelled by the
       {opening.type === 'REGULAR' ? `${opening.groupName} Leader` : 'Council'}.
     </>
   )

--- a/packages/ui/src/working-groups/components/Activities/StakeChangedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StakeChangedContent.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { TokenValue } from '@/common/components/typography'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { StakeChangedActivity } from '@/working-groups/types'
 
-interface Props {
-  activity: StakeChangedActivity
+export const StakeChangedContent: React.FC<ActivityContentProps> = ({ activity }) => {
+  const { member, amount, eventType } = activity as StakeChangedActivity
+  return (
+    <>
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink>'s stake has
+      been {eventType === 'StakeDecreased' ? 'reduced' : 'increased'} by <TokenValue value={amount} />
+    </>
+  )
 }
-export const StakeChangedContent = ({ activity: { member, amount, eventType } }: Props) => (
-  <>
-    <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink>'s stake has
-    been {eventType === 'StakeDecreased' ? 'reduced' : 'increased'} by <TokenValue value={amount} />
-  </>
-)

--- a/packages/ui/src/working-groups/components/Activities/StakeChangedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StakeChangedContent.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { TokenValue } from '@/common/components/typography'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { StakeChangedActivity } from '@/working-groups/types'
 
-export const StakeChangedContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
+export const StakeChangedContent: ActivityContentComponent = ({ activity, isOwn }) => {
   const { member, amount, eventType } = activity as StakeChangedActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/StakeChangedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StakeChangedContent.tsx
@@ -5,12 +5,18 @@ import { TokenValue } from '@/common/components/typography'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { StakeChangedActivity } from '@/working-groups/types'
 
-export const StakeChangedContent: React.FC<ActivityContentProps> = ({ activity }) => {
+export const StakeChangedContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
   const { member, amount, eventType } = activity as StakeChangedActivity
   return (
     <>
-      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink>'s stake has
-      been {eventType === 'StakeDecreased' ? 'reduced' : 'increased'} by <TokenValue value={amount} />
+      {isOwn ? (
+        <>Your </>
+      ) : (
+        <>
+          <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink>'s{' '}
+        </>
+      )}
+      stake has been {eventType === 'StakeDecreased' ? 'reduced' : 'increased'} by <TokenValue value={amount} />
     </>
   )
 }

--- a/packages/ui/src/working-groups/components/Activities/StakeChangedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StakeChangedContent.tsx
@@ -7,16 +7,18 @@ import { StakeChangedActivity } from '@/working-groups/types'
 
 export const StakeChangedContent: ActivityContentComponent = ({ activity, isOwn }) => {
   const { member, amount, eventType } = activity as StakeChangedActivity
+
+  if (isOwn) {
+    return (
+      <>
+        Your stake has been {eventType === 'StakeDecreased' ? 'reduced' : 'increased'} by <TokenValue value={amount} />
+      </>
+    )
+  }
   return (
     <>
-      {isOwn ? (
-        <>Your </>
-      ) : (
-        <>
-          <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink>'s{' '}
-        </>
-      )}
-      stake has been {eventType === 'StakeDecreased' ? 'reduced' : 'increased'} by <TokenValue value={amount} />
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink>'s stake has
+      been {eventType === 'StakeDecreased' ? 'reduced' : 'increased'} by <TokenValue value={amount} />
     </>
   )
 }

--- a/packages/ui/src/working-groups/components/Activities/StakeChangedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StakeChangedContent.tsx
@@ -5,8 +5,8 @@ import { TokenValue } from '@/common/components/typography'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { StakeChangedActivity } from '@/working-groups/types'
 
-export const StakeChangedContent: ActivityContentComponent = ({ activity, isOwn }) => {
-  const { member, amount, eventType } = activity as StakeChangedActivity
+export const StakeChangedContent: ActivityContentComponent<StakeChangedActivity> = ({ activity, isOwn }) => {
+  const { member, amount, eventType } = activity
 
   if (isOwn) {
     return (

--- a/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
@@ -4,8 +4,8 @@ import { ActivityContentComponent } from '@/common/components/Activities/Activit
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { StakeSlashedActivity } from '@/working-groups/types'
 
-export const StakeSlashedContent: ActivityContentComponent = ({ activity, isOwn }) => {
-  const { member, groupName } = activity as StakeSlashedActivity
+export const StakeSlashedContent: ActivityContentComponent<StakeSlashedActivity> = ({ activity, isOwn }) => {
+  const { member, groupName } = activity
 
   if (isOwn) {
     return <>You have been slashed by the {groupName} Working Group Lead.</>

--- a/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { StakeSlashedActivity } from '@/working-groups/types'
 
-export const StakeSlashedContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
+export const StakeSlashedContent: ActivityContentComponent = ({ activity, isOwn }) => {
   const { member, groupName } = activity as StakeSlashedActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { StakeSlashedActivity } from '@/working-groups/types'
 
-interface Props {
-  activity: StakeSlashedActivity
+export const StakeSlashedContent: React.FC<ActivityContentProps> = ({ activity }) => {
+  const { member, groupName } = activity as StakeSlashedActivity
+  return (
+    <>
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has been
+      slashed by the {groupName} Working Group Lead.
+    </>
+  )
 }
-
-export const StakeSlashedContent = ({ activity: { member, groupName } }: Props) => (
-  <>
-    <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has been
-    slashed by the {groupName} Working Group Lead.
-  </>
-)

--- a/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
@@ -4,12 +4,18 @@ import { ActivityContentProps } from '@/common/components/Activities/ActivityCon
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { StakeSlashedActivity } from '@/working-groups/types'
 
-export const StakeSlashedContent: React.FC<ActivityContentProps> = ({ activity }) => {
+export const StakeSlashedContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
   const { member, groupName } = activity as StakeSlashedActivity
   return (
     <>
-      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has been
-      slashed by the {groupName} Working Group Lead.
+      {isOwn ? (
+        <>You have </>
+      ) : (
+        <>
+          <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has{' '}
+        </>
+      )}
+      been slashed by the {groupName} Working Group Lead.
     </>
   )
 }

--- a/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
@@ -6,16 +6,15 @@ import { StakeSlashedActivity } from '@/working-groups/types'
 
 export const StakeSlashedContent: ActivityContentComponent = ({ activity, isOwn }) => {
   const { member, groupName } = activity as StakeSlashedActivity
+
+  if (isOwn) {
+    return <>You have been slashed by the {groupName} Working Group Lead.</>
+  }
+
   return (
     <>
-      {isOwn ? (
-        <>You have </>
-      ) : (
-        <>
-          <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has{' '}
-        </>
-      )}
-      been slashed by the {groupName} Working Group Lead.
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has been
+      slashed by the {groupName} Working Group Lead.
     </>
   )
 }

--- a/packages/ui/src/working-groups/components/Activities/StatusTextChangedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StatusTextChangedContent.tsx
@@ -1,18 +1,16 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 
 import { StatusTextChangedActivity } from '../../types'
 
-interface Props {
-  activity: StatusTextChangedActivity
-}
-export const StatusTextChangedContent = React.memo(({ activity }: Props) => (
-  <>
-    Status updated by the{' '}
-    <ActivityRouterLink to={`/working-groups/${activity.groupName}`}>
-      {activity.groupName} Working Group
-    </ActivityRouterLink>{' '}
-    Lead.
-  </>
-))
+export const StatusTextChangedContent: React.FC<ActivityContentProps> = React.memo(({ activity }) => {
+  const { groupName } = activity as StatusTextChangedActivity
+  return (
+    <>
+      Status updated by the{' '}
+      <ActivityRouterLink to={`/working-groups/${groupName}`}>{groupName} Working Group</ActivityRouterLink> Lead.
+    </>
+  )
+})

--- a/packages/ui/src/working-groups/components/Activities/StatusTextChangedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StatusTextChangedContent.tsx
@@ -7,9 +7,10 @@ import { StatusTextChangedActivity } from '../../types'
 
 export const StatusTextChangedContent: ActivityContentComponent = React.memo(({ activity }) => {
   const { groupName } = activity as StatusTextChangedActivity
+
   return (
     <>
-      Status updated by the{' '}
+      Status updated by the
       <ActivityRouterLink to={`/working-groups/${groupName}`}>{groupName} Working Group</ActivityRouterLink> Lead.
     </>
   )

--- a/packages/ui/src/working-groups/components/Activities/StatusTextChangedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StatusTextChangedContent.tsx
@@ -5,13 +5,15 @@ import { ActivityRouterLink } from '@/common/components/Activities/ActivityRoute
 
 import { StatusTextChangedActivity } from '../../types'
 
-export const StatusTextChangedContent: ActivityContentComponent = React.memo(({ activity }) => {
-  const { groupName } = activity as StatusTextChangedActivity
+export const StatusTextChangedContent: ActivityContentComponent<StatusTextChangedActivity> = React.memo(
+  ({ activity }) => {
+    const { groupName } = activity
 
-  return (
-    <>
-      Status updated by the
-      <ActivityRouterLink to={`/working-groups/${groupName}`}>{groupName} Working Group</ActivityRouterLink> Lead.
-    </>
-  )
-})
+    return (
+      <>
+        Status updated by the
+        <ActivityRouterLink to={`/working-groups/${groupName}`}>{groupName} Working Group</ActivityRouterLink> Lead.
+      </>
+    )
+  }
+)

--- a/packages/ui/src/working-groups/components/Activities/StatusTextChangedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StatusTextChangedContent.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
 
 import { StatusTextChangedActivity } from '../../types'
 
-export const StatusTextChangedContent: React.FC<ActivityContentProps> = React.memo(({ activity }) => {
+export const StatusTextChangedContent: ActivityContentComponent = React.memo(({ activity }) => {
   const { groupName } = activity as StatusTextChangedActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { WorkerExitedActivity } from '@/working-groups/types'
 
-export const WorkerExitedContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
+export const WorkerExitedContent: ActivityContentComponent = ({ activity, isOwn }) => {
   const { member } = activity as WorkerExitedActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
@@ -4,8 +4,8 @@ import { ActivityContentComponent } from '@/common/components/Activities/Activit
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { WorkerExitedActivity } from '@/working-groups/types'
 
-export const WorkerExitedContent: ActivityContentComponent = ({ activity, isOwn }) => {
-  const { member } = activity as WorkerExitedActivity
+export const WorkerExitedContent: ActivityContentComponent<WorkerExitedActivity> = ({ activity, isOwn }) => {
+  const { member } = activity
 
   if (isOwn) {
     return <>You left a role.</>

--- a/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
@@ -6,13 +6,14 @@ import { WorkerExitedActivity } from '@/working-groups/types'
 
 export const WorkerExitedContent: ActivityContentComponent = ({ activity, isOwn }) => {
   const { member } = activity as WorkerExitedActivity
+
+  if (isOwn) {
+    return <>You left a role.</>
+  }
+
   return (
     <>
-      {isOwn ? (
-        <>You </>
-      ) : (
-        <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle} </MemberModalLink>
-      )}
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink>
       left a role.
     </>
   )

--- a/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { WorkerExitedActivity } from '@/working-groups/types'
 
-interface Props {
-  activity: WorkerExitedActivity
+export const WorkerExitedContent: React.FC<ActivityContentProps> = ({ activity }) => {
+  const { member } = activity as WorkerExitedActivity
+  return (
+    <>
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> left a
+      role.
+    </>
+  )
 }
-
-export const WorkerExitedContent = ({ activity: { member } }: Props) => (
-  <>
-    <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> left a role.
-  </>
-)

--- a/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
@@ -4,12 +4,16 @@ import { ActivityContentProps } from '@/common/components/Activities/ActivityCon
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { WorkerExitedActivity } from '@/working-groups/types'
 
-export const WorkerExitedContent: React.FC<ActivityContentProps> = ({ activity }) => {
+export const WorkerExitedContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
   const { member } = activity as WorkerExitedActivity
   return (
     <>
-      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> left a
-      role.
+      {isOwn ? (
+        <>You </>
+      ) : (
+        <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle} </MemberModalLink>
+      )}
+      left a role.
     </>
   )
 }

--- a/packages/ui/src/working-groups/components/Activities/WorkerStartedLeavingContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/WorkerStartedLeavingContent.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 
+import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { WorkerStartedLeavingActivity } from '@/working-groups/types'
 
-interface Props {
-  activity: WorkerStartedLeavingActivity
+export const WorkerStartedLeavingContent: React.FC<ActivityContentProps> = ({ activity }) => {
+  const { member } = activity as WorkerStartedLeavingActivity
+  return (
+    <>
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> left a role
+      and is still in the unstaking period.
+    </>
+  )
 }
-
-export const WorkerStartedLeavingContent = ({ activity: { member } }: Props) => (
-  <>
-    <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> left a role
-    and is still in the unstaking period.
-  </>
-)

--- a/packages/ui/src/working-groups/components/Activities/WorkerStartedLeavingContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/WorkerStartedLeavingContent.tsx
@@ -4,8 +4,11 @@ import { ActivityContentComponent } from '@/common/components/Activities/Activit
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { WorkerStartedLeavingActivity } from '@/working-groups/types'
 
-export const WorkerStartedLeavingContent: ActivityContentComponent = ({ activity, isOwn }) => {
-  const { member } = activity as WorkerStartedLeavingActivity
+export const WorkerStartedLeavingContent: ActivityContentComponent<WorkerStartedLeavingActivity> = ({
+  activity,
+  isOwn,
+}) => {
+  const { member } = activity
 
   if (isOwn) {
     return <>You left role and you are still in the unstaking period.</>

--- a/packages/ui/src/working-groups/components/Activities/WorkerStartedLeavingContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/WorkerStartedLeavingContent.tsx
@@ -4,12 +4,16 @@ import { ActivityContentProps } from '@/common/components/Activities/ActivityCon
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { WorkerStartedLeavingActivity } from '@/working-groups/types'
 
-export const WorkerStartedLeavingContent: React.FC<ActivityContentProps> = ({ activity }) => {
+export const WorkerStartedLeavingContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
   const { member } = activity as WorkerStartedLeavingActivity
   return (
     <>
-      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> left a role
-      and is still in the unstaking period.
+      {isOwn ? (
+        <>You </>
+      ) : (
+        <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle} </MemberModalLink>
+      )}
+      left a role and {isOwn ? 'are' : 'is'} still in the unstaking period.
     </>
   )
 }

--- a/packages/ui/src/working-groups/components/Activities/WorkerStartedLeavingContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/WorkerStartedLeavingContent.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
-import { ActivityContentProps } from '@/common/components/Activities/ActivityContent'
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
 import { MemberModalLink } from '@/memberships/components/MemberModalLink'
 import { WorkerStartedLeavingActivity } from '@/working-groups/types'
 
-export const WorkerStartedLeavingContent: React.FC<ActivityContentProps> = ({ activity, isOwn }) => {
+export const WorkerStartedLeavingContent: ActivityContentComponent = ({ activity, isOwn }) => {
   const { member } = activity as WorkerStartedLeavingActivity
   return (
     <>

--- a/packages/ui/src/working-groups/components/Activities/WorkerStartedLeavingContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/WorkerStartedLeavingContent.tsx
@@ -6,14 +6,15 @@ import { WorkerStartedLeavingActivity } from '@/working-groups/types'
 
 export const WorkerStartedLeavingContent: ActivityContentComponent = ({ activity, isOwn }) => {
   const { member } = activity as WorkerStartedLeavingActivity
+
+  if (isOwn) {
+    return <>You left role and you are still in the unstaking period.</>
+  }
+
   return (
     <>
-      {isOwn ? (
-        <>You </>
-      ) : (
-        <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle} </MemberModalLink>
-      )}
-      left a role and {isOwn ? 'are' : 'is'} still in the unstaking period.
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle} </MemberModalLink>
+      left a role and is still in the unstaking period.
     </>
   )
 }

--- a/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
@@ -39,7 +39,6 @@ describe('UI: AddNewProposalModal', () => {
   }
 
   let useAccounts: UseAccounts
-  let tx: any
 
   const server = setupMockServer()
 
@@ -60,7 +59,7 @@ describe('UI: AddNewProposalModal', () => {
 
     stubDefaultBalances(api)
     stubProposalConstants(api)
-    tx = stubTransaction(api, 'api.tx.proposalsCodex.createProposal', 25)
+    stubTransaction(api, 'api.tx.proposalsCodex.createProposal', 25)
   })
 
   describe('Requirements', () => {
@@ -73,7 +72,7 @@ describe('UI: AddNewProposalModal', () => {
     })
 
     it('Insufficient funds', async () => {
-      tx = stubTransaction(api, 'api.tx.proposalsCodex.createProposal', 10000)
+      stubTransaction(api, 'api.tx.proposalsCodex.createProposal', 10000)
 
       const { findByText } = renderModal()
 


### PR DESCRIPTION
Changed member notifications to refer to the selected member in 2nd person. It's done through a prop in `ActivitiesBlock` and introduces some unfortunate prop drilling, but this way seems to be most efficient overall.

I've also refactored `ActivityContent` to use a `Record` as a map, instead of an elaborate switch. The final version of the refactor is pretty much on par with the previous one, gaining some strengths in one way while getting weaker in another.
The Good:
* `Record` enforces mapping of all activity categories to components, making sure no category is omitted by mistake
* `ActivityContent` is much easier on the eyes

The Bad:
* Type checking in respective content components is completely gone. However, this shouldn't pose a problem as long as activity contents are only used in the `ActivityContent` component.