### PR TITLE
🦀 Add worker leaving + status changed activities

### DIFF
--- a/packages/ui/dev/scripts/generators/generateEvents.ts
+++ b/packages/ui/dev/scripts/generators/generateEvents.ts
@@ -117,7 +117,8 @@ const generateStatusTextChangedEvents = (mocks: Mocks) => {
     createdAt: faker.date.recent(7),
     groupId: group.id,
     upcomingworkinggroupopeningcreatedInEventIds: [openings.find(opening => opening.groupId == group.id)?.id],
-    workinggroupmetadatasetInEvent: [],
+    // assuming this controls the "status updated" activity, just the array being empty or non-empty matters
+    workinggroupmetadatasetInEventIds: Math.random() > .5 ? ['1'] : [],
   }))
 }
 

--- a/packages/ui/dev/scripts/generators/generateEvents.ts
+++ b/packages/ui/dev/scripts/generators/generateEvents.ts
@@ -99,6 +99,17 @@ const generateOpeningFilledEvent = (mocks: Mocks) => () => {
   }
 }
 
+const generateWorkerLeavingEvent = (mocks: Mocks, leftAlready?: boolean) => () => {
+  const status = leftAlready ? 'left' : 'active'
+  const workers = mocks.workers.filter(worker => worker && worker.status === status)
+  const worker = workers[randomFromRange(0, workers.length - 1)]
+  return {
+    createdAt: faker.date.recent(7),
+    groupId: worker?.groupId,
+    workerId: worker?.id,
+  }
+}
+
 export const eventGenerators = {
   rewardPaidEvents : (mocks: Mocks) => Array.from({ length: 10 }).map(generateRewardPaidEvent(mocks)),
   budgetSpendingEvents : (mocks: Mocks) => Array.from({ length: 10 }).map(generateBudgetSpending(mocks)),
@@ -108,6 +119,8 @@ export const eventGenerators = {
   stakeIncreasedEvents : (mocks: Mocks) => Array.from({ length: 10 }).map(generateStakeChanged(mocks)),
   stakeSlashedEvents : (mocks: Mocks) => Array.from({ length: 10 }).map(generateStakeSlashedEvent(mocks)),
   openingFilledEvents : (mocks: Mocks) => Array.from({ length: 15 }).map(generateOpeningFilledEvent(mocks)),
+  workerExitedEvents : (mocks: Mocks) => Array.from({ length: 10 }).map(generateWorkerLeavingEvent(mocks, true)),
+  workerStartedLeavingEvents : (mocks: Mocks) => Array.from({ length: 10 }).map(generateWorkerLeavingEvent(mocks)),
 }
 
 export const generateAllEvents = (mocks: Mocks) => {

--- a/packages/ui/dev/scripts/generators/generateEvents.ts
+++ b/packages/ui/dev/scripts/generators/generateEvents.ts
@@ -110,6 +110,17 @@ const generateWorkerLeavingEvent = (mocks: Mocks, leftAlready?: boolean) => () =
   }
 }
 
+const generateStatusTextChangedEvents = (mocks: Mocks) => {
+  const groups = mocks.workingGroups
+  const openings = mocks.upcomingOpenings
+  return groups.map(group => ({
+    createdAt: faker.date.recent(7),
+    groupId: group.id,
+    upcomingworkinggroupopeningcreatedInEventIds: [openings.find(opening => opening.groupId == group.id)?.id],
+    workinggroupmetadatasetInEvent: [],
+  }))
+}
+
 export const eventGenerators = {
   rewardPaidEvents : (mocks: Mocks) => Array.from({ length: 10 }).map(generateRewardPaidEvent(mocks)),
   budgetSpendingEvents : (mocks: Mocks) => Array.from({ length: 10 }).map(generateBudgetSpending(mocks)),
@@ -121,6 +132,7 @@ export const eventGenerators = {
   openingFilledEvents : (mocks: Mocks) => Array.from({ length: 15 }).map(generateOpeningFilledEvent(mocks)),
   workerExitedEvents : (mocks: Mocks) => Array.from({ length: 10 }).map(generateWorkerLeavingEvent(mocks, true)),
   workerStartedLeavingEvents : (mocks: Mocks) => Array.from({ length: 10 }).map(generateWorkerLeavingEvent(mocks)),
+  statusTextChangedEvents : (mocks: Mocks) => generateStatusTextChangedEvents(mocks),
 }
 
 export const generateAllEvents = (mocks: Mocks) => {

--- a/packages/ui/src/common/components/Activities/ActivityContent.tsx
+++ b/packages/ui/src/common/components/Activities/ActivityContent.tsx
@@ -7,6 +7,7 @@ import { BudgetSetContent } from '@/working-groups/components/Activities/BudgetS
 import { BudgetSpendingContent } from '@/working-groups/components/Activities/BudgetSpendingContent'
 import { LeaderSetContent } from '@/working-groups/components/Activities/LeaderSetContent'
 import { OpeningAddedContent } from '@/working-groups/components/Activities/OpeningAddedContent'
+import { OpeningAnnouncedContent } from '@/working-groups/components/Activities/OpeningAnnouncedContent'
 import { OpeningCanceledContent } from '@/working-groups/components/Activities/OpeningCanceledContent'
 import { OpeningFilledContent } from '@/working-groups/components/Activities/OpeningFilledContent'
 import { StakeChangedContent } from '@/working-groups/components/Activities/StakeChangedContent'
@@ -34,6 +35,7 @@ const ActivityMap: Record<ActivityCategory, ActivityContentComponent<any>> = {
   WorkerExited: WorkerExitedContent,
   WorkerStartedLeaving: WorkerStartedLeavingContent,
   OpeningFilled: OpeningFilledContent,
+  OpeningAnnounced: OpeningAnnouncedContent,
 }
 
 export const ActivityContent = React.memo(({ activity, isOwn }: { activity: Activity; isOwn?: boolean }) => {

--- a/packages/ui/src/common/components/Activities/ActivityToIconMap.tsx
+++ b/packages/ui/src/common/components/Activities/ActivityToIconMap.tsx
@@ -1,5 +1,7 @@
 import { JSXElementConstructor } from 'react'
 
+import { BudgetIcon, ExiteRoleIcon, UpcomingIcon } from '@/common/components/icons/activities'
+
 import { ActivityCategory } from '../../types'
 import { AppliedIcon } from '../icons/activities/AppliedIcon'
 import { ClosedIcon } from '../icons/activities/ClosedIcon'
@@ -15,15 +17,16 @@ export const ActivityToIconMap: Record<ActivityCategory, [JSXElementConstructor<
   AppliedOnOpening: [AppliedIcon, 'joystream'],
   ApplicationWithdrawn: [AppliedIcon, 'joystream'],
   BudgetSpending: [DecreasedIcon, 'negative'],
-  BudgetSet: [IncreasedIcon, 'positive'],
+  BudgetSet: [BudgetIcon, 'positive'],
   LeaderSet: [HiredIcon, 'joystream'],
   StatusTextChanged: [AppliedIcon, 'positive'],
   OpeningAdded: [CreatedIcon, 'joystream'],
   OpeningCanceled: [ClosedIcon, 'negative'],
   StakeSlashed: [WarnedIcon, 'negative'],
-  StakeIncreased: [AppliedIcon, 'negative'],
-  StakeDecreased: [AppliedIcon, 'positive'],
-  WorkerExited: [ClosedIcon, 'negative'],
+  StakeIncreased: [IncreasedIcon, 'negative'],
+  StakeDecreased: [DecreasedIcon, 'positive'],
+  WorkerExited: [ExiteRoleIcon, 'negative'],
   WorkerStartedLeaving: [ClosedIcon, 'negative'],
   OpeningFilled: [HiredIcon, 'positive'],
+  OpeningAnnounced: [UpcomingIcon, 'joystream'],
 }

--- a/packages/ui/src/memberships/hooks/useMemberNotifications.ts
+++ b/packages/ui/src/memberships/hooks/useMemberNotifications.ts
@@ -8,6 +8,8 @@ import {
   asAppliedOnOpeningActivity,
   asStakeChangedActivity,
   asStakeSlashedActivity,
+  asWorkerExitedActivity,
+  asWorkerStartedLeavingActivity,
 } from '@/working-groups/types/WorkingGroupActivity'
 
 export const useMemberNotifications = () => {
@@ -25,6 +27,8 @@ export const useMemberNotifications = () => {
             ...data.stakeDecreasedEvents.map(asStakeChangedActivity),
             ...data.stakeIncreasedEvents.map(asStakeChangedActivity),
             ...data.stakeSlashedEvents.map(asStakeSlashedActivity),
+            ...data.workerExitedEvents.map(asWorkerExitedActivity),
+            ...data.workerStartedLeavingEvents.map(asWorkerStartedLeavingActivity),
           ].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
         : [],
     [loading, data, workerIds.length]

--- a/packages/ui/src/mocks/data/raw/statusTextChangedEvents.json
+++ b/packages/ui/src/mocks/data/raw/statusTextChangedEvents.json
@@ -5,7 +5,7 @@
     "upcomingworkinggroupopeningcreatedInEventIds": [
       "forumWorkingGroup-0"
     ],
-    "workinggroupmetadatasetInEvent": []
+    "workinggroupmetadatasetInEventIds": ["1"]
   },
   {
     "createdAt": "2021-06-30T23:22:05.064Z",
@@ -13,7 +13,7 @@
     "upcomingworkinggroupopeningcreatedInEventIds": [
       "storageWorkingGroup-2"
     ],
-    "workinggroupmetadatasetInEvent": []
+    "workinggroupmetadatasetInEventIds": []
   },
   {
     "createdAt": "2021-07-03T17:13:17.278Z",
@@ -21,7 +21,7 @@
     "upcomingworkinggroupopeningcreatedInEventIds": [
       "contentDirectoryWorkingGroup-5"
     ],
-    "workinggroupmetadatasetInEvent": []
+    "workinggroupmetadatasetInEventIds": ["1"]
   },
   {
     "createdAt": "2021-07-04T13:51:26.285Z",
@@ -29,6 +29,6 @@
     "upcomingworkinggroupopeningcreatedInEventIds": [
       "membershipWorkingGroup-8"
     ],
-    "workinggroupmetadatasetInEvent": []
+    "workinggroupmetadatasetInEventIds": []
   }
 ]

--- a/packages/ui/src/mocks/data/raw/statusTextChangedEvents.json
+++ b/packages/ui/src/mocks/data/raw/statusTextChangedEvents.json
@@ -1,0 +1,34 @@
+[
+  {
+    "createdAt": "2021-07-03T11:50:28.089Z",
+    "groupId": "forumWorkingGroup",
+    "upcomingworkinggroupopeningcreatedInEventIds": [
+      "forumWorkingGroup-0"
+    ],
+    "workinggroupmetadatasetInEvent": []
+  },
+  {
+    "createdAt": "2021-06-30T23:22:05.064Z",
+    "groupId": "storageWorkingGroup",
+    "upcomingworkinggroupopeningcreatedInEventIds": [
+      "storageWorkingGroup-2"
+    ],
+    "workinggroupmetadatasetInEvent": []
+  },
+  {
+    "createdAt": "2021-07-03T17:13:17.278Z",
+    "groupId": "contentDirectoryWorkingGroup",
+    "upcomingworkinggroupopeningcreatedInEventIds": [
+      "contentDirectoryWorkingGroup-5"
+    ],
+    "workinggroupmetadatasetInEvent": []
+  },
+  {
+    "createdAt": "2021-07-04T13:51:26.285Z",
+    "groupId": "membershipWorkingGroup",
+    "upcomingworkinggroupopeningcreatedInEventIds": [
+      "membershipWorkingGroup-8"
+    ],
+    "workinggroupmetadatasetInEvent": []
+  }
+]

--- a/packages/ui/src/mocks/data/raw/workerExitedEvents.json
+++ b/packages/ui/src/mocks/data/raw/workerExitedEvents.json
@@ -1,0 +1,52 @@
+[
+  {
+    "createdAt": "2021-07-02T08:43:29.894Z",
+    "groupId": "contentDirectoryWorkingGroup",
+    "workerId": "contentDirectoryWorkingGroup-50"
+  },
+  {
+    "createdAt": "2021-06-30T20:49:34.134Z",
+    "groupId": "contentDirectoryWorkingGroup",
+    "workerId": "contentDirectoryWorkingGroup-48"
+  },
+  {
+    "createdAt": "2021-07-05T11:37:57.188Z",
+    "groupId": "membershipWorkingGroup",
+    "workerId": "membershipWorkingGroup-67"
+  },
+  {
+    "createdAt": "2021-07-01T23:18:53.093Z",
+    "groupId": "forumWorkingGroup",
+    "workerId": "forumWorkingGroup-13"
+  },
+  {
+    "createdAt": "2021-07-05T05:08:44.630Z",
+    "groupId": "storageWorkingGroup",
+    "workerId": "storageWorkingGroup-32"
+  },
+  {
+    "createdAt": "2021-07-05T09:48:28.220Z",
+    "groupId": "forumWorkingGroup",
+    "workerId": "forumWorkingGroup-12"
+  },
+  {
+    "createdAt": "2021-07-01T02:03:20.296Z",
+    "groupId": "membershipWorkingGroup",
+    "workerId": "membershipWorkingGroup-68"
+  },
+  {
+    "createdAt": "2021-07-03T15:47:38.713Z",
+    "groupId": "contentDirectoryWorkingGroup",
+    "workerId": "contentDirectoryWorkingGroup-46"
+  },
+  {
+    "createdAt": "2021-06-30T12:37:47.892Z",
+    "groupId": "contentDirectoryWorkingGroup",
+    "workerId": "contentDirectoryWorkingGroup-49"
+  },
+  {
+    "createdAt": "2021-07-02T11:11:15.876Z",
+    "groupId": "forumWorkingGroup",
+    "workerId": "forumWorkingGroup-14"
+  }
+]

--- a/packages/ui/src/mocks/data/raw/workerStartedLeavingEvents.json
+++ b/packages/ui/src/mocks/data/raw/workerStartedLeavingEvents.json
@@ -1,0 +1,52 @@
+[
+  {
+    "createdAt": "2021-06-29T20:26:41.472Z",
+    "groupId": "forumWorkingGroup",
+    "workerId": "forumWorkingGroup-0"
+  },
+  {
+    "createdAt": "2021-07-04T19:25:44.032Z",
+    "groupId": "forumWorkingGroup",
+    "workerId": "forumWorkingGroup-2"
+  },
+  {
+    "createdAt": "2021-07-06T02:09:29.369Z",
+    "groupId": "forumWorkingGroup",
+    "workerId": "forumWorkingGroup-1"
+  },
+  {
+    "createdAt": "2021-07-02T17:52:26.972Z",
+    "groupId": "contentDirectoryWorkingGroup",
+    "workerId": "contentDirectoryWorkingGroup-38"
+  },
+  {
+    "createdAt": "2021-07-02T17:47:53.759Z",
+    "groupId": "contentDirectoryWorkingGroup",
+    "workerId": "contentDirectoryWorkingGroup-34"
+  },
+  {
+    "createdAt": "2021-07-06T08:05:21.768Z",
+    "groupId": "storageWorkingGroup",
+    "workerId": "storageWorkingGroup-22"
+  },
+  {
+    "createdAt": "2021-06-30T20:20:17.721Z",
+    "groupId": "contentDirectoryWorkingGroup",
+    "workerId": "contentDirectoryWorkingGroup-38"
+  },
+  {
+    "createdAt": "2021-07-05T15:33:38.012Z",
+    "groupId": "membershipWorkingGroup",
+    "workerId": "membershipWorkingGroup-53"
+  },
+  {
+    "createdAt": "2021-07-05T09:27:00.568Z",
+    "groupId": "membershipWorkingGroup",
+    "workerId": "membershipWorkingGroup-55"
+  },
+  {
+    "createdAt": "2021-07-02T21:09:18.760Z",
+    "groupId": "contentDirectoryWorkingGroup",
+    "workerId": "contentDirectoryWorkingGroup-35"
+  }
+]

--- a/packages/ui/src/mocks/data/seedEvents.ts
+++ b/packages/ui/src/mocks/data/seedEvents.ts
@@ -59,6 +59,7 @@ interface WorkerLeavingEvent extends BaseEvent {
 interface StatusTextChangedEvent extends BaseEvent {
   groupId: string
   upcomingworkinggroupopeningcreatedInEventIds: string[]
+  workinggroupmetadatasetInEventIds: string[]
 }
 
 export const eventCategories = {

--- a/packages/ui/src/mocks/data/seedEvents.ts
+++ b/packages/ui/src/mocks/data/seedEvents.ts
@@ -6,6 +6,8 @@ import rawRewardPaidEvents from './raw/rewardPaidEvents.json'
 import rawStakeDecreasedEvents from './raw/stakeDecreasedEvents.json'
 import rawStakeIncreasedEvents from './raw/stakeIncreasedEvents.json'
 import rawStakeSlashedEvents from './raw/stakeSlashedEvents.json'
+import rawWorkerExitedEvents from './raw/workerExitedEvents.json'
+import rawWorkerStartedLeavingEvents from './raw/workerStartedLeavingEvents.json'
 
 interface BaseEvent {
   id?: string
@@ -48,6 +50,11 @@ interface RawOpeningFilledEvent extends BaseEvent {
   workersHiredIds: string[]
 }
 
+interface WorkerLeavingEvent extends BaseEvent {
+  groupId: string
+  workerId: string
+}
+
 export const eventCategories = {
   ApplicationWithdrawnEvent: rawApplicationWithdrawnEvents.map((rawEvent: RawApplicationWithdrawnEvent) => ({
     ...rawEvent,
@@ -59,6 +66,8 @@ export const eventCategories = {
   StakeIncreasedEvent: rawStakeIncreasedEvents.map((rawEvent: RawStakeChangedEvent) => ({ ...rawEvent })),
   StakeSlashedEvent: rawStakeSlashedEvents.map((rawEvent: RawStakeSlashedEvent) => ({ ...rawEvent })),
   OpeningFilledEvent: rawOpeningFilledEvents.map((rawEvent: RawOpeningFilledEvent) => ({ ...rawEvent })),
+  WorkerExitedEvent: rawWorkerExitedEvents.map((rawEvent: WorkerLeavingEvent) => ({ ...rawEvent })),
+  WorkerStartedLeavingEvent: rawWorkerStartedLeavingEvents.map((rawEvent: WorkerLeavingEvent) => ({ ...rawEvent })),
 }
 
 type EventType = keyof typeof eventCategories

--- a/packages/ui/src/mocks/data/seedEvents.ts
+++ b/packages/ui/src/mocks/data/seedEvents.ts
@@ -6,6 +6,7 @@ import rawRewardPaidEvents from './raw/rewardPaidEvents.json'
 import rawStakeDecreasedEvents from './raw/stakeDecreasedEvents.json'
 import rawStakeIncreasedEvents from './raw/stakeIncreasedEvents.json'
 import rawStakeSlashedEvents from './raw/stakeSlashedEvents.json'
+import rawStatusTextChangedEvents from './raw/statusTextChangedEvents.json'
 import rawWorkerExitedEvents from './raw/workerExitedEvents.json'
 import rawWorkerStartedLeavingEvents from './raw/workerStartedLeavingEvents.json'
 
@@ -55,6 +56,11 @@ interface WorkerLeavingEvent extends BaseEvent {
   workerId: string
 }
 
+interface StatusTextChangedEvent extends BaseEvent {
+  groupId: string
+  upcomingworkinggroupopeningcreatedInEventIds: string[]
+}
+
 export const eventCategories = {
   ApplicationWithdrawnEvent: rawApplicationWithdrawnEvents.map((rawEvent: RawApplicationWithdrawnEvent) => ({
     ...rawEvent,
@@ -68,6 +74,7 @@ export const eventCategories = {
   OpeningFilledEvent: rawOpeningFilledEvents.map((rawEvent: RawOpeningFilledEvent) => ({ ...rawEvent })),
   WorkerExitedEvent: rawWorkerExitedEvents.map((rawEvent: WorkerLeavingEvent) => ({ ...rawEvent })),
   WorkerStartedLeavingEvent: rawWorkerStartedLeavingEvents.map((rawEvent: WorkerLeavingEvent) => ({ ...rawEvent })),
+  StatusTextChangedEvent: rawStatusTextChangedEvents.map((rawEvent: StatusTextChangedEvent) => ({ ...rawEvent })),
 }
 
 type EventType = keyof typeof eventCategories

--- a/packages/ui/src/mocks/server.ts
+++ b/packages/ui/src/mocks/server.ts
@@ -78,6 +78,7 @@ export const makeServer = (environment = 'development') => {
               openingFilledEvents: getWhereResolver('OpeningFilledEvent'),
               workerExitedEvents: getWhereResolver('WorkerExitedEvent'),
               workerStartedLeavingEvents: getWhereResolver('WorkerStartedLeavingEvent'),
+              statusTextChangedEvents: getWhereResolver('StatusTextChangedEvent'),
               proposals: getWhereResolver('Proposal'),
               proposalByUniqueInput: getUniqueResolver('Proposal'),
             },

--- a/packages/ui/src/mocks/server.ts
+++ b/packages/ui/src/mocks/server.ts
@@ -76,6 +76,8 @@ export const makeServer = (environment = 'development') => {
               stakeIncreasedEvents: getWhereResolver('StakeIncreasedEvent'),
               stakeSlashedEvents: getWhereResolver('StakeSlashedEvent'),
               openingFilledEvents: getWhereResolver('OpeningFilledEvent'),
+              workerExitedEvents: getWhereResolver('WorkerExitedEvent'),
+              workerStartedLeavingEvents: getWhereResolver('WorkerStartedLeavingEvent'),
               proposals: getWhereResolver('Proposal'),
               proposalByUniqueInput: getUniqueResolver('Proposal'),
             },

--- a/packages/ui/src/working-groups/components/Activities/OpeningAnnouncedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/OpeningAnnouncedContent.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
+import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
+import { OpeningAnnouncedActivity, OpeningFilledActivity } from '@/working-groups/types'
+
+export const OpeningAnnouncedContent: ActivityContentComponent<OpeningAnnouncedActivity> = ({ activity }) => {
+  const { openingId, groupName } = activity
+  return (
+    <>
+      An <ActivityRouterLink to={`/working-groups/upcoming-openings/${openingId}`}>upcoming opening</ActivityRouterLink>{' '}
+      for {groupName} has been announced.
+    </>
+  )
+}

--- a/packages/ui/src/working-groups/components/Activities/StatusTextChangedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StatusTextChangedContent.tsx
@@ -11,7 +11,7 @@ export const StatusTextChangedContent: ActivityContentComponent<StatusTextChange
 
     return (
       <>
-        Status updated by the
+        Status updated by the{' '}
         <ActivityRouterLink to={`/working-groups/${groupName}`}>{groupName} Working Group</ActivityRouterLink> Lead.
       </>
     )

--- a/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/WorkerExitedContent.tsx
@@ -13,8 +13,8 @@ export const WorkerExitedContent: ActivityContentComponent<WorkerExitedActivity>
 
   return (
     <>
-      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink>
-      left a role.
+      <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> left a
+      role.
     </>
   )
 }

--- a/packages/ui/src/working-groups/hooks/useGroupActivities.ts
+++ b/packages/ui/src/working-groups/hooks/useGroupActivities.ts
@@ -7,6 +7,7 @@ import {
   asBudgetSpendingActivity,
   asOpeningFilledActivity,
   asStakeChangedActivity,
+  asStatusTextChangedEventActivities,
   asWorkerExitedActivity,
 } from '@/working-groups/types/WorkingGroupActivity'
 
@@ -23,6 +24,7 @@ export const useGroupActivities = (groupId: string) => {
             ...data.stakeIncreasedEvents.map(asStakeChangedActivity),
             ...data.openingFilledEvents.map(asOpeningFilledActivity),
             ...data.workerExitedEvents.map(asWorkerExitedActivity),
+            ...data.statusTextChangedEvents.map(asStatusTextChangedEventActivities).flat(),
           ].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
         : [],
     [data, loading]

--- a/packages/ui/src/working-groups/hooks/useGroupActivities.ts
+++ b/packages/ui/src/working-groups/hooks/useGroupActivities.ts
@@ -7,6 +7,7 @@ import {
   asBudgetSpendingActivity,
   asOpeningFilledActivity,
   asStakeChangedActivity,
+  asWorkerExitedActivity,
 } from '@/working-groups/types/WorkingGroupActivity'
 
 export const useGroupActivities = (groupId: string) => {
@@ -21,6 +22,7 @@ export const useGroupActivities = (groupId: string) => {
             ...data.stakeDecreasedEvents.map(asStakeChangedActivity),
             ...data.stakeIncreasedEvents.map(asStakeChangedActivity),
             ...data.openingFilledEvents.map(asOpeningFilledActivity),
+            ...data.workerExitedEvents.map(asWorkerExitedActivity),
           ].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
         : [],
     [data, loading]

--- a/packages/ui/src/working-groups/queries/__generated__/workingGroups.generated.tsx
+++ b/packages/ui/src/working-groups/queries/__generated__/workingGroups.generated.tsx
@@ -439,6 +439,17 @@ export type WorkerExitedEventFieldsFragment = {
   worker: { __typename: 'Worker'; membership: { __typename: 'Membership'; id: string; handle: string } }
 }
 
+export type StatusTextChangedEventFieldsFragment = {
+  __typename: 'StatusTextChangedEvent'
+  id: string
+  createdAt: any
+  workinggroupmetadatasetInEvent?: Types.Maybe<Array<{ __typename: 'WorkingGroupMetadata'; id: string }>>
+  upcomingworkinggroupopeningcreatedInEvent?: Types.Maybe<
+    Array<{ __typename: 'UpcomingWorkingGroupOpening'; id: string }>
+  >
+  group: { __typename: 'WorkingGroup'; name: string }
+}
+
 export type GetMemberRoleEventsQueryVariables = Types.Exact<{
   worker_in?: Types.Maybe<Array<Types.Scalars['ID']> | Types.Scalars['ID']>
   application_in?: Types.Maybe<Array<Types.Scalars['ID']> | Types.Scalars['ID']>
@@ -474,6 +485,7 @@ export type GetGroupEventsQuery = {
   stakeIncreasedEvents: Array<{ __typename: 'StakeIncreasedEvent' } & StakeIncreasedEventFieldsFragment>
   openingFilledEvents: Array<{ __typename: 'OpeningFilledEvent' } & OpeningFilledEventFieldsFragment>
   workerExitedEvents: Array<{ __typename: 'WorkerExitedEvent' } & WorkerExitedEventFieldsFragment>
+  statusTextChangedEvents: Array<{ __typename: 'StatusTextChangedEvent' } & StatusTextChangedEventFieldsFragment>
 }
 
 export type GetWorkerIdsQueryVariables = Types.Exact<{
@@ -809,6 +821,21 @@ export const WorkerExitedEventFieldsFragmentDoc = gql`
         id
         handle
       }
+    }
+  }
+`
+export const StatusTextChangedEventFieldsFragmentDoc = gql`
+  fragment StatusTextChangedEventFields on StatusTextChangedEvent {
+    id
+    createdAt
+    workinggroupmetadatasetInEvent {
+      id
+    }
+    upcomingworkinggroupopeningcreatedInEvent {
+      id
+    }
+    group {
+      name
     }
   }
 `
@@ -1855,6 +1882,9 @@ export const GetGroupEventsDocument = gql`
     workerExitedEvents(where: { group: { id_eq: $group_eq } }) {
       ...WorkerExitedEventFields
     }
+    statusTextChangedEvents(where: { group: { id_eq: $group_eq } }) {
+      ...StatusTextChangedEventFields
+    }
   }
   ${AppliedOnOpeningEventFieldsFragmentDoc}
   ${ApplicationWithdrawnEventFieldsFragmentDoc}
@@ -1863,6 +1893,7 @@ export const GetGroupEventsDocument = gql`
   ${StakeIncreasedEventFieldsFragmentDoc}
   ${OpeningFilledEventFieldsFragmentDoc}
   ${WorkerExitedEventFieldsFragmentDoc}
+  ${StatusTextChangedEventFieldsFragmentDoc}
 `
 
 /**

--- a/packages/ui/src/working-groups/queries/__generated__/workingGroups.generated.tsx
+++ b/packages/ui/src/working-groups/queries/__generated__/workingGroups.generated.tsx
@@ -423,6 +423,22 @@ export type OpeningFilledEventFieldsFragment = {
   workersHired: Array<{ __typename: 'Worker'; membership: { __typename: 'Membership'; id: string; handle: string } }>
 }
 
+export type WorkerStartedLeavingEventFieldsFragment = {
+  __typename: 'WorkerStartedLeavingEvent'
+  id: string
+  createdAt: any
+  group: { __typename: 'WorkingGroup'; name: string }
+  worker: { __typename: 'Worker'; membership: { __typename: 'Membership'; id: string; handle: string } }
+}
+
+export type WorkerExitedEventFieldsFragment = {
+  __typename: 'WorkerExitedEvent'
+  id: string
+  createdAt: any
+  group: { __typename: 'WorkingGroup'; name: string }
+  worker: { __typename: 'Worker'; membership: { __typename: 'Membership'; id: string; handle: string } }
+}
+
 export type GetMemberRoleEventsQueryVariables = Types.Exact<{
   worker_in?: Types.Maybe<Array<Types.Scalars['ID']> | Types.Scalars['ID']>
   application_in?: Types.Maybe<Array<Types.Scalars['ID']> | Types.Scalars['ID']>
@@ -437,6 +453,10 @@ export type GetMemberRoleEventsQuery = {
   stakeDecreasedEvents: Array<{ __typename: 'StakeDecreasedEvent' } & StakeDecreasedEventFieldsFragment>
   stakeIncreasedEvents: Array<{ __typename: 'StakeIncreasedEvent' } & StakeIncreasedEventFieldsFragment>
   stakeSlashedEvents: Array<{ __typename: 'StakeSlashedEvent' } & StakeSlashedEventFieldsFragment>
+  workerStartedLeavingEvents: Array<
+    { __typename: 'WorkerStartedLeavingEvent' } & WorkerStartedLeavingEventFieldsFragment
+  >
+  workerExitedEvents: Array<{ __typename: 'WorkerExitedEvent' } & WorkerExitedEventFieldsFragment>
 }
 
 export type GetGroupEventsQueryVariables = Types.Exact<{
@@ -453,6 +473,7 @@ export type GetGroupEventsQuery = {
   stakeDecreasedEvents: Array<{ __typename: 'StakeDecreasedEvent' } & StakeDecreasedEventFieldsFragment>
   stakeIncreasedEvents: Array<{ __typename: 'StakeIncreasedEvent' } & StakeIncreasedEventFieldsFragment>
   openingFilledEvents: Array<{ __typename: 'OpeningFilledEvent' } & OpeningFilledEventFieldsFragment>
+  workerExitedEvents: Array<{ __typename: 'WorkerExitedEvent' } & WorkerExitedEventFieldsFragment>
 }
 
 export type GetWorkerIdsQueryVariables = Types.Exact<{
@@ -754,6 +775,36 @@ export const OpeningFilledEventFieldsFragmentDoc = gql`
       name
     }
     workersHired {
+      membership {
+        id
+        handle
+      }
+    }
+  }
+`
+export const WorkerStartedLeavingEventFieldsFragmentDoc = gql`
+  fragment WorkerStartedLeavingEventFields on WorkerStartedLeavingEvent {
+    id
+    createdAt
+    group {
+      name
+    }
+    worker {
+      membership {
+        id
+        handle
+      }
+    }
+  }
+`
+export const WorkerExitedEventFieldsFragmentDoc = gql`
+  fragment WorkerExitedEventFields on WorkerExitedEvent {
+    id
+    createdAt
+    group {
+      name
+    }
+    worker {
       membership {
         id
         handle
@@ -1724,12 +1775,20 @@ export const GetMemberRoleEventsDocument = gql`
     stakeSlashedEvents(where: { worker_in: $worker_in }) {
       ...StakeSlashedEventFields
     }
+    workerStartedLeavingEvents(where: { worker_in: $worker_in }) {
+      ...WorkerStartedLeavingEventFields
+    }
+    workerExitedEvents(where: { worker_in: $worker_in }) {
+      ...WorkerExitedEventFields
+    }
   }
   ${AppliedOnOpeningEventFieldsFragmentDoc}
   ${ApplicationWithdrawnEventFieldsFragmentDoc}
   ${StakeDecreasedEventFieldsFragmentDoc}
   ${StakeIncreasedEventFieldsFragmentDoc}
   ${StakeSlashedEventFieldsFragmentDoc}
+  ${WorkerStartedLeavingEventFieldsFragmentDoc}
+  ${WorkerExitedEventFieldsFragmentDoc}
 `
 
 /**
@@ -1793,6 +1852,9 @@ export const GetGroupEventsDocument = gql`
     openingFilledEvents(where: { group: { id_eq: $group_eq } }) {
       ...OpeningFilledEventFields
     }
+    workerExitedEvents(where: { group: { id_eq: $group_eq } }) {
+      ...WorkerExitedEventFields
+    }
   }
   ${AppliedOnOpeningEventFieldsFragmentDoc}
   ${ApplicationWithdrawnEventFieldsFragmentDoc}
@@ -1800,6 +1862,7 @@ export const GetGroupEventsDocument = gql`
   ${StakeDecreasedEventFieldsFragmentDoc}
   ${StakeIncreasedEventFieldsFragmentDoc}
   ${OpeningFilledEventFieldsFragmentDoc}
+  ${WorkerExitedEventFieldsFragmentDoc}
 `
 
 /**

--- a/packages/ui/src/working-groups/queries/workingGroups.graphql
+++ b/packages/ui/src/working-groups/queries/workingGroups.graphql
@@ -405,6 +405,34 @@ fragment OpeningFilledEventFields on OpeningFilledEvent {
   }
 }
 
+fragment WorkerStartedLeavingEventFields on WorkerStartedLeavingEvent {
+  id
+  createdAt
+  group {
+    name
+  }
+  worker {
+    membership {
+      id
+      handle
+    }
+  }
+}
+
+fragment WorkerExitedEventFields on WorkerExitedEvent {
+  id
+  createdAt
+  group {
+    name
+  }
+  worker {
+    membership {
+      id
+      handle
+    }
+  }
+}
+
 query GetMemberRoleEvents($worker_in: [ID!], $application_in: [ID!]) {
   appliedOnOpeningEvents(where: { application_in: $application_in }) {
     ...AppliedOnOpeningEventFields
@@ -420,6 +448,12 @@ query GetMemberRoleEvents($worker_in: [ID!], $application_in: [ID!]) {
   }
   stakeSlashedEvents(where: { worker_in: $worker_in }) {
     ...StakeSlashedEventFields
+  }
+  workerStartedLeavingEvents(where: { worker_in: $worker_in }) {
+    ...WorkerStartedLeavingEventFields
+  }
+  workerExitedEvents(where: { worker_in: $worker_in }) {
+    ...WorkerExitedEventFields
   }
 }
 
@@ -441,6 +475,9 @@ query GetGroupEvents($group_eq: ID!) {
   }
   openingFilledEvents(where: { group: { id_eq: $group_eq } }) {
     ...OpeningFilledEventFields
+  }
+  workerExitedEvents(where: { group: { id_eq: $group_eq } }) {
+    ...WorkerExitedEventFields
   }
 }
 

--- a/packages/ui/src/working-groups/queries/workingGroups.graphql
+++ b/packages/ui/src/working-groups/queries/workingGroups.graphql
@@ -433,6 +433,20 @@ fragment WorkerExitedEventFields on WorkerExitedEvent {
   }
 }
 
+fragment StatusTextChangedEventFields on StatusTextChangedEvent {
+  id
+  createdAt
+  workinggroupmetadatasetInEvent {
+    id
+  }
+  upcomingworkinggroupopeningcreatedInEvent {
+    id
+  }
+  group {
+    name
+  }
+}
+
 query GetMemberRoleEvents($worker_in: [ID!], $application_in: [ID!]) {
   appliedOnOpeningEvents(where: { application_in: $application_in }) {
     ...AppliedOnOpeningEventFields
@@ -478,6 +492,9 @@ query GetGroupEvents($group_eq: ID!) {
   }
   workerExitedEvents(where: { group: { id_eq: $group_eq } }) {
     ...WorkerExitedEventFields
+  }
+  statusTextChangedEvents(where: { group: { id_eq: $group_eq } }) {
+    ...StatusTextChangedEventFields
   }
 }
 

--- a/packages/ui/src/working-groups/types/WorkingGroupActivity/casts.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroupActivity/casts.ts
@@ -155,12 +155,14 @@ export function asStatusTextChangedEventActivities(
   fragment: StatusTextChangedEventFieldsFragment
 ): Array<StatusTextChangedActivity | OpeningAnnouncedActivity> {
   const result: Array<StatusTextChangedActivity | OpeningAnnouncedActivity> = []
-  result.push({
-    id: fragment.id,
-    eventType: 'StatusTextChanged',
-    createdAt: fragment.createdAt,
-    groupName: asWorkingGroupName(fragment.group.name),
-  })
+  if (fragment.workinggroupmetadatasetInEvent?.length) {
+    result.push({
+      id: fragment.id,
+      eventType: 'StatusTextChanged',
+      createdAt: fragment.createdAt,
+      groupName: asWorkingGroupName(fragment.group.name),
+    })
+  }
   fragment.upcomingworkinggroupopeningcreatedInEvent?.forEach((opening) => {
     result.push({
       id: opening.id,

--- a/packages/ui/src/working-groups/types/WorkingGroupActivity/casts.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroupActivity/casts.ts
@@ -9,6 +9,8 @@ import {
   StakeDecreasedEventFieldsFragment,
   StakeIncreasedEventFieldsFragment,
   StakeSlashedEventFieldsFragment,
+  WorkerExitedEventFieldsFragment,
+  WorkerStartedLeavingEventFieldsFragment,
 } from '@/working-groups/queries/__generated__/workingGroups.generated'
 import {
   ApplicationWithdrawnActivity,
@@ -18,6 +20,8 @@ import {
   OpeningFilledActivity,
   StakeChangedActivity,
   StakeSlashedActivity,
+  WorkerExitedActivity,
+  WorkerStartedLeavingActivity,
 } from '@/working-groups/types'
 
 function asPositionTitle(groupName: string, type: 'LEADER' | 'REGULAR') {
@@ -115,5 +119,31 @@ export function asOpeningFilledActivity(fragment: OpeningFilledEventFieldsFragme
       id: membership.id,
       handle: membership.handle,
     })),
+  }
+}
+
+export function asWorkerExitedActivity(fragment: WorkerExitedEventFieldsFragment): WorkerExitedActivity {
+  return {
+    eventType: 'WorkerExited',
+    createdAt: fragment.createdAt,
+    id: fragment.id,
+    member: {
+      id: fragment.worker.membership.id,
+      handle: fragment.worker.membership.handle,
+    },
+  }
+}
+
+export function asWorkerStartedLeavingActivity(
+  fragment: WorkerStartedLeavingEventFieldsFragment
+): WorkerStartedLeavingActivity {
+  return {
+    eventType: 'WorkerStartedLeaving',
+    createdAt: fragment.createdAt,
+    id: fragment.id,
+    member: {
+      id: fragment.worker.membership.id,
+      handle: fragment.worker.membership.handle,
+    },
   }
 }

--- a/packages/ui/src/working-groups/types/WorkingGroupActivity/casts.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroupActivity/casts.ts
@@ -9,6 +9,7 @@ import {
   StakeDecreasedEventFieldsFragment,
   StakeIncreasedEventFieldsFragment,
   StakeSlashedEventFieldsFragment,
+  StatusTextChangedEventFieldsFragment,
   WorkerExitedEventFieldsFragment,
   WorkerStartedLeavingEventFieldsFragment,
 } from '@/working-groups/queries/__generated__/workingGroups.generated'
@@ -17,9 +18,11 @@ import {
   AppliedOnOpeningActivity,
   asWorkingGroupName,
   BudgetSpendingActivity,
+  OpeningAnnouncedActivity,
   OpeningFilledActivity,
   StakeChangedActivity,
   StakeSlashedActivity,
+  StatusTextChangedActivity,
   WorkerExitedActivity,
   WorkerStartedLeavingActivity,
 } from '@/working-groups/types'
@@ -146,4 +149,26 @@ export function asWorkerStartedLeavingActivity(
       handle: fragment.worker.membership.handle,
     },
   }
+}
+
+export function asStatusTextChangedEventActivities(
+  fragment: StatusTextChangedEventFieldsFragment
+): Array<StatusTextChangedActivity | OpeningAnnouncedActivity> {
+  const result: Array<StatusTextChangedActivity | OpeningAnnouncedActivity> = []
+  result.push({
+    id: fragment.id,
+    eventType: 'StatusTextChanged',
+    createdAt: fragment.createdAt,
+    groupName: asWorkingGroupName(fragment.group.name),
+  })
+  fragment.upcomingworkinggroupopeningcreatedInEvent?.forEach((opening) => {
+    result.push({
+      id: opening.id,
+      eventType: 'OpeningAnnounced',
+      createdAt: fragment.createdAt,
+      groupName: asWorkingGroupName(fragment.group.name),
+      openingId: opening.id,
+    })
+  })
+  return result
 }

--- a/packages/ui/src/working-groups/types/WorkingGroupActivity/types.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroupActivity/types.ts
@@ -19,6 +19,7 @@ export type WorkingGroupActivity =
   | WorkerExitedActivity
   | WorkerStartedLeavingActivity
   | OpeningFilledActivity
+  | OpeningAnnouncedActivity
 
 type ShortMember = Pick<Member, 'id' | 'handle'>
 
@@ -61,6 +62,12 @@ export interface LeaderSetActivity extends BaseActivity {
 export interface StatusTextChangedActivity extends BaseActivity {
   eventType: 'StatusTextChanged'
   groupName: string
+}
+
+export interface OpeningAnnouncedActivity extends BaseActivity {
+  eventType: 'OpeningAnnounced'
+  groupName: string
+  openingId: string
 }
 
 export interface OpeningAddedActivity extends OpeningActivity {


### PR DESCRIPTION
* Added worker exited + started leaving activities. Might want to add a more descriptive text for the worker exited activity, to at least hint at what they were doing and in which group
* Added activities for `StatusTextChangedEvent`. There might be more activities tied to it that haven't been designed yet, e.g. cancelled upcoming openings. The event itself is quite confusing overall, it has fields for changed metadata and added openings but then it also has a "result" type field which potentially doubles both above mentioned fields and at the same time seems to hint at them being mutually exclusive... I think it could use a redesign.
