### PR TITLE
⏲ Set CI job timeout to 30 minutes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   test:
+    timeout-minutes: 30
     strategy:
       matrix:
         node: ['14.x']


### PR DESCRIPTION
One job ran for 144 min ... and I had to cancel it