### PR TITLE
🚀 Improve tests performance

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,4 +19,4 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn build
-      - run: yarn test --runInBand --silent
+      - run: yarn test --silent

--- a/packages/ui/src/mocks/data/seedMembers.ts
+++ b/packages/ui/src/mocks/data/seedMembers.ts
@@ -25,6 +25,6 @@ export const seedMember = (member: MockMember, server: any) => {
   })
 }
 
-export const seedMembers = (server: any) => {
-  mockMembers.map((member) => seedMember(member, server))
+export const seedMembers = (server: any, howMany?: number) => {
+  mockMembers.slice(0, howMany).map((member) => seedMember(member, server))
 }

--- a/packages/ui/test/_helpers/getButton.ts
+++ b/packages/ui/test/_helpers/getButton.ts
@@ -1,0 +1,5 @@
+import { screen } from '@testing-library/react'
+
+export async function getButton(text: string | RegExp) {
+  return (await screen.findByText(text, { selector: 'span' })).parentElement!
+}

--- a/packages/ui/test/_mocks/server/index.ts
+++ b/packages/ui/test/_mocks/server/index.ts
@@ -6,15 +6,25 @@ interface MockServer {
   server?: Server
 }
 
-export function setupMockServer(): MockServer {
+interface Props {
+  noCleanupAfterEach: boolean
+}
+
+export function setupMockServer(props?: Props): MockServer {
   const mock: MockServer = {}
 
-  beforeEach(() => {
+  beforeAll(() => {
     mock.server = makeServer('test')
     fixAssociations((mock.server as unknown) as any)
   })
 
-  afterEach(() => {
+  if (!props?.noCleanupAfterEach) {
+    afterEach(() => {
+      mock?.server?.db.emptyData()
+    })
+  }
+
+  afterAll(() => {
     mock?.server?.shutdown()
   })
 

--- a/packages/ui/test/accounts/components/MyAccounts.test.tsx
+++ b/packages/ui/test/accounts/components/MyAccounts.test.tsx
@@ -5,14 +5,15 @@ import BN from 'bn.js'
 import React from 'react'
 import { HashRouter } from 'react-router-dom'
 
-import { Account, Balances } from '../../../src/accounts/types'
-import { Accounts } from '../../../src/app/pages/Profile/components/Accounts'
-import { shortenAddress } from '../../../src/common/model/formatters'
-import { KeyringContext } from '../../../src/common/providers/keyring/context'
-import { MembershipContext } from '../../../src/memberships/providers/membership/context'
-import { MyMemberships } from '../../../src/memberships/providers/membership/provider'
-import { Member } from '../../../src/memberships/types'
-import { seedMembers } from '../../../src/mocks/data'
+import { Account, Balances } from '@/accounts/types'
+import { Accounts } from '@/app/pages/Profile/components/Accounts'
+import { shortenAddress } from '@/common/model/formatters'
+import { KeyringContext } from '@/common/providers/keyring/context'
+import { MembershipContext } from '@/memberships/providers/membership/context'
+import { MyMemberships } from '@/memberships/providers/membership/provider'
+import { Member } from '@/memberships/types'
+import { seedMembers } from '@/mocks/data'
+
 import { alice, aliceStash, bob, bobStash } from '../../_mocks/keyring'
 import { getMember } from '../../_mocks/members'
 import { MockApolloProvider } from '../../_mocks/providers'
@@ -23,7 +24,7 @@ const useMyAccounts: { hasAccounts: boolean; allAccounts: Account[] } = {
   allAccounts: [],
 }
 
-jest.mock('../../../src/accounts/hooks/useMyAccounts', () => {
+jest.mock('@/accounts/hooks/useMyAccounts', () => {
   return {
     useMyAccounts: () => useMyAccounts,
   }
@@ -35,10 +36,10 @@ const useBalance = {
   useBalance: () => balances,
 }
 
-jest.mock('../../../src/accounts/hooks/useBalance', () => useBalance)
+jest.mock('@/accounts/hooks/useBalance', () => useBalance)
 
 describe('UI: Accounts list', () => {
-  const mockServer = setupMockServer()
+  const mockServer = setupMockServer({ noCleanupAfterEach: true })
 
   beforeAll(cryptoWaitReady)
 
@@ -107,7 +108,7 @@ describe('UI: Accounts list', () => {
         locks: [],
       }
       const aliceMember = getMember('alice')
-      seedMembers(mockServer.server)
+      seedMembers(mockServer.server, 2)
       const { findByText } = renderAccounts(aliceMember)
 
       const aliceBox = (await findByText(shortenAddress(alice.address)))!.parentElement!.parentElement!

--- a/packages/ui/test/accounts/modal/RecoverBalanceModal.test.tsx
+++ b/packages/ui/test/accounts/modal/RecoverBalanceModal.test.tsx
@@ -35,19 +35,20 @@ jest.mock('@/accounts/hooks/useMyAccounts', () => {
 })
 
 describe('UI: RecoverBalanceModal', () => {
+  const api = stubApi()
+  const server = setupMockServer({ noCleanupAfterEach: true })
+  let tx: any
+
   beforeAll(async () => {
     await cryptoWaitReady()
     jest.spyOn(console, 'log').mockImplementation()
     useMyAccounts.allAccounts.push(alice, bob)
+    seedMembers(server.server, 2)
   })
 
   afterAll(() => {
     jest.restoreAllMocks()
   })
-
-  const api = stubApi()
-  const server = setupMockServer()
-  let tx: any
 
   const useModal: UseModal<any> = {
     hideModal: jest.fn(),
@@ -65,7 +66,6 @@ describe('UI: RecoverBalanceModal', () => {
   }
 
   beforeEach(async () => {
-    seedMembers(server.server)
     stubDefaultBalances(api)
     useMyMemberships.setActive(getMember('alice'))
     tx = stubTransaction(api, 'api.tx.council.releaseCandidacyStake')

--- a/packages/ui/test/accounts/modal/TransferModal.test.tsx
+++ b/packages/ui/test/accounts/modal/TransferModal.test.tsx
@@ -4,10 +4,12 @@ import { set } from 'lodash'
 import React from 'react'
 import { of } from 'rxjs'
 
-import { TransferModal } from '../../../src/accounts/modals/TransferModal'
-import { Account } from '../../../src/accounts/types'
-import { ApiContext } from '../../../src/common/providers/api/context'
-import { ModalContext } from '../../../src/common/providers/modal/context'
+import { TransferModal } from '@/accounts/modals/TransferModal'
+import { Account } from '@/accounts/types'
+import { ApiContext } from '@/common/providers/api/context'
+import { ModalContext } from '@/common/providers/modal/context'
+
+import { getButton } from '../../_helpers/getButton'
 import { selectAccount } from '../../_helpers/selectAccount'
 import { alice, bob } from '../../_mocks/keyring'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
@@ -25,7 +27,7 @@ const useMyAccounts: { hasAccounts: boolean; allAccounts: Account[] } = {
   allAccounts: [],
 }
 
-jest.mock('../../../src/accounts/hooks/useMyAccounts', () => {
+jest.mock('@/accounts/hooks/useMyAccounts', () => {
   return {
     useMyAccounts: () => useMyAccounts,
   }
@@ -66,11 +68,11 @@ describe('UI: TransferModal', () => {
   })
 
   it('Enables value input', async () => {
-    const { findByLabelText, findByRole } = renderModal({})
+    const { findByLabelText } = renderModal({})
 
     const input = await findByLabelText(/number of tokens/i)
-    const useHalfButton = await findByRole('button', { name: /use half/i })
-    const useMaxButton = await findByRole('button', { name: /use max/i })
+    const useHalfButton = await getButton(/use half/i)
+    const useMaxButton = await getButton(/use max/i)
 
     expect(input).toBeDisabled()
     expect(useHalfButton).toBeDisabled()
@@ -84,14 +86,14 @@ describe('UI: TransferModal', () => {
   })
 
   it('Renders an Authorize transaction step', async () => {
-    const { findByLabelText, findByText, findByRole } = renderModal({ from: alice, to: bob })
+    const { findByLabelText, findByText } = renderModal({ from: alice, to: bob })
 
     const input = await findByLabelText('Number of tokens')
-    expect(await findByRole('button', { name: 'Transfer tokens' })).toBeDisabled()
+    expect(await getButton('Transfer tokens')).toBeDisabled()
 
     await fireEvent.change(input, { target: { value: '50' } })
 
-    const button = await findByRole('button', { name: /transfer tokens/i })
+    const button = await getButton(/transfer tokens/i)
     expect(button).not.toBeDisabled()
 
     fireEvent.click(button)

--- a/packages/ui/test/app/pages/Members.test.tsx
+++ b/packages/ui/test/app/pages/Members.test.tsx
@@ -8,19 +8,20 @@ import { GlobalModals } from '@/app/GlobalModals'
 import { Members } from '@/app/pages/Members/Members'
 import { ModalContextProvider } from '@/common/providers/modal/provider'
 import { seedMembers } from '@/mocks/data'
+import { seedApplications } from '@/mocks/data/seedApplications'
+import { seedOpenings } from '@/mocks/data/seedOpenings'
 import { seedWorkers } from '@/mocks/data/seedWorkers'
 import { seedWorkingGroups } from '@/mocks/data/seedWorkingGroups'
 
-import { seedApplications } from '../../../src/mocks/data/seedApplications'
-import { seedOpenings } from '../../../src/mocks/data/seedOpenings'
 import { MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 
 describe('Members', () => {
-  const server = setupMockServer()
+  const server = setupMockServer({ noCleanupAfterEach: true })
+
   beforeAll(cryptoWaitReady)
 
-  beforeEach(() => {
+  beforeAll(() => {
     seedMembers(server.server)
     seedWorkingGroups(server.server)
     seedOpenings(server.server)

--- a/packages/ui/test/membership/components/CurrentMember.test.tsx
+++ b/packages/ui/test/membership/components/CurrentMember.test.tsx
@@ -29,7 +29,7 @@ describe('UI: CurrentMember component', () => {
 
   describe('with multiple memberships', () => {
     beforeEach(() => {
-      seedMembers(mockServer.server)
+      seedMembers(mockServer.server, 2)
     })
 
     it('Displays memberships count', async () => {

--- a/packages/ui/test/membership/components/MyMemberships.test.tsx
+++ b/packages/ui/test/membership/components/MyMemberships.test.tsx
@@ -37,7 +37,7 @@ describe('UI: Memberships list', () => {
   })
 
   it('With memberships', async () => {
-    seedMembers(mockServer.server)
+    seedMembers(mockServer.server, 2)
     const { getByText } = renderMemberships()
 
     await waitForElementToBeRemoved(() => getByText('Loading...'))

--- a/packages/ui/test/membership/hooks/useMyMemberships.test.tsx
+++ b/packages/ui/test/membership/hooks/useMyMemberships.test.tsx
@@ -60,7 +60,7 @@ describe('useMyMemberships', () => {
   })
 
   it('Matched rootAccount', async () => {
-    seedMembers(mockServer.server)
+    seedMembers(mockServer.server, 2)
     const aliceMember = getMember('alice')
     useMyAccounts.hasAccounts = true
     useMyAccounts.allAccounts.push(alice)
@@ -78,7 +78,7 @@ describe('useMyMemberships', () => {
   })
 
   it('Matched controllerAccount', async () => {
-    seedMembers(mockServer.server)
+    seedMembers(mockServer.server, 2)
     const bobMember = getMember('bob')
     useMyAccounts.hasAccounts = true
     useMyAccounts.allAccounts.push(bob)
@@ -96,7 +96,7 @@ describe('useMyMemberships', () => {
   })
 
   it('Allows to set active member', async () => {
-    seedMembers(mockServer.server)
+    seedMembers(mockServer.server, 2)
     const aliceMember = getMember('alice')
     useMyAccounts.hasAccounts = true
     useMyAccounts.allAccounts.push(alice)

--- a/packages/ui/test/membership/modals/BuyMembershipModal.test.tsx
+++ b/packages/ui/test/membership/modals/BuyMembershipModal.test.tsx
@@ -10,6 +10,7 @@ import { Account } from '@/accounts/types'
 import { ApiContext } from '@/common/providers/api/context'
 import { BuyMembershipModal } from '@/memberships/modals/BuyMembershipModal'
 
+import { getButton } from '../../_helpers/getButton'
 import { selectAccount } from '../../_helpers/selectAccount'
 import { toBalanceOf } from '../../_mocks/chainTypes'
 import { alice, bob } from '../../_mocks/keyring'
@@ -172,10 +173,6 @@ describe('UI: BuyMembershipModal', () => {
       })
     })
   })
-
-  async function getButton(text: string | RegExp) {
-    return (await screen.findByText(text, { selector: 'span' })).parentElement!
-  }
 
   async function findSubmitButton() {
     return await getButton(/^Create a membership$/i)

--- a/packages/ui/test/membership/modals/BuyMembershipModal.test.tsx
+++ b/packages/ui/test/membership/modals/BuyMembershipModal.test.tsx
@@ -66,98 +66,95 @@ describe('UI: BuyMembershipModal', () => {
   })
 
   it('Renders a modal', async () => {
-    const { findByText } = renderModal()
+    renderModal()
 
-    expect(await findByText('Add membership')).toBeDefined()
-    expect((await findByText('Creation fee:'))?.parentNode?.textContent).toMatch(/^Creation fee:100/i)
+    expect(await screen.findByText('Add membership')).toBeDefined()
+    expect((await screen.findByText('Creation fee:'))?.parentNode?.textContent).toMatch(/^Creation fee:100/i)
   })
 
   it('Enables button when valid form', async () => {
-    const { getByLabelText } = renderModal()
+    renderModal()
 
     expect(await findSubmitButton()).toBeDisabled()
 
     await selectAccount('Root account', 'bob')
     await selectAccount('Controller account', 'alice')
-    fireEvent.change(getByLabelText(/member name/i), { target: { value: 'Bobby Bob' } })
-    fireEvent.change(getByLabelText(/membership handle/i), { target: { value: 'realbobbybob' } })
-    fireEvent.click(getByLabelText(/I agree to the terms/i))
+    fireEvent.change(screen.getByLabelText(/member name/i), { target: { value: 'Bobby Bob' } })
+    fireEvent.change(screen.getByLabelText(/membership handle/i), { target: { value: 'realbobbybob' } })
+    fireEvent.click(screen.getByLabelText(/I agree to the terms/i))
 
     expect(await findSubmitButton()).not.toBeDisabled()
   })
 
   it('Disables button when invalid avatar URL', async () => {
-    const { getByLabelText } = renderModal()
+    renderModal()
 
     expect(await findSubmitButton()).toBeDisabled()
 
     await selectAccount('Root account', 'bob')
     await selectAccount('Controller account', 'alice')
-    fireEvent.change(getByLabelText(/member name/i), { target: { value: 'Bobby Bob' } })
-    fireEvent.change(getByLabelText(/membership handle/i), { target: { value: 'realbobbybob' } })
-    fireEvent.click(getByLabelText(/I agree to the terms/i))
+    fireEvent.change(screen.getByLabelText(/member name/i), { target: { value: 'Bobby Bob' } })
+    fireEvent.change(screen.getByLabelText(/membership handle/i), { target: { value: 'realbobbybob' } })
+    fireEvent.click(screen.getByLabelText(/I agree to the terms/i))
 
-    fireEvent.change(getByLabelText(/member avatar/i), { target: { value: 'avatar' } })
+    fireEvent.change(screen.getByLabelText(/member avatar/i), { target: { value: 'avatar' } })
     expect(await findSubmitButton()).toBeDisabled()
 
-    fireEvent.change(getByLabelText(/member avatar/i), { target: { value: 'http://example.com/example.jpg' } })
+    fireEvent.change(screen.getByLabelText(/member avatar/i), { target: { value: 'http://example.com/example.jpg' } })
     expect(await findSubmitButton()).not.toBeDisabled()
   })
 
   describe('Authorize step', () => {
     const renderAuthorizeStep = async () => {
-      const rendered = renderModal()
-      const { getByLabelText } = rendered
+      renderModal()
 
       await selectAccount('Root account', 'bob')
       await selectAccount('Controller account', 'alice')
-      fireEvent.change(getByLabelText(/member name/i), { target: { value: 'Bobby Bob' } })
-      fireEvent.change(getByLabelText(/membership handle/i), { target: { value: 'realbobbybob' } })
-      fireEvent.change(getByLabelText(/about member/i), { target: { value: "I'm Bob" } })
-      fireEvent.change(getByLabelText(/member avatar/i), { target: { value: 'http://example.com/example.jpg' } })
-      fireEvent.click(getByLabelText(/I agree to the terms/i))
+      fireEvent.change(screen.getByLabelText(/member name/i), { target: { value: 'Bobby Bob' } })
+      fireEvent.change(screen.getByLabelText(/membership handle/i), { target: { value: 'realbobbybob' } })
+      fireEvent.change(screen.getByLabelText(/about member/i), { target: { value: "I'm Bob" } })
+      fireEvent.change(screen.getByLabelText(/member avatar/i), { target: { value: 'http://example.com/example.jpg' } })
+      fireEvent.click(screen.getByLabelText(/I agree to the terms/i))
 
       fireEvent.click(await findSubmitButton())
-
-      return rendered
     }
 
     it('Renders authorize transaction', async () => {
-      const { getByText, getByRole } = await renderAuthorizeStep()
+      await renderAuthorizeStep()
 
-      expect(getByText('Authorize transaction')).toBeDefined()
-      expect(getByText(/^Creation fee:/i)?.nextSibling?.textContent).toBe('100')
-      expect(getByText(/^Transaction fee:/i)?.nextSibling?.textContent).toBe('25')
-      expect(getByRole('heading', { name: /alice/i })).toBeDefined()
+      expect(screen.getByText('Authorize transaction')).toBeDefined()
+      expect(screen.getByText(/^Creation fee:/i)?.nextSibling?.textContent).toBe('100')
+      expect(screen.getByText(/^Transaction fee:/i)?.nextSibling?.textContent).toBe('25')
+      expect(screen.getByRole('heading', { name: /alice/i })).toBeDefined()
     })
 
     it('Without required balance', async () => {
       stubBalances(api, { available: 0, locked: 0 })
 
-      const { findByRole } = await renderAuthorizeStep()
+      await renderAuthorizeStep()
 
-      expect(await findByRole('button', { name: /^sign and/i })).toBeDisabled()
+      expect(await getButton(/^sign and/i)).toBeDisabled()
     })
 
     describe('Success', () => {
       it('Renders transaction success', async () => {
         stubTransactionSuccess(transaction, [1], 'members', 'MemberRegistered')
-        const { getByText, findByText } = await renderAuthorizeStep()
+        await renderAuthorizeStep()
 
-        fireEvent.click(await screen.findByRole('button', { name: /^sign and create a member$/i }))
+        fireEvent.click(await getButton(/^sign and create a member$/i))
 
-        expect(await findByText('Success')).toBeDefined()
-        expect(getByText(/^realbobbybob/i)).toBeDefined()
+        expect(await screen.findByText('Success')).toBeDefined()
+        expect(screen.getByText(/^realbobbybob/i)).toBeDefined()
       })
 
       it('Enables the View My Profile button', async () => {
         stubTransactionSuccess(transaction, [registry.createType('MemberId', 12)], 'members', 'MemberRegistered')
-        const { findByText, findByRole } = await renderAuthorizeStep()
+        await renderAuthorizeStep()
 
-        fireEvent.click(await screen.findByRole('button', { name: /^sign and create a member$/i }))
+        fireEvent.click(await getButton(/^sign and create a member$/i))
 
-        expect(await findByText('Success')).toBeDefined()
-        const button = await findByRole('button', { name: 'View my profile' })
+        expect(await screen.findByText('Success')).toBeDefined()
+        const button = await getButton('View my profile')
         expect(button).toBeEnabled()
         fireEvent.click(button)
         expect(mockCallback.mock.calls[0][0]).toEqual({ modal: 'Member', data: { id: '12' } })
@@ -167,21 +164,25 @@ describe('UI: BuyMembershipModal', () => {
     describe('Failure', () => {
       it('Renders transaction failure', async () => {
         stubTransactionFailure(transaction)
-        const { findByText } = await renderAuthorizeStep()
+        await renderAuthorizeStep()
 
-        fireEvent.click(await screen.findByRole('button', { name: /^sign and create a member$/i }))
+        fireEvent.click(await getButton(/^sign and create a member$/i))
 
-        expect(await findByText('Failure')).toBeDefined()
+        expect(await screen.findByText('Failure')).toBeDefined()
       })
     })
   })
 
+  async function getButton(text: string | RegExp) {
+    return (await screen.findByText(text, { selector: 'span' })).parentElement!
+  }
+
   async function findSubmitButton() {
-    return await screen.findByRole('button', { name: /^Create a membership$/i })
+    return await getButton(/^Create a membership$/i)
   }
 
   function renderModal() {
-    return render(
+    render(
       <MockQueryNodeProviders>
         <MockKeyringProvider>
           <ApiContext.Provider value={api}>

--- a/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
+++ b/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
@@ -5,10 +5,11 @@ import { set } from 'lodash'
 import React from 'react'
 import { of } from 'rxjs'
 
-import { UseAccounts } from '../../../src/accounts/providers/accounts/provider'
-import { ApiContext } from '../../../src/common/providers/api/context'
-import { InviteMemberModal } from '../../../src/memberships/modals/InviteMemberModal'
-import { seedMembers } from '../../../src/mocks/data'
+import { UseAccounts } from '@/accounts/providers/accounts/provider'
+import { ApiContext } from '@/common/providers/api/context'
+import { InviteMemberModal } from '@/memberships/modals/InviteMemberModal'
+import { seedMembers } from '@/mocks/data'
+
 import { selectMember } from '../../_helpers/selectMember'
 import { toBalanceOf } from '../../_mocks/chainTypes'
 import { alice, aliceStash, bobStash } from '../../_mocks/keyring'
@@ -74,7 +75,7 @@ describe('UI: InviteMemberModal', () => {
   })
 
   it('Enables button', async () => {
-    seedMembers(server.server)
+    seedMembers(server.server, 2)
 
     renderModal()
 
@@ -94,7 +95,7 @@ describe('UI: InviteMemberModal', () => {
   })
 
   it('Disables button when one of addresses is invalid', async () => {
-    seedMembers(server.server)
+    seedMembers(server.server, 2)
 
     renderModal()
 
@@ -115,7 +116,7 @@ describe('UI: InviteMemberModal', () => {
 
   describe('Authorize', () => {
     async function fillFormAndProceed(invitor = 'alice') {
-      seedMembers(server.server)
+      seedMembers(server.server, 2)
       renderModal()
       await screen.findAllByRole('button')
       await selectMember('Inviting member', invitor)

--- a/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
+++ b/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
@@ -10,6 +10,7 @@ import { ApiContext } from '@/common/providers/api/context'
 import { InviteMemberModal } from '@/memberships/modals/InviteMemberModal'
 import { seedMembers } from '@/mocks/data'
 
+import { getButton } from '../../_helpers/getButton'
 import { selectMember } from '../../_helpers/selectMember'
 import { toBalanceOf } from '../../_mocks/chainTypes'
 import { alice, aliceStash, bobStash } from '../../_mocks/keyring'
@@ -167,10 +168,6 @@ describe('UI: InviteMemberModal', () => {
       expect(await screen.findByText('Failure')).toBeDefined()
     })
   })
-
-  async function getButton(text: string | RegExp) {
-    return (await screen.findByText(text, { selector: 'span' })).parentElement!
-  }
 
   function getInput(labelText: string | RegExp) {
     return screen.getByLabelText(labelText, { selector: 'input' })

--- a/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
+++ b/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
@@ -79,19 +79,19 @@ describe('UI: InviteMemberModal', () => {
 
     renderModal()
 
-    expect(await screen.findByRole('button', { name: /^Invite a member$/i })).toBeDisabled()
+    expect(await getButton(/^Invite a member$/i)).toBeDisabled()
 
     await selectMember('Inviting member', 'alice')
-    await fireEvent.change(screen.getByRole('textbox', { name: /Root account/i }), {
+    await fireEvent.change(getInput(/Root account/i), {
       target: { value: bobStash.address },
     })
-    await fireEvent.change(screen.getByRole('textbox', { name: /Controller account/i }), {
+    await fireEvent.change(getInput(/Controller account/i), {
       target: { value: controllerAddress },
     })
     await fireEvent.change(screen.getByLabelText(/member name/i), { target: { value: 'Bobby Bob' } })
     await fireEvent.change(screen.getByLabelText(/membership handle/i), { target: { value: 'bobby1' } })
 
-    expect(await screen.findByRole('button', { name: /^Invite a member$/i })).toBeEnabled()
+    expect(await getButton(/^Invite a member$/i)).toBeEnabled()
   })
 
   it('Disables button when one of addresses is invalid', async () => {
@@ -99,36 +99,36 @@ describe('UI: InviteMemberModal', () => {
 
     renderModal()
 
-    expect(await screen.findByRole('button', { name: /^Invite a member$/i })).toBeDisabled()
+    expect(await getButton(/^Invite a member$/i)).toBeDisabled()
 
     await selectMember('Inviting member', 'alice')
-    await fireEvent.change(screen.getByRole('textbox', { name: /Root account/i }), {
+    await fireEvent.change(getInput(/Root account/i), {
       target: { value: bobStash.address },
     })
-    await fireEvent.change(screen.getByRole('textbox', { name: /Controller account/i }), {
+    await fireEvent.change(getInput(/Controller account/i), {
       target: { value: 'AAa' },
     })
     await fireEvent.change(screen.getByLabelText(/member name/i), { target: { value: 'Bobby Bob' } })
     await fireEvent.change(screen.getByLabelText(/membership handle/i), { target: { value: 'bobby1' } })
 
-    expect(await screen.findByRole('button', { name: /^Invite a member$/i })).toBeDisabled()
+    expect(await getButton(/^Invite a member$/i)).toBeDisabled()
   })
 
   describe('Authorize', () => {
     async function fillFormAndProceed(invitor = 'alice') {
       seedMembers(server.server, 2)
       renderModal()
-      await screen.findAllByRole('button')
+      await getButton(/^Invite a member$/i)
       await selectMember('Inviting member', invitor)
-      fireEvent.change(screen.getByRole('textbox', { name: /Root account/i }), {
+      fireEvent.change(getInput(/Root account/i), {
         target: { value: bobStash.address },
       })
-      fireEvent.change(screen.getByRole('textbox', { name: /Controller account/i }), {
+      fireEvent.change(getInput(/Controller account/i), {
         target: { value: controllerAddress },
       })
       fireEvent.change(screen.getByLabelText(/member name/i), { target: { value: 'Bobby Bob' } })
       fireEvent.change(screen.getByLabelText(/membership handle/i), { target: { value: 'bobby1' } })
-      fireEvent.click(await screen.findByRole('button', { name: /^Invite a member$/i }))
+      fireEvent.click(await getButton(/^Invite a member$/i))
     }
 
     it('Authorize step', async () => {
@@ -137,14 +137,14 @@ describe('UI: InviteMemberModal', () => {
       expect(await screen.findByText('Authorize transaction')).toBeDefined()
       expect(await screen.findByText('You are inviting this member. You have 5 invites left.')).toBeDefined()
       expect((await screen.findByText(/^Transaction fee:/i))?.nextSibling?.textContent).toBe('25')
-      expect(await screen.findByRole('button', { name: /^Sign and create/i })).toBeEnabled()
+      expect(await getButton(/^Sign and create/i)).toBeEnabled()
     })
 
     it('Validate funds', async () => {
       stubBalances(api, { available: 0 })
       await fillFormAndProceed()
 
-      expect(await screen.findByRole('button', { name: /^Sign and create/i })).toBeDisabled()
+      expect(await getButton(/^Sign and create/i)).toBeDisabled()
       expect(await screen.findByText(/^Insufficient funds to cover/i)).toBeDefined()
     })
 
@@ -167,6 +167,14 @@ describe('UI: InviteMemberModal', () => {
       expect(await screen.findByText('Failure')).toBeDefined()
     })
   })
+
+  async function getButton(text: string | RegExp) {
+    return (await screen.findByText(text, { selector: 'span' })).parentElement!
+  }
+
+  function getInput(labelText: string | RegExp) {
+    return screen.getByLabelText(labelText, { selector: 'input' })
+  }
 
   function renderModal() {
     render(

--- a/packages/ui/test/membership/modals/TransferInviteModal.test.tsx
+++ b/packages/ui/test/membership/modals/TransferInviteModal.test.tsx
@@ -2,15 +2,16 @@ import { cryptoWaitReady } from '@polkadot/util-crypto'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 
-import { ApiContext } from '../../../src/common/providers/api/context'
-import { TransferInviteModal } from '../../../src/memberships/modals/TransferInviteModal'
-import { seedMembers } from '../../../src/mocks/data'
+import { ApiContext } from '@/common/providers/api/context'
+import { TransferInviteModal } from '@/memberships/modals/TransferInviteModal'
+import { seedMembers } from '@/mocks/data'
+
 import { selectMember } from '../../_helpers/selectMember'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import { stubApi, stubDefaultBalances, stubTransaction } from '../../_mocks/transactions'
 
-jest.mock('../../../src/common/hooks/useModal', () => {
+jest.mock('@/common/hooks/useModal', () => {
   return {
     useModal: () => ({
       modalData: { memberId: '0' },
@@ -19,10 +20,13 @@ jest.mock('../../../src/common/hooks/useModal', () => {
 })
 
 describe('UI: TransferInviteModal', () => {
-  beforeAll(cryptoWaitReady)
-
-  const mockServer = setupMockServer()
+  const mockServer = setupMockServer({ noCleanupAfterEach: true })
   const api = stubApi()
+
+  beforeAll(async () => {
+    await cryptoWaitReady()
+    seedMembers(mockServer.server, 2)
+  })
 
   beforeEach(async () => {
     stubDefaultBalances(api)
@@ -30,16 +34,12 @@ describe('UI: TransferInviteModal', () => {
   })
 
   it('Renders a modal', async () => {
-    seedMembers(mockServer.server)
-
     const { findByRole } = renderModal()
 
     expect(await findByRole('button', { name: /transfer invites/i })).toBeDefined()
   })
 
   it('Validates form', async () => {
-    seedMembers(mockServer.server)
-
     const { findByLabelText, findByRole } = renderModal()
 
     expect(await findByRole('button', { name: /transfer invites/i })).toBeDisabled()

--- a/packages/ui/test/membership/modals/TransferInviteModal.test.tsx
+++ b/packages/ui/test/membership/modals/TransferInviteModal.test.tsx
@@ -1,11 +1,12 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 
 import { ApiContext } from '@/common/providers/api/context'
 import { TransferInviteModal } from '@/memberships/modals/TransferInviteModal'
 import { seedMembers } from '@/mocks/data'
 
+import { getButton } from '../../_helpers/getButton'
 import { selectMember } from '../../_helpers/selectMember'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
@@ -34,27 +35,27 @@ describe('UI: TransferInviteModal', () => {
   })
 
   it('Renders a modal', async () => {
-    const { findByRole } = renderModal()
+    renderModal()
 
-    expect(await findByRole('button', { name: /transfer invites/i })).toBeDefined()
+    expect(await getButton(/transfer invites/i)).toBeDefined()
   })
 
   it('Validates form', async () => {
-    const { findByLabelText, findByRole } = renderModal()
+    renderModal()
 
-    expect(await findByRole('button', { name: /transfer invites/i })).toBeDisabled()
+    expect(await getButton(/transfer invites/i)).toBeDisabled()
 
-    const input = await findByLabelText(/number of invites/i)
+    const input = await screen.findByLabelText(/number of invites/i)
     expect(input).toBeDefined()
     fireEvent.change(input, { target: { value: '1' } })
 
     await selectMember('^to', 'bob')
 
-    expect(await findByRole('button', { name: /transfer invites/i })).toBeEnabled()
+    expect(await getButton(/transfer invites/i)).toBeEnabled()
   })
 
   function renderModal() {
-    return render(
+    render(
       <MockQueryNodeProviders>
         <MockKeyringProvider>
           <ApiContext.Provider value={api}>

--- a/packages/ui/test/membership/modals/UpdateMembershipModal.test.tsx
+++ b/packages/ui/test/membership/modals/UpdateMembershipModal.test.tsx
@@ -9,6 +9,7 @@ import { UseAccounts } from '../../../src/accounts/providers/accounts/provider'
 import { ApiContext } from '../../../src/common/providers/api/context'
 import { UpdateMembershipModal } from '../../../src/memberships/modals/UpdateMembershipModal'
 import { Member } from '../../../src/memberships/types'
+import { getButton } from '../../_helpers/getButton'
 import { selectAccount } from '../../_helpers/selectAccount'
 import { toBalanceOf } from '../../_mocks/chainTypes'
 import { alice, aliceStash, bob, bobStash } from '../../_mocks/keyring'
@@ -70,11 +71,11 @@ describe('UI: UpdatedMembershipModal', () => {
   it('Enables button on member field change', async () => {
     renderModal(member)
 
-    expect(await screen.findByRole('button', { name: /^Save changes$/i })).toBeDisabled()
+    expect(await getButton(/^Save changes$/i)).toBeDisabled()
 
     fireEvent.change(screen.getByLabelText(/member name/i), { target: { value: 'Bobby Bob' } })
 
-    expect(await screen.findByRole('button', { name: /^Save changes$/i })).toBeEnabled()
+    expect(await getButton(/^Save changes$/i)).toBeEnabled()
   })
 
   it('Enables save button on account change', async () => {
@@ -82,19 +83,19 @@ describe('UI: UpdatedMembershipModal', () => {
 
     await selectAccount('root account', 'bob')
 
-    expect(await screen.findByRole('button', { name: /^Save changes$/i })).toBeEnabled()
+    expect(await getButton(/^Save changes$/i)).toBeEnabled()
   })
 
   it('Disables button when invalid avatar URL', async () => {
     renderModal(member)
 
     fireEvent.change(await screen.findByLabelText(/member avatar/i), { target: { value: 'avatar' } })
-    expect(await screen.findByRole('button', { name: /^Save changes$/i })).toBeDisabled()
+    expect(await getButton(/^Save changes$/i)).toBeDisabled()
 
     fireEvent.change(await screen.findByLabelText(/member avatar/i), {
       target: { value: 'http://example.com/example.jpg' },
     })
-    expect(await screen.findByRole('button', { name: /^Save changes$/i })).toBeEnabled()
+    expect(await getButton(/^Save changes$/i)).toBeEnabled()
   })
 
   describe('Authorize - member field', () => {

--- a/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
@@ -17,6 +17,7 @@ import { seedMembers } from '@/mocks/data'
 import { AddNewProposalModal } from '@/proposals/modals/AddNewProposal'
 import { addNewProposalMachine } from '@/proposals/modals/AddNewProposal/machine'
 
+import { getButton } from '../../_helpers/getButton'
 import { selectAccount } from '../../_helpers/selectAccount'
 import { selectMember } from '../../_helpers/selectMember'
 import { mockCKEditor } from '../../_mocks/components/CKEditor'
@@ -382,10 +383,6 @@ describe('UI: AddNewProposalModal', () => {
   async function clickNextButton() {
     const button = await getNextStepButton()
     await fireEvent.click(button as HTMLElement)
-  }
-
-  async function getButton(text: string | RegExp) {
-    return (await screen.findByText(text, { selector: 'span' })).parentElement!
   }
 
   function renderModal() {

--- a/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
@@ -59,7 +59,7 @@ describe('UI: AddNewProposalModal', () => {
 
   beforeAll(async () => {
     await cryptoWaitReady()
-    seedMembers(server.server)
+    seedMembers(server.server, 2)
 
     jest.spyOn(console, 'log').mockImplementation()
 
@@ -76,6 +76,8 @@ describe('UI: AddNewProposalModal', () => {
     stubDefaultBalances(api)
     stubProposalConstants(api)
     stubTransaction(api, 'api.tx.proposalsCodex.createProposal', 25)
+
+    await renderModal()
   })
 
   describe('Requirements', () => {
@@ -94,10 +96,6 @@ describe('UI: AddNewProposalModal', () => {
 
       expect(await findByText('Insufficient Funds')).toBeDefined()
     })
-  })
-
-  beforeEach(async () => {
-    await renderModal()
   })
 
   describe('Warning modal', () => {
@@ -369,7 +367,7 @@ describe('UI: AddNewProposalModal', () => {
   }
 
   async function getPreviousStepButton() {
-    return await screen.findByRole('button', { name: /Previous step/i })
+    return await getButton(/Previous step/i)
   }
 
   async function clickPreviousButton() {
@@ -378,12 +376,16 @@ describe('UI: AddNewProposalModal', () => {
   }
 
   async function getNextStepButton() {
-    return await screen.findByRole('button', { name: /Next step/i })
+    return getButton(/Next step/i)
   }
 
   async function clickNextButton() {
     const button = await getNextStepButton()
     await fireEvent.click(button as HTMLElement)
+  }
+
+  async function getButton(text: string | RegExp) {
+    return (await screen.findByText(text, { selector: 'span' })).parentElement!
   }
 
   function renderModal() {

--- a/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
@@ -55,10 +55,12 @@ describe('UI: AddNewProposalModal', () => {
 
   let useAccounts: UseAccounts
 
-  const server = setupMockServer()
+  const server = setupMockServer({ noCleanupAfterEach: true })
 
   beforeAll(async () => {
     await cryptoWaitReady()
+    seedMembers(server.server)
+
     jest.spyOn(console, 'log').mockImplementation()
 
     useAccounts = {
@@ -68,8 +70,6 @@ describe('UI: AddNewProposalModal', () => {
   })
 
   beforeEach(async () => {
-    seedMembers(server.server)
-
     useMyMemberships.members = [getMember('alice'), getMember('bob')]
     useMyMemberships.setActive(getMember('alice'))
 

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -21,6 +21,7 @@ import { WorkingGroupOpeningFieldsFragment } from '@/working-groups/queries'
 import { asWorkingGroupOpening } from '@/working-groups/types'
 
 import { seedOpening, seedOpeningStatuses } from '../../../src/mocks/data/seedOpenings'
+import { getButton } from '../../_helpers/getButton'
 import { selectAccount } from '../../_helpers/selectAccount'
 import { alice, bob } from '../../_mocks/keyring'
 import { getMember } from '../../_mocks/members'
@@ -225,7 +226,7 @@ describe('UI: ApplyForRoleModal', () => {
   })
 
   async function getNextStepButton() {
-    return (await screen.findByText(/Next step/i)).parentElement!
+    return getButton(/Next step/i)
   }
 
   async function fillAndSubmitStakeStep() {

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -137,7 +137,7 @@ describe('UI: ApplyForRoleModal', () => {
 
       await selectAccount('Select account for Staking', 'alice')
       const input = await screen.findByLabelText(/Select amount for staking/i)
-      await fireEvent.change(input, { target: { value: '50' } })
+      fireEvent.change(input, { target: { value: '50' } })
 
       const button = await getNextStepButton()
       expect(button).toBeDisabled()
@@ -148,7 +148,7 @@ describe('UI: ApplyForRoleModal', () => {
 
       await selectAccount('Select account for Staking', 'alice')
       const input = await screen.findByLabelText(/Select amount for staking/i)
-      await fireEvent.change(input, { target: { value: '2000' } })
+      fireEvent.change(input, { target: { value: '2000' } })
 
       const button = await getNextStepButton()
       expect(button).not.toBeDisabled()
@@ -158,9 +158,7 @@ describe('UI: ApplyForRoleModal', () => {
   describe('Application form step', () => {
     beforeEach(async () => {
       await renderModal()
-      await fillStakeStep()
-      await fireEvent.click(await getNextStepButton())
-      await screen.findByRole('heading', { name: 'Application' })
+      await fillAndSubmitStakeStep()
     })
 
     it('Form questions', async () => {
@@ -174,9 +172,9 @@ describe('UI: ApplyForRoleModal', () => {
     })
 
     it('Valid fields', async () => {
-      await fireEvent.change(await screen.findByLabelText(/Question 1/i), { target: { value: 'Foo bar baz' } })
-      await fireEvent.change(await screen.findByLabelText(/Question 2/i), { target: { value: 'Foo bar baz' } })
-      await fireEvent.change(await screen.findByLabelText(/Question 3/i), { target: { value: 'Foo bar baz' } })
+      fireEvent.change(await screen.findByLabelText(/Question 1/i), { target: { value: 'Foo bar baz' } })
+      fireEvent.change(await screen.findByLabelText(/Question 2/i), { target: { value: 'Foo bar baz' } })
+      fireEvent.change(await screen.findByLabelText(/Question 3/i), { target: { value: 'Foo bar baz' } })
 
       const button = await getNextStepButton()
       expect(button).not.toBeDisabled()
@@ -186,12 +184,11 @@ describe('UI: ApplyForRoleModal', () => {
   describe('Authorize', () => {
     async function fillSteps() {
       await renderModal()
-      await fillStakeStep()
-      await fireEvent.click(await getNextStepButton())
-      await screen.findByRole('heading', { name: 'Application' })
-      await fireEvent.change(await screen.findByLabelText(/Question 1/i), { target: { value: 'Foo bar baz' } })
-      await fireEvent.change(await screen.findByLabelText(/Question 2/i), { target: { value: 'Foo bar baz' } })
-      await fireEvent.change(await screen.findByLabelText(/Question 3/i), { target: { value: 'Foo bar baz' } })
+      await fillAndSubmitStakeStep()
+
+      fireEvent.change(await screen.findByLabelText(/Question 1/i), { target: { value: 'Foo bar baz' } })
+      fireEvent.change(await screen.findByLabelText(/Question 2/i), { target: { value: 'Foo bar baz' } })
+      fireEvent.change(await screen.findByLabelText(/Question 3/i), { target: { value: 'Foo bar baz' } })
       fireEvent.click(await getNextStepButton())
     }
 
@@ -228,13 +225,15 @@ describe('UI: ApplyForRoleModal', () => {
   })
 
   async function getNextStepButton() {
-    return await screen.findByRole('button', { name: /Next step/i })
+    return (await screen.findByText(/Next step/i)).parentElement!
   }
 
-  async function fillStakeStep() {
+  async function fillAndSubmitStakeStep() {
     await selectAccount('Select account for Staking', 'alice')
     const input = await screen.findByLabelText(/Select amount for staking/i)
-    await fireEvent.change(input, { target: { value: '2000' } })
+    fireEvent.change(input, { target: { value: '2000' } })
+    fireEvent.click(await getNextStepButton())
+    await screen.findByText('Application')
   }
 
   function renderModal() {

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -62,11 +62,16 @@ describe('UI: ApplyForRoleModal', () => {
   let useAccounts: UseAccounts
   let tx: any
 
-  const server = setupMockServer()
+  const server = setupMockServer({ noCleanupAfterEach: true })
 
   beforeAll(async () => {
     await cryptoWaitReady()
     jest.spyOn(console, 'log').mockImplementation()
+
+    seedMembers(server.server)
+    seedWorkingGroups(server.server)
+    seedOpeningStatuses(server.server)
+    seedOpening(OPENING_DATA, server.server)
 
     useAccounts = {
       hasAccounts: true,
@@ -75,11 +80,6 @@ describe('UI: ApplyForRoleModal', () => {
   })
 
   beforeEach(async () => {
-    seedMembers(server.server)
-    seedWorkingGroups(server.server)
-    seedOpeningStatuses(server.server)
-    seedOpening(OPENING_DATA, server.server)
-
     const fields = (server.server?.schema.first('WorkingGroupOpening') as unknown) as WorkingGroupOpeningFieldsFragment
     const opening = asWorkingGroupOpening(fields)
     useModal.modalData = { opening }

--- a/packages/ui/test/working-groups/modals/ChangeAccountModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ChangeAccountModal.test.tsx
@@ -11,13 +11,14 @@ import { UseModal } from '@/common/providers/modal/types'
 import { MembershipContext } from '@/memberships/providers/membership/context'
 import { MyMemberships } from '@/memberships/providers/membership/provider'
 import { seedMembers } from '@/mocks/data'
+import { seedApplication } from '@/mocks/data/seedApplications'
+import { seedOpening, seedOpeningStatuses } from '@/mocks/data/seedOpenings'
 import { seedWorker } from '@/mocks/data/seedWorkers'
 import { seedWorkingGroups } from '@/mocks/data/seedWorkingGroups'
 import { ChangeAccountModal } from '@/working-groups/modals/ChangeAccountModal/ChangeAccountModal'
 import { ModalTypes } from '@/working-groups/modals/ChangeAccountModal/constants'
 
-import { seedApplication } from '../../../src/mocks/data/seedApplications'
-import { seedOpening, seedOpeningStatuses } from '../../../src/mocks/data/seedOpenings'
+import { getButton } from '../../_helpers/getButton'
 import { alice, bob } from '../../_mocks/keyring'
 import { getMember } from '../../_mocks/members'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
@@ -52,7 +53,7 @@ describe('UI: ChangeRoleModal', () => {
   let useAccounts: UseAccounts
   let transaction: any
 
-  const server = setupMockServer()
+  const server = setupMockServer({ noCleanupAfterEach: true })
 
   beforeAll(async () => {
     jest.spyOn(console, 'log').mockImplementation()
@@ -62,15 +63,16 @@ describe('UI: ChangeRoleModal', () => {
       hasAccounts: true,
       allAccounts: [alice, bob],
     }
-  })
 
-  beforeEach(async () => {
     seedMembers(server.server)
     seedWorkingGroups(server.server)
     seedOpeningStatuses(server.server)
     seedOpening(OPENING_DATA, server.server)
     seedApplication(APPLICATION_DATA, server.server)
     seedWorker(WORKER_DATA, server.server)
+  })
+
+  beforeEach(async () => {
     useMyMemberships.setActive(getMember('alice'))
     stubDefaultBalances(api)
   })
@@ -82,20 +84,20 @@ describe('UI: ChangeRoleModal', () => {
       renderModal()
       fireEvent.click(await screen.findByPlaceholderText('Select account or paste account address'))
       fireEvent.click(await screen.findByText('bob'))
-      fireEvent.click(await screen.findByRole('button', { name: 'Change' }))
+      fireEvent.click(await getButton('Change'))
     }
 
     it('Should render transaction success', async () => {
       await renderSignStep()
       stubTransactionSuccess(transaction, [worker.id, bob.address], 'workingGroup', 'WorkerRoleAccountUpdated')
-      fireEvent.click(await screen.findByRole('button', { name: 'Sign and change role account' }))
+      fireEvent.click(await getButton('Sign and change role account'))
       expect(await screen.findByText('You have successfully changed the role account.')).toBeDefined()
     })
 
     it('Should render transaction failure', async () => {
       await renderSignStep()
       stubTransactionFailure(transaction)
-      fireEvent.click(screen.getByRole('button', { name: 'Sign and change role account' }))
+      fireEvent.click(await getButton('Sign and change role account'))
       expect(await screen.findByText('There was a problem changing the role account.')).toBeDefined()
     })
   })
@@ -107,20 +109,20 @@ describe('UI: ChangeRoleModal', () => {
       renderModal()
       fireEvent.click(await screen.findByPlaceholderText('Select account or paste account address'))
       fireEvent.click(await screen.findByText('bob'))
-      fireEvent.click(await screen.findByRole('button', { name: 'Change' }))
+      fireEvent.click(await getButton('Change'))
     }
 
     it('Should render transaction success', async () => {
       await renderSignStep()
       stubTransactionSuccess(transaction, [worker.id, bob.address], 'workingGroup', 'WorkerRewardAccountUpdated')
-      fireEvent.click(await screen.findByRole('button', { name: 'Sign and change reward account' }))
+      fireEvent.click(await getButton('Sign and change reward account'))
       expect(await screen.findByText('You have successfully changed the reward account.')).toBeDefined()
     })
 
     it('Should render transaction failure', async () => {
       await renderSignStep()
       stubTransactionFailure(transaction)
-      fireEvent.click(screen.getByRole('button', { name: 'Sign and change reward account' }))
+      fireEvent.click(await getButton('Sign and change reward account'))
       expect(await screen.findByText('There was a problem changing the reward account.')).toBeDefined()
     })
   })

--- a/packages/ui/test/working-groups/modals/LeaveRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/LeaveRoleModal.test.tsx
@@ -10,12 +10,13 @@ import { ModalContext } from '@/common/providers/modal/context'
 import { MembershipContext } from '@/memberships/providers/membership/context'
 import { MyMemberships } from '@/memberships/providers/membership/provider'
 import { seedMembers } from '@/mocks/data'
+import { seedApplication } from '@/mocks/data/seedApplications'
+import { seedOpening, seedOpeningStatuses } from '@/mocks/data/seedOpenings'
 import { seedWorker } from '@/mocks/data/seedWorkers'
 import { seedWorkingGroups } from '@/mocks/data/seedWorkingGroups'
 import { LeaveRoleModal } from '@/working-groups/modals/LeaveRoleModal/LeaveRoleModal'
 
-import { seedApplication } from '../../../src/mocks/data/seedApplications'
-import { seedOpening, seedOpeningStatuses } from '../../../src/mocks/data/seedOpenings'
+import { getButton } from '../../_helpers/getButton'
 import { alice } from '../../_mocks/keyring'
 import { getMember } from '../../_mocks/members'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
@@ -74,26 +75,26 @@ describe('UI: LeaveRoleModal', () => {
     expect(await screen.findByText('Leaving a position?')).toBeDefined()
     expect(await screen.findByText('Please remember that this action is irreversible.')).toBeDefined()
     expect(await screen.findByText('Unstaking period takes 14409 blocks.')).toBeDefined()
-    expect(await screen.findByRole('button', { name: 'Leave the position anyway' })).toBeDefined()
+    expect(await getButton('Leave the position anyway')).toBeDefined()
   })
 
   describe('Authorize step', () => {
     async function renderSignStep() {
       renderModal()
-      fireEvent.click(await screen.findByRole('button', { name: 'Leave the position anyway' }))
+      fireEvent.click(await getButton('Leave the position anyway'))
     }
 
     it('Transaction success', async () => {
       await renderSignStep()
       stubTransactionSuccess(transaction, [WORKER.id], 'workingGroup', 'WorkerStartedLeaving')
-      fireEvent.click(await screen.findByRole('button', { name: 'Sign and leave role' }))
+      fireEvent.click(await getButton('Sign and leave role'))
       expect(await screen.findByText('Success!')).toBeDefined()
     })
 
     it('Transaction failure', async () => {
       await renderSignStep()
       stubTransactionFailure(transaction)
-      fireEvent.click(await screen.findByRole('button', { name: 'Sign and leave role' }))
+      fireEvent.click(await getButton('Sign and leave role'))
       expect(await screen.findByText('There was a problem leaving the role.')).toBeDefined()
     })
   })

--- a/packages/ui/test/working-groups/modals/LeaveRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/LeaveRoleModal.test.tsx
@@ -44,11 +44,18 @@ describe('UI: LeaveRoleModal', () => {
   let useAccounts: UseAccounts
   let transaction: any
 
-  const server = setupMockServer()
+  const server = setupMockServer({ noCleanupAfterEach: true })
 
   beforeAll(async () => {
     jest.spyOn(console, 'log').mockImplementation()
     await cryptoWaitReady()
+
+    seedMembers(server.server)
+    seedWorkingGroups(server.server)
+    seedOpeningStatuses(server.server)
+    seedOpening(OPENING_DATA, server.server)
+    seedApplication(APPLICATION_DATA, server.server)
+    seedWorker(WORKER_DATA, server.server)
 
     useAccounts = {
       hasAccounts: true,
@@ -57,12 +64,6 @@ describe('UI: LeaveRoleModal', () => {
   })
 
   beforeEach(async () => {
-    seedMembers(server.server)
-    seedWorkingGroups(server.server)
-    seedOpeningStatuses(server.server)
-    seedOpening(OPENING_DATA, server.server)
-    seedApplication(APPLICATION_DATA, server.server)
-    seedWorker(WORKER_DATA, server.server)
     useMyMemberships.setActive(getMember('alice'))
     stubDefaultBalances(api)
     transaction = stubTransaction(api, 'api.tx.forumWorkingGroup.leaveRole')


### PR DESCRIPTION
Comparison on my local machine:

Before:

![](https://user-images.githubusercontent.com/247363/125276154-2e422200-e310-11eb-9c73-6b6500579481.png)

After:

![](https://user-images.githubusercontent.com/247363/125276170-339f6c80-e310-11eb-9a19-96260b830d79.png)

Few findings:

*   `findByRole()` is very slow, most of my changes relate to that by adding `getButton()` helper. See the "AddNewProposalModal.test.tsx" above :scream:
*   The `--runInBand` has no effect on CI
*   Not so great improvement on CI :disappointed:
*   Some server seeds can be created once per file (only reads, no writes) or reducing number of seeds (especially with Members)