### PR TITLE
🫐 Update styles for lead opening proposal

### DIFF
--- a/packages/ui/src/common/components/icons/FileIcon.tsx
+++ b/packages/ui/src/common/components/icons/FileIcon.tsx
@@ -7,9 +7,10 @@ export const FileIcon = React.memo(() => (
     <path
       d="M2 1.33301H9.60947L14 5.72353L14 14.3524L13 15.333H2V1.33301ZM3.33333 2.66634V13.9997H12.6667L12.6667 6.27582L9.05719 2.66634H3.33333Z"
       fill="currentColor"
+      className="blackPart"
     />
-    <path d="M8.66669 2H10V5.33333H13.3334V6.66667H8.66669V2Z" fill="currentColor" />
-    <path d="M5.33331 8.66602H10.6666V9.99935H5.33331V8.66602Z" fill="currentColor" />
-    <path d="M5.33331 11.333H10.6666V12.6663H5.33331V11.333Z" fill="currentColor" />
+    <path d="M8.66669 2H10V5.33333H13.3334V6.66667H8.66669V2Z" fill="currentColor" className="blackPart" />
+    <path d="M5.33331 8.66602H10.6666V9.99935H5.33331V8.66602Z" fill="currentColor" className="primaryPart" />
+    <path d="M5.33331 11.333H10.6666V12.6663H5.33331V11.333Z" fill="currentColor" className="primaryPart" />
   </Icon>
 ))

--- a/packages/ui/src/common/components/statistics/StatisticButton.tsx
+++ b/packages/ui/src/common/components/statistics/StatisticButton.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { BorderRad, Colors, Shadows, Transitions } from '../../constants'
 import { Icon } from '../icons'
 
-import { StatiscticBlockProps, StatisticItemProps, StatsContent } from '.'
+import { StatiscticBlockProps, StatisticItemContentGrid, StatisticItemProps, StatsContent } from '.'
 import { StatisticHeader } from './StatisticHeader'
 
 export interface StatisticButtonProps extends StatisticItemProps {
@@ -24,7 +24,9 @@ export const StatisticButton: FC<StatisticButtonProps> = ({
   <StatsButton key={headerProps.title} className={className} onClick={onClick} disabled={disabled}>
     <StatsButtonInnerWrapper>
       <StatisticHeader {...headerProps} />
-      <StatsContent>{children}</StatsContent>
+      <StatsContent>
+        <StatisticItemContentGrid>{children}</StatisticItemContentGrid>
+      </StatsContent>
       <StatsButtonIcon size={16}>{icon}</StatsButtonIcon>
     </StatsButtonInnerWrapper>
   </StatsButton>
@@ -105,9 +107,17 @@ export const StatsButton = styled.button`
     color: ${Colors.Black[600]};
   }
 
+  .blackPart {
+    color: ${Colors.Black[900]};
+  }
+  .primaryPart {
+    color: ${Colors.Blue[500]};
+  }
+
   &:hover,
   &:focus {
     border-color: ${Colors.Blue[100]};
+    color: ${Colors.Blue[500]};
     ${StatsButtonIcon} {
       color: ${Colors.Blue[500]};
       transform: translateX(4px) translateY(-50%);
@@ -123,10 +133,16 @@ export const StatsButton = styled.button`
   }
   &:active {
     border-color: ${Colors.Blue[100]};
+    color: ${Colors.Blue[600]};
     transform: scale(0.96);
     ${StatsButtonIcon} {
       color: ${Colors.Blue[500]};
       transform: translateX(8px) translateY(-50%);
+    }
+    & .blackPart,
+    & .primaryPart {
+      color: ${Colors.Blue[600]};
+      fill: ${Colors.Blue[600]};
     }
     ${StatsButtonInnerWrapper}:after {
       transform: translate(-50%, -50%);
@@ -134,6 +150,7 @@ export const StatsButton = styled.button`
   }
   &:disabled {
     cursor: not-allowed;
+    color: ${Colors.Black[300]};
     ${StatsButtonIcon} {
       color: ${Colors.Black[300]};
     }

--- a/packages/ui/src/common/components/statistics/StatisticItem.tsx
+++ b/packages/ui/src/common/components/statistics/StatisticItem.tsx
@@ -5,6 +5,7 @@ import { TextSmall } from '@/common/components/typography'
 import { spacing } from '@/common/utils/styles'
 
 import { BorderRad, Colors, Shadows } from '../../constants'
+import { ColumnGapBlock } from '../page/PageContent'
 
 import { StatisticHeader, StatisticHeaderProps } from './StatisticHeader'
 
@@ -57,6 +58,17 @@ export const StatisticItemSpacedContent = styled.div`
   justify-content: space-between;
   align-items: center;
   width: 100%;
+`
+
+export const StatisticItemContentGrid = styled(ColumnGapBlock).attrs(() => ({
+  align: 'center',
+  gap: 4,
+}))`
+  color: inherit;
+
+  & svg {
+    transform: translateY(-2px);
+  }
 `
 
 export const StatisticLabel = styled(TextSmall)`

--- a/packages/ui/src/proposals/components/ProposalPreview/CreateLeadOpeningDetailsComponent.tsx
+++ b/packages/ui/src/proposals/components/ProposalPreview/CreateLeadOpeningDetailsComponent.tsx
@@ -3,7 +3,7 @@ import BN from 'bn.js'
 import React, { useState } from 'react'
 
 import { CloseButton } from '@/common/components/buttons'
-import { Link } from '@/common/components/Link'
+import { ArrowRightIcon } from '@/common/components/icons'
 import { MarkdownPreview } from '@/common/components/MarkdownPreview'
 import {
   SidePane,
@@ -13,7 +13,8 @@ import {
   SidePanelTop,
   SidePaneTitle,
 } from '@/common/components/SidePane'
-import { StatisticItem, Statistics } from '@/common/components/statistics'
+import { StatisticItem, StatisticsThreeColumns } from '@/common/components/statistics'
+import { StatisticButton } from '@/common/components/statistics/StatisticButton'
 import { TextBig, TokenValue } from '@/common/components/typography'
 import { capitalizeFirstLetter } from '@/common/helpers'
 import { CreateLeadOpeningDetails } from '@/proposals/types/ProposalDetails'
@@ -35,7 +36,7 @@ export const CreateLeadOpeningDetailsComponent: ProposalPropertiesContent<'creat
   const description = details.openingDescription ?? ''
   return (
     <>
-      <Statistics>
+      <StatisticsThreeColumns>
         <StatisticItem title="Working group">
           <TextBig>{capitalizeFirstLetter(name)}</TextBig>
         </StatisticItem>
@@ -47,27 +48,21 @@ export const CreateLeadOpeningDetailsComponent: ProposalPropertiesContent<'creat
         <StatisticItem title="Unstaking period">
           <TextBig>{details.unstakingPeriod.toString()} blocks</TextBig>
         </StatisticItem>
-      </Statistics>
-      <Statistics>
         <StatisticItem title={`Reward per ${rewardPeriod.toString()} blocks`}>
           <TextBig>
             <TokenValue value={payoutAmount} />
           </TextBig>
         </StatisticItem>
-        <StatisticItem title="Description">
-          <TextBig>
-            <Link
-              dark
-              onClick={(evt) => {
-                evt.preventDefault()
-                setDescriptionVisible(true)
-              }}
-            >
-              Opening Description
-            </Link>
-          </TextBig>
-        </StatisticItem>
-      </Statistics>
+        <StatisticButton
+          title="Description"
+          onClick={() => {
+            setDescriptionVisible(true)
+          }}
+          icon={<ArrowRightIcon />}
+        >
+          Opening Description
+        </StatisticButton>
+      </StatisticsThreeColumns>
       {isDescriptionVisible && (
         <OpeningDescriptionPreview description={description} onClose={() => setDescriptionVisible(false)} />
       )}

--- a/packages/ui/src/proposals/components/ProposalPreview/CreateLeadOpeningDetailsComponent.tsx
+++ b/packages/ui/src/proposals/components/ProposalPreview/CreateLeadOpeningDetailsComponent.tsx
@@ -3,7 +3,7 @@ import BN from 'bn.js'
 import React, { useState } from 'react'
 
 import { CloseButton } from '@/common/components/buttons'
-import { ArrowRightIcon } from '@/common/components/icons'
+import { ArrowRightIcon, FileIcon } from '@/common/components/icons'
 import { MarkdownPreview } from '@/common/components/MarkdownPreview'
 import {
   SidePane,
@@ -15,7 +15,7 @@ import {
 } from '@/common/components/SidePane'
 import { StatisticItem, StatisticsThreeColumns } from '@/common/components/statistics'
 import { StatisticButton } from '@/common/components/statistics/StatisticButton'
-import { TextBig, TokenValue } from '@/common/components/typography'
+import { TextInlineBig, TokenValue } from '@/common/components/typography'
 import { capitalizeFirstLetter } from '@/common/helpers'
 import { CreateLeadOpeningDetails } from '@/proposals/types/ProposalDetails'
 import { GroupRewardPeriods, isKnownGroupName } from '@/working-groups/types'
@@ -38,20 +38,22 @@ export const CreateLeadOpeningDetailsComponent: ProposalPropertiesContent<'creat
     <>
       <StatisticsThreeColumns>
         <StatisticItem title="Working group">
-          <TextBig>{capitalizeFirstLetter(name)}</TextBig>
+          <TextInlineBig bold value>
+            {capitalizeFirstLetter(name)}
+          </TextInlineBig>
         </StatisticItem>
         <StatisticItem title="Stake amount">
-          <TextBig>
-            <TokenValue value={details.stakeAmount} />
-          </TextBig>
+          <TokenValue value={details.stakeAmount} />
         </StatisticItem>
         <StatisticItem title="Unstaking period">
-          <TextBig>{details.unstakingPeriod.toString()} blocks</TextBig>
+          <TextInlineBig bold value>
+            {details.unstakingPeriod.toString()} blocks
+          </TextInlineBig>
         </StatisticItem>
         <StatisticItem title={`Reward per ${rewardPeriod.toString()} blocks`}>
-          <TextBig>
+          <TextInlineBig bold value>
             <TokenValue value={payoutAmount} />
-          </TextBig>
+          </TextInlineBig>
         </StatisticItem>
         <StatisticButton
           title="Description"
@@ -60,7 +62,10 @@ export const CreateLeadOpeningDetailsComponent: ProposalPropertiesContent<'creat
           }}
           icon={<ArrowRightIcon />}
         >
-          Opening Description
+          <FileIcon />
+          <TextInlineBig bold value>
+            Opening Description
+          </TextInlineBig>
         </StatisticButton>
       </StatisticsThreeColumns>
       {isDescriptionVisible && (

--- a/packages/ui/src/proposals/modals/AddNewProposal/components/SuccessModal.tsx
+++ b/packages/ui/src/proposals/modals/AddNewProposal/components/SuccessModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { ButtonGhost } from '@/common/components/buttons'
-import { AlertSymbol, SuccessSymbol } from '@/common/components/icons/symbols'
+import { SuccessSymbol } from '@/common/components/icons/symbols'
 import { Info } from '@/common/components/Info'
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@/common/components/Modal'
 import { TextMedium } from '@/common/components/typography'


### PR DESCRIPTION
Added the statistic button to the create working group lead opening proposal

@ClumsyVlad I think that we miss [the title's icon](https://www.figma.com/file/GlgN8uBRtvtMJtiOsdtDF7/Design?node-id=2059%3A20) still