### PR TITLE
🥑 Apply filters to past proposals

### DIFF
--- a/packages/ui/src/app/pages/Proposals/PastProposals.tsx
+++ b/packages/ui/src/app/pages/Proposals/PastProposals.tsx
@@ -17,10 +17,10 @@ import { ProposalsTabs } from './components/ProposalsTabs'
 
 export const PastProposals = () => {
   const searchSlot = useRef<HTMLDivElement>(null)
-  const [, setFilters] = useState(ProposalEmptyFilter)
+  const [filters, setFilters] = useState(ProposalEmptyFilter)
 
   const { types, stages } = usePastProposals()
-  const { isLoading, proposals } = useProposals({ status: 'past' })
+  const { isLoading, proposals } = useProposals({ status: 'past', filters })
 
   const activities = useActivities()
 

--- a/packages/ui/src/mocks/resolvers/baseResolvers.ts
+++ b/packages/ui/src/mocks/resolvers/baseResolvers.ts
@@ -66,11 +66,16 @@ const getFilter = (where: Record<string, any>, nestedField?: string) => {
       }
     }
 
-    if (type === 'gte') {
-      if (field === 'createdAt') {
-        filters.push((model: Record<string, any>) => new Date(model[field]).getTime() >= new Date(checkValue).getTime())
+    if (['gte', 'lte'].includes(type)) {
+      const resultToBoolean: (a: number) => boolean = type == 'gte' ? (a) => a >= 0 : (a) => a <= 0
+      if (['createdAt', 'statusSetAtTime'].includes(field)) {
+        filters.push((model: Record<string, any>) =>
+          resultToBoolean(new Date(model[field]).getTime() - new Date(checkValue).getTime())
+        )
       } else {
-        filters.push((model: Record<string, any>) => String(model[field]).localeCompare(checkValue.toString()) === 1)
+        filters.push((model: Record<string, any>) =>
+          resultToBoolean(String(model[field]).localeCompare(checkValue.toString()))
+        )
       }
     }
 

--- a/packages/ui/test/_mocks/proposals/index.ts
+++ b/packages/ui/test/_mocks/proposals/index.ts
@@ -1,0 +1,114 @@
+import { ProposalMock } from '../../../dev/scripts/generators/generateProposals'
+
+const baseMock = {
+  creatorId: '0',
+  statusSetAtBlock: 0,
+  createdInEvent: {
+    inBlock: 0,
+  },
+  description: '',
+  votes: [],
+  proposalStatusUpdates: [],
+  discussionThread: {
+    discussionPosts: [],
+    mode: 'ProposalDiscussionThreadModeClosed',
+  },
+}
+
+export const testProposals: ProposalMock[] = [
+  // Past
+  {
+    ...baseMock,
+    id: '0',
+    title: 'Canceled Proposal One',
+    status: 'canceledByRuntime',
+    createdAt: '2021-07-03T10:00:00.000Z',
+    statusSetAtTime: '2021-07-09T10:00:00.000Z',
+    details: {
+      type: 'fundingRequest',
+      data: {
+        destinationsList: {
+          destinations: [
+            {
+              account: '5GETSBUMwbLJgUTWMQgU8B2CP7E8kDHR8NoNNZh5tqums9AF',
+              amount: 5000,
+            },
+          ],
+        },
+      },
+    },
+  },
+  {
+    ...baseMock,
+    id: '1',
+    title: 'Very Similar Name Proposal',
+    status: 'executed',
+    createdAt: '2021-07-05T10:00:00.000Z',
+    statusSetAtTime: '2021-07-06T10:00:00.000Z',
+    details: {
+      type: 'fundingRequest',
+      data: {
+        destinationsList: {
+          destinations: [
+            {
+              account: '5GETSBUMwbLJgUTWMQgU8B2CP7E8kDHR8NoNNZh5tqums9AF',
+              amount: 5000,
+            },
+          ],
+        },
+      },
+    },
+    creatorId: '1',
+  },
+  {
+    ...baseMock,
+    id: '2',
+    title: 'Executed Proposal Two',
+    status: 'executed',
+    createdAt: '2021-07-01T10:00:00.000Z',
+    statusSetAtTime: '2021-07-04T10:00:00.000Z',
+    details: {
+      type: 'runtimeUpgrade',
+      data: {
+        bytecode: '0x0061736d',
+      },
+    },
+  },
+  {
+    ...baseMock,
+    id: '3',
+    title: 'Quite Similar Named Proposal',
+    status: 'vetoed',
+    createdAt: '2021-07-08T10:00:00.000Z',
+    statusSetAtTime: '2021-07-14T10:00:00.000Z',
+    details: {
+      type: 'runtimeUpgrade',
+      data: {
+        bytecode: '0x0061736d',
+      },
+    },
+    creatorId: '1',
+  },
+  // Active
+  {
+    ...baseMock,
+    id: '4',
+    title: 'Gracing Proposal One',
+    status: 'gracing',
+    createdAt: '2021-07-21T10:00:00.000Z',
+    statusSetAtTime: '2021-07-24T10:00:00.000Z',
+    details: {
+      type: 'fundingRequest',
+      data: {
+        destinationsList: {
+          destinations: [
+            {
+              account: '5GETSBUMwbLJgUTWMQgU8B2CP7E8kDHR8NoNNZh5tqums9AF',
+              amount: 5000,
+            },
+          ],
+        },
+      },
+    },
+  },
+]

--- a/packages/ui/test/proposals/hooks/useProposals.test.tsx
+++ b/packages/ui/test/proposals/hooks/useProposals.test.tsx
@@ -1,0 +1,130 @@
+import { renderHook } from '@testing-library/react-hooks'
+import React from 'react'
+
+import { capitalizeFirstLetter } from '@/common/helpers'
+import {
+  seedApplications,
+  seedMembers,
+  seedOpenings,
+  seedProposals,
+  seedWorkers,
+  seedWorkingGroups,
+} from '@/mocks/data'
+import { ProposalEmptyFilter } from '@/proposals/components/ProposalFilters'
+import { useProposals, UseProposalsProps } from '@/proposals/hooks/useProposals'
+import { proposalDetails } from '@/proposals/model/proposalDetails'
+import { proposalActiveStatuses, proposalPastStatuses } from '@/proposals/model/proposalStatus'
+
+import { MockQueryNodeProviders } from '../../_mocks/providers'
+import { setupMockServer } from '../../_mocks/server'
+
+const renderUseProposals = (props: UseProposalsProps) =>
+  renderHook(() => useProposals(props), {
+    wrapper: ({ children }) => <MockQueryNodeProviders>{children}</MockQueryNodeProviders>,
+  })
+
+describe('useProposals', () => {
+  const mockServer = setupMockServer({ noCleanupAfterEach: true })
+
+  beforeAll(() => {
+    seedMembers(mockServer.server)
+    seedWorkingGroups(mockServer.server)
+    seedOpenings(mockServer.server)
+    seedApplications(mockServer.server)
+    seedWorkers(mockServer.server)
+    seedProposals(mockServer.server)
+  })
+
+  describe('Status: active | past', () => {
+    it('Status: active', async () => {
+      const result = await loadUseProposals({ status: 'active' })
+      result.current.proposals.forEach((proposal) => {
+        expect(proposalActiveStatuses.includes(proposal.status)).toBeTruthy()
+      })
+    })
+
+    it('Status: past', async () => {
+      const result = await loadUseProposals({ status: 'past' })
+      result.current.proposals.forEach((proposal) => {
+        expect(proposalPastStatuses.includes(proposal.status)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('With filters', () => {
+    describe('Separate', () => {
+      describe('Stage/Status', () => {
+        proposalPastStatuses.forEach((status) => {
+          it(`Status: ${status}`, async () => {
+            const result = await loadUseProposals({
+              status: 'past',
+              filters: {
+                ...ProposalEmptyFilter,
+                stage: status,
+              },
+            })
+            result.current.proposals.forEach((proposal) => {
+              expect(proposal.status).toBe(status)
+            })
+          })
+        })
+      })
+
+      it('Search', async () => {
+        const allPast = await loadUseProposals({ status: 'past' })
+        const title = allPast.current.proposals[0].title
+        const search = title.substr(3, title.length - 8)
+        const result = await loadUseProposals({
+          status: 'past',
+          filters: {
+            ...ProposalEmptyFilter,
+            search,
+          },
+        })
+        expect(result.current.proposals[0].title).toBe(title)
+      })
+
+      describe('Type', () => {
+        proposalDetails.forEach((type) => {
+          const typeFilter = capitalizeFirstLetter(type)
+          it(typeFilter, async () => {
+            const result = await loadUseProposals({
+              status: 'past',
+              filters: {
+                ...ProposalEmptyFilter,
+                type: typeFilter,
+              },
+            })
+            result.current.proposals.forEach((proposal) => {
+              expect(proposal.type).toBe(type)
+            })
+          })
+        })
+      })
+
+      it('Proposer', async () => {
+        const allPast = await loadUseProposals({ status: 'past' })
+        const member = allPast.current.proposals[0].proposer
+        const result = await loadUseProposals({
+          status: 'past',
+          filters: {
+            ...ProposalEmptyFilter,
+            proposer: member,
+          },
+        })
+        expect(result.current.proposals.length).toBeGreaterThan(0)
+        result.current.proposals.forEach((proposal) => {
+          expect(proposal.proposer.id).toBe(member.id)
+        })
+      })
+    })
+  })
+
+  const loadUseProposals = async (props: UseProposalsProps) => {
+    const { result, waitForNextUpdate } = renderUseProposals(props)
+    while (result.current.isLoading) {
+      await waitForNextUpdate()
+    }
+    return result
+  }
+})

--- a/packages/ui/test/proposals/hooks/useProposals.test.tsx
+++ b/packages/ui/test/proposals/hooks/useProposals.test.tsx
@@ -38,6 +38,7 @@ describe('useProposals', () => {
   describe('Status: active | past', () => {
     it('Status: active', async () => {
       const result = await loadUseProposals({ status: 'active' })
+      expect(result.current.proposals.length).toBeGreaterThan(0)
       result.current.proposals.forEach((proposal) => {
         expect(proposalActiveStatuses.includes(proposal.status)).toBeTruthy()
       })
@@ -45,6 +46,7 @@ describe('useProposals', () => {
 
     it('Status: past', async () => {
       const result = await loadUseProposals({ status: 'past' })
+      expect(result.current.proposals.length).toBeGreaterThan(0)
       result.current.proposals.forEach((proposal) => {
         expect(proposalPastStatuses.includes(proposal.status)).toBeTruthy()
       })
@@ -52,21 +54,33 @@ describe('useProposals', () => {
   })
 
   describe('With filters', () => {
+    it('Empty filters', async () => {
+      const result = await loadUseProposals({
+        status: 'past',
+        filters: {
+          ...ProposalEmptyFilter,
+        },
+      })
+      expect(result.current.proposals.length).toBeGreaterThan(0)
+      result.current.proposals.forEach((proposal) => {
+        expect(proposalPastStatuses.includes(proposal.status)).toBeTruthy()
+      })
+    })
+
     describe('Separate', () => {
-      describe('Stage/Status', () => {
-        proposalPastStatuses.forEach((status) => {
-          it(`Status: ${status}`, async () => {
-            const result = await loadUseProposals({
-              status: 'past',
-              filters: {
-                ...ProposalEmptyFilter,
-                stage: status,
-              },
-            })
-            result.current.proposals.forEach((proposal) => {
-              expect(proposal.status).toBe(status)
-            })
-          })
+      it('Stage/Status', async () => {
+        const allPast = await loadUseProposals({ status: 'past' })
+        const { status } = allPast.current.proposals[0]
+        const result = await loadUseProposals({
+          status: 'past',
+          filters: {
+            ...ProposalEmptyFilter,
+            stage: status,
+          },
+        })
+        expect(result.current.proposals.length).toBeGreaterThan(0)
+        result.current.proposals.forEach((proposal) => {
+          expect(proposal.status).toBe(status)
         })
       })
 
@@ -84,21 +98,19 @@ describe('useProposals', () => {
         expect(result.current.proposals[0].title).toBe(title)
       })
 
-      describe('Type', () => {
-        proposalDetails.forEach((type) => {
-          const typeFilter = capitalizeFirstLetter(type)
-          it(typeFilter, async () => {
-            const result = await loadUseProposals({
-              status: 'past',
-              filters: {
-                ...ProposalEmptyFilter,
-                type: typeFilter,
-              },
-            })
-            result.current.proposals.forEach((proposal) => {
-              expect(proposal.type).toBe(type)
-            })
-          })
+      it('Type', async () => {
+        const type = proposalDetails[Math.floor(Math.random() * proposalDetails.length)]
+        const typeFilter = capitalizeFirstLetter(type)
+        const result = await loadUseProposals({
+          status: 'past',
+          filters: {
+            ...ProposalEmptyFilter,
+            type: typeFilter,
+          },
+        })
+        expect(result.current.proposals.length).toBeGreaterThan(0)
+        result.current.proposals.forEach((proposal) => {
+          expect(proposal.type).toBe(type)
         })
       })
 


### PR DESCRIPTION
Closes #586 
Filters work well with past proposals at the moment. Their behaviour for active proposals is currently undefined, but by design they aren't meant to used with Active ones. The only filter that would cause problems with active proposals would be the lifetime filter since active proposals don't have an end date.
Lifetime filter has been tested for start date only/end date only, as we don't have an OR clause resolver in our mocks. The intervals used are correct in theory however.