### PR TITLE
🦘 Add a sufficient funds requirement to Delete Post modal

### DIFF
--- a/packages/ui/test/_mocks/forum/posts.ts
+++ b/packages/ui/test/_mocks/forum/posts.ts
@@ -2,7 +2,7 @@ import { RawForumPostMock } from '@/mocks/data/seedForum'
 
 export const mockPosts: RawForumPostMock[] = [
   {
-    id: '0:0',
+    id: '0',
     threadId: '0',
     authorId: '0',
     text:
@@ -30,7 +30,7 @@ export const mockPosts: RawForumPostMock[] = [
     },
   },
   {
-    id: '0:1',
+    id: '1',
     threadId: '0',
     authorId: '1',
     text:

--- a/packages/ui/test/forum/modals/DeletePostModal.test.tsx
+++ b/packages/ui/test/forum/modals/DeletePostModal.test.tsx
@@ -1,5 +1,5 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import React from 'react'
 
 import { AccountsContext } from '@/accounts/providers/accounts/context'
@@ -7,39 +7,31 @@ import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
 import { ModalCallData, UseModal } from '@/common/providers/modal/types'
-import { EditPostModal, EditPostModalCall } from '@/forum/modals/PostActionModal/EditPostModal'
+import { DeletePostModal, DeletePostModalCall } from '@/forum/modals/PostActionModal/DeletePostModal'
 import { MembershipContext } from '@/memberships/providers/membership/context'
 import { MyMemberships } from '@/memberships/providers/membership/provider'
 import { seedMember } from '@/mocks/data'
 import rawMembers from '@/mocks/data/raw/members.json'
 import { seedForumCategory, seedForumPost, seedForumThread } from '@/mocks/data/seedForum'
 
-import { getButton } from '../../_helpers/getButton'
 import { mockCategories, mockPosts, mockThreads } from '../../_mocks/forum'
 import { alice, bob } from '../../_mocks/keyring'
 import { getMember } from '../../_mocks/members'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
-import {
-  stubApi,
-  stubDefaultBalances,
-  stubTransaction,
-  stubTransactionFailure,
-  stubTransactionSuccess,
-} from '../../_mocks/transactions'
+import { stubApi, stubDefaultBalances, stubTransaction } from '../../_mocks/transactions'
 
-describe('UI: EditPostModal', () => {
+describe('UI: DeletePostModal', () => {
   const api = stubApi()
-  const txPath = 'api.tx.forum.editPostText'
+  const txPath = 'api.tx.forum.deletePosts'
   let tx: any
-  const modalData: ModalCallData<EditPostModalCall> = {
+  const modalData: ModalCallData<DeletePostModalCall> = {
     post: {
       id: '0',
       author: getMember('alice'),
       createdAt: '2021-07-02T04:22:13.523Z',
       text: 'Sample post text',
     },
-    newText: 'New text',
   }
 
   const useModal: UseModal<any> = {
@@ -84,20 +76,6 @@ describe('UI: EditPostModal', () => {
     expect(await screen.findByText('Insufficient Funds')).toBeDefined()
   })
 
-  it('Transaction failed', async () => {
-    stubTransactionFailure(tx)
-    renderModal()
-    await fireEvent.click(await getButton(/Sign and send/i))
-    expect(await screen.getByText('There was a problem submitting an edit to your post.')).toBeDefined()
-  })
-
-  it('Transaction success', async () => {
-    stubTransactionSuccess(tx, [], 'forum', 'editPostText')
-    renderModal()
-    await fireEvent.click(await getButton(/Sign and send/i))
-    expect(await screen.getByText('Your edit has been submitted.')).toBeDefined()
-  })
-
   const renderModal = () =>
     render(
       <ModalContext.Provider value={useModal}>
@@ -106,7 +84,7 @@ describe('UI: EditPostModal', () => {
             <AccountsContext.Provider value={useAccounts}>
               <MembershipContext.Provider value={useMyMemberships}>
                 <ApiContext.Provider value={api}>
-                  <EditPostModal />
+                  <DeletePostModal />
                 </ApiContext.Provider>
               </MembershipContext.Provider>
             </AccountsContext.Provider>

--- a/packages/ui/test/forum/modals/DeletePostModal.test.tsx
+++ b/packages/ui/test/forum/modals/DeletePostModal.test.tsx
@@ -24,7 +24,6 @@ import { stubApi, stubDefaultBalances, stubTransaction } from '../../_mocks/tran
 describe('UI: DeletePostModal', () => {
   const api = stubApi()
   const txPath = 'api.tx.forum.deletePosts'
-  let tx: any
   const modalData: ModalCallData<DeletePostModalCall> = {
     post: {
       id: '0',
@@ -67,13 +66,18 @@ describe('UI: DeletePostModal', () => {
 
   beforeEach(async () => {
     stubDefaultBalances(api)
-    tx = stubTransaction(api, txPath)
+    stubTransaction(api, txPath)
   })
 
   it('Requirements failed', async () => {
-    tx = stubTransaction(api, txPath, 10000)
+    stubTransaction(api, txPath, 10000)
     renderModal()
     expect(await screen.findByText('Insufficient Funds')).toBeDefined()
+  })
+
+  it('Requirements passed', async () => {
+    renderModal()
+    expect(await screen.findByText('You intend to delete your post.')).toBeDefined()
   })
 
   const renderModal = () =>


### PR DESCRIPTION
Also removed the requirement for active member being identical to post author, as this is checked before opening the modal and should not be reachable with normal use