### PR TITLE
🩴 Scroll to edits on stepper click in edits history

### DIFF
--- a/packages/ui/src/common/components/Stepper/Stepper.tsx
+++ b/packages/ui/src/common/components/Stepper/Stepper.tsx
@@ -80,7 +80,7 @@ const StepBody = styled.div`
   row-gap: 8px;
 `
 
-type StepNumberProps = Pick<StepToRender, 'isActive' | 'isPast' | 'isBaby'>
+type StepNumberProps = Pick<StepToRender, 'isActive' | 'isPast' | 'isBaby'> & { onClick?: () => void }
 
 const StepWrap = styled.div<StepNumberProps>`
   display: grid;
@@ -88,6 +88,7 @@ const StepWrap = styled.div<StepNumberProps>`
   grid-template-columns: 28px 1fr;
   grid-column-gap: 8px;
   justify-content: start;
+  cursor: ${({ onClick }) => (onClick ? 'pointer' : 'auto')};
 
   /* History line */
   &:not(:last-child) {

--- a/packages/ui/src/common/model/machines/getSteps.ts
+++ b/packages/ui/src/common/model/machines/getSteps.ts
@@ -4,6 +4,7 @@ export interface Step {
   title: string
   type: 'past' | 'active' | 'next'
   isBaby?: boolean
+  onClick?: () => void
 }
 
 const getActiveNodeOrder = (state: State<any>) => (activeId: number, stateNode: StateNode) => {

--- a/packages/ui/src/forum/modals/PostHistoryModal/PostHistoryModal.stories.tsx
+++ b/packages/ui/src/forum/modals/PostHistoryModal/PostHistoryModal.stories.tsx
@@ -42,6 +42,7 @@ Default.args = {
         description: 'Category description',
         parentId: null,
         moderatorIds: [],
+        status: 'CategoryStatusActive',
       },
     ],
     threads: [

--- a/packages/ui/src/forum/modals/PostHistoryModal/PostHistoryModal.tsx
+++ b/packages/ui/src/forum/modals/PostHistoryModal/PostHistoryModal.tsx
@@ -39,6 +39,9 @@ export const PostHistoryModal = React.memo(() => {
     [editsInView]
   )
 
+  const getScrollToEdit = (index: number) => () =>
+    editsRefs[index]?.current?.scrollIntoView({ behavior: 'smooth', inline: 'start' })
+
   const getInsertRef = (index: number) => (ref: RefObject<HTMLDivElement>) => (editsRefs[index] = ref)
 
   const viewport = useRef<HTMLDivElement>(null)
@@ -48,14 +51,18 @@ export const PostHistoryModal = React.memo(() => {
       return 'active'
     }
 
-    return index > activeEdit ? 'next' : 'past'
+    return 'next'
   }
 
   const displayEdits = () => (
     <>
       <Stepper
         steps={
-          edits?.map((edit, index) => ({ title: formatDateString(edit.createdAt), type: getStepType(index) })) ?? []
+          edits?.map((edit, index) => ({
+            title: formatDateString(edit.createdAt),
+            type: getStepType(index),
+            onClick: getScrollToEdit(index),
+          })) ?? []
         }
       />
       <StepperBody ref={viewport}>

--- a/packages/ui/src/forum/modals/PostHistoryModal/PostHistoryModal.tsx
+++ b/packages/ui/src/forum/modals/PostHistoryModal/PostHistoryModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState, RefObject } from 'react'
 import InView from 'react-intersection-observer'
 import styled from 'styled-components'
 
@@ -28,6 +28,7 @@ export const PostHistoryModal = React.memo(() => {
   const [activeEdit, setActiveEdit] = useState(0)
 
   const editsInView = useMemo(() => new Array<boolean>(edits?.length ?? 0), [edits?.length])
+  const editsRefs = useMemo(() => new Array<RefObject<HTMLDivElement>>(edits?.length ?? 0), [edits?.length])
 
   const pickActiveEdit = useCallback(
     (index: number) => (isCurrentInView: boolean) => {
@@ -37,6 +38,8 @@ export const PostHistoryModal = React.memo(() => {
     },
     [editsInView]
   )
+
+  const getInsertRef = (index: number) => (ref: RefObject<HTMLDivElement>) => (editsRefs[index] = ref)
 
   const viewport = useRef<HTMLDivElement>(null)
 
@@ -61,7 +64,13 @@ export const PostHistoryModal = React.memo(() => {
         ) : (
           <RowGapBlock gap={32}>
             {edits?.map((edit, index) => (
-              <HistoryPost edit={edit} author={author} onChange={pickActiveEdit(index)} root={viewport.current} />
+              <HistoryPost
+                edit={edit}
+                author={author}
+                onChange={pickActiveEdit(index)}
+                root={viewport.current}
+                insertRef={getInsertRef(index)}
+              />
             ))}
           </RowGapBlock>
         )}
@@ -84,21 +93,28 @@ interface HistoryPostProps {
   author: Member
   onChange: (inView: boolean) => void
   root: HTMLDivElement | null
+  insertRef: (ref: RefObject<HTMLDivElement>) => void
 }
 
-const HistoryPost = ({ edit, author, onChange, root }: HistoryPostProps) => (
-  <InView onChange={onChange} root={root} rootMargin="-32px 0px 0px">
-    <ForumPostStyles>
-      <ForumPostRow>
-        <ForumPostAuthor>{author && <MemberInfo member={author} />}</ForumPostAuthor>
-        <BlockTime block={asBlock(edit)} layout="reverse" />
-      </ForumPostRow>
-      <ForumPostRow>
-        <MarkdownPreview markdown={edit.newText} />
-      </ForumPostRow>
-    </ForumPostStyles>
-  </InView>
-)
+const HistoryPost = ({ edit, author, onChange, root, insertRef }: HistoryPostProps) => {
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    !!ref.current && insertRef(ref)
+  }, [ref.current])
+  return (
+    <InView onChange={onChange} root={root} rootMargin="-32px 0px 0px">
+      <ForumPostStyles ref={ref}>
+        <ForumPostRow>
+          <ForumPostAuthor>{author && <MemberInfo member={author} />}</ForumPostAuthor>
+          <BlockTime block={asBlock(edit)} layout="reverse" />
+        </ForumPostRow>
+        <ForumPostRow>
+          <MarkdownPreview markdown={edit.newText} />
+        </ForumPostRow>
+      </ForumPostStyles>
+    </InView>
+  )
+}
 
 const HistoryModalWrapper = styled(StepperModalWrapper)`
   grid-template-columns: 300px 1fr;


### PR DESCRIPTION
Closes #1192 
Passing element refs upwards like this is extremely cursed, but it works fairly well