### PR TITLE
📭 Min height for thread browser

### DIFF
--- a/packages/ui/src/forum/components/threads/ThreadBrowser.tsx
+++ b/packages/ui/src/forum/components/threads/ThreadBrowser.tsx
@@ -69,6 +69,7 @@ const ThreadBrowserStyles = styled.div`
   flex-shrink: 0;
   flex-grow: 1;
   max-width: 100%;
+  min-height: 330px;
   max-height: 472px;
   padding: 16px;
   border: 1px solid ${Colors.Black[100]};


### PR DESCRIPTION
Add min height for thread browser item to resolve content jumping on load state

Closes #1347 