### PR TITLE
🥖 Truncate breadcrumbs in thread items

### DIFF
--- a/packages/ui/src/common/components/page/Sidebar/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/ui/src/common/components/page/Sidebar/Breadcrumbs/BreadcrumbsItem.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { Colors, Transitions, Fonts } from '../../../../constants'
 
@@ -22,6 +22,13 @@ export const BreadcrumbsItem = React.memo(({ url, children, isLink }: Breadcrumb
   )
 })
 
+const truncatedBreadcrumbText = css`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+`
+
 export const BreadcrumbsItemLink = styled(Link)`
   &,
   &:visited {
@@ -38,6 +45,7 @@ export const BreadcrumbsItemLink = styled(Link)`
       color: ${Colors.Blue[500]};
     }
   }
+  ${truncatedBreadcrumbText}
 `
 
 const BreadcrumbsItemText = styled.span`
@@ -47,6 +55,7 @@ const BreadcrumbsItemText = styled.span`
   font-family: ${Fonts.Inter};
   cursor: auto;
   transition: ${Transitions.all};
+  ${truncatedBreadcrumbText}
 `
 
 const BreadcrumbsItemComponent = styled.li`
@@ -54,6 +63,7 @@ const BreadcrumbsItemComponent = styled.li`
   position: relative;
   align-items: center;
   margin-left: 26px;
+  min-width: 26px;
 
   &:before {
     content: '';

--- a/packages/ui/src/forum/components/threads/ThreadItem.tsx
+++ b/packages/ui/src/forum/components/threads/ThreadItem.tsx
@@ -31,7 +31,7 @@ export interface ThreadItemContentProps {
 export const ThreadItem = ({ thread, badges, halfSize, empty }: ThreadItemContentProps) => {
   const { originalPost, isLoading } = useThreadOriginalPost(thread.id)
   const repliesCount = thread.visiblePostsCount - 1
-  const { threadBreadcrumb, categoryBreadcrumbs } = useThreadBreadcrumbs(thread.id)
+  const { categoryBreadcrumbs } = useThreadBreadcrumbs(thread.id)
   const content = originalPost?.text
   const threadAddress = `/forum/thread/${thread.id}`
 
@@ -48,11 +48,7 @@ export const ThreadItem = ({ thread, badges, halfSize, empty }: ThreadItemConten
         <ThreadItemTitle empty={empty}>{thread.title}</ThreadItemTitle>
         <ThreadItemTime lighter>{relativeTime(thread.createdInBlock.timestamp)}</ThreadItemTime>
       </ThreadItemHeader>
-      <ForumBreadcrumbsList
-        categoryBreadcrumbs={categoryBreadcrumbs ?? []}
-        threadBreadcrumb={threadBreadcrumb}
-        nonInteractive
-      />
+      <ForumBreadcrumbsList categoryBreadcrumbs={categoryBreadcrumbs ?? []} nonInteractive />
       {content && (
         <ThreadItemText light value>
           {content}


### PR DESCRIPTION
Closes #1062 
Final touch for thread overview - breadcrumbs would get massive and take up half the space in the component, so they need to be truncated if they're too verbose. The style was changed site-wide but in practice we shouldn't see it much outside forum overview, and if someone's screen is narrow enough the crumbs should sit neatly in a single line anyway.
Also removed the thread title breadcrumb from there since the thread title is at the top of the component anyway.