### PR TITLE
⛵ Make the forum navigable with the search pane

### DIFF
--- a/packages/ui/src/common/components/Search/SearchResultsModal.tsx
+++ b/packages/ui/src/common/components/Search/SearchResultsModal.tsx
@@ -1,5 +1,6 @@
 import escapeStringRegexp from 'escape-string-regexp'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { MouseEventHandler, useCallback, useEffect, useMemo, useState } from 'react'
+import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 
 import { Close, CloseButton } from '@/common/components/buttons'
@@ -28,6 +29,20 @@ export const SearchResultsModal = () => {
   const { forum, forumPostCount, isLoading } = useSearch(search, activeTab)
   const pattern = useMemo(() => (search ? RegExp(escapeStringRegexp(search), 'ig') : null), [search])
 
+  const history = useHistory()
+  const [hasOverlay, setHasOverlay] = useState(true)
+  useEffect(
+    () =>
+      history.listen((location) => {
+        if (activeTab === 'FORUM' && location.pathname.startsWith(ForumRoutes.forum)) {
+          setHasOverlay(false)
+        } else {
+          hideModal()
+        }
+      }),
+    []
+  )
+
   useEffect(() => {
     const escapeEvent = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -39,8 +54,13 @@ export const SearchResultsModal = () => {
     return () => document.removeEventListener('keydown', escapeEvent)
   }, [])
 
+  const overlayClickHandler = useCallback<MouseEventHandler<HTMLDivElement>>(
+    (event) => event.target === event.currentTarget && hideModal(),
+    []
+  )
+
   return (
-    <SidePaneGlass onClick={(event) => event.target === event.currentTarget && hideModal()}>
+    <SidePaneGlass onClick={hasOverlay ? overlayClickHandler : undefined}>
       <SearchResultsSidePane>
         <SearchResultsHeader>
           <CloseButton onClick={hideModal} />

--- a/packages/ui/src/common/components/SidePane/SidePane.tsx
+++ b/packages/ui/src/common/components/SidePane/SidePane.tsx
@@ -1,21 +1,8 @@
+import { MouseEventHandler } from 'react'
 import styled, { css } from 'styled-components'
 
-import { Animations, Colors, RemoveScrollbar, ZIndex } from '../../constants'
+import { Animations, Colors, RemoveScrollbar, Shadows, ZIndex } from '../../constants'
 import { ButtonsGroup } from '../buttons'
-
-export const SidePaneGlass = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  background-color: ${Colors.Black[700.85]};
-  color: ${Colors.Black[900]};
-  z-index: ${ZIndex.modal};
-  ${Animations.showModalBackground};
-`
 
 export const SidePaneHeader = styled.div`
   display: grid;
@@ -98,4 +85,30 @@ export const SidePane = styled.div<{ topSize?: 'xs' | 's' | 'm' }>`
         `
     }
   }};
+`
+
+export const SidePaneGlass = styled.div<{ onClick?: MouseEventHandler<HTMLDivElement> }>`
+  display: flex;
+  justify-content: flex-end;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  color: ${Colors.Black[900]};
+  z-index: ${ZIndex.modal};
+
+  ${({ onClick }) =>
+    onClick
+      ? css`
+          background-color: ${Colors.Black[700.85]};
+          ${Animations.showModalBackground};
+        `
+      : css`
+          pointer-events: none;
+          & > ${SidePane} {
+            box-shadow: ${Shadows.common};
+            pointer-events: auto;
+          }
+        `}
 `


### PR DESCRIPTION
Since the search pane also allows to explore categories with each results breadcrumbs, you can now navigate through the all forum with the search result pane open. The overlay disappears once the route changes.

Closes #1326