### PR TITLE
🐫 Multi transaction modals updates

### DIFF
--- a/packages/ui/src/accounts/hooks/useStakingAccountStatus.ts
+++ b/packages/ui/src/accounts/hooks/useStakingAccountStatus.ts
@@ -1,0 +1,31 @@
+import { useApi } from '@/common/hooks/useApi'
+import { useObservable } from '@/common/hooks/useObservable'
+
+type StakingStatus = 'unknown' | 'free' | 'other' | 'candidate' | 'confirmed'
+
+export const useStakingAccountStatus = (address?: string, memberId?: string): StakingStatus => {
+  const { api } = useApi()
+
+  const stakingAccountInfoSize = useObservable(
+    address ? api?.query.members.stakingAccountIdMemberStatus.size(address) : undefined,
+    [api, address]
+  )
+  const stakingAccountInfo = useObservable(
+    address ? api?.query.members.stakingAccountIdMemberStatus(address) : undefined,
+    [api, address]
+  )
+
+  if (!stakingAccountInfoSize || !stakingAccountInfo) {
+    return 'unknown'
+  }
+
+  if (stakingAccountInfoSize.isEmpty) {
+    return 'free'
+  }
+
+  if (!stakingAccountInfo.member_id.eq(parseInt(memberId ?? '-1'))) {
+    return 'other'
+  }
+
+  return stakingAccountInfo.confirmed.isTrue ? 'confirmed' : 'candidate'
+}

--- a/packages/ui/src/proposals/modals/AddNewProposal/AddNewProposalModal.tsx
+++ b/packages/ui/src/proposals/modals/AddNewProposal/AddNewProposalModal.tsx
@@ -85,9 +85,13 @@ export const AddNewProposalModal = () => {
     if (activeMember && api) {
       const txSpecificParameters = getSpecificParameters(api, state as AddNewProposalMachineState)
 
-      return api.tx.proposalsCodex.createProposal(txBaseParams, txSpecificParameters)
+      return api.tx.utility.batch([
+        api.tx.members.confirmStakingAccount(activeMember.id, state?.context?.stakingAccount?.address ?? ''),
+        api.tx.proposalsCodex.createProposal(txBaseParams, txSpecificParameters),
+      ])
     }
   }, [JSON.stringify(txBaseParams), JSON.stringify(state.context.specifics), connectionState])
+
   const feeInfo = useTransactionFee(activeMember?.controllerAccount, transaction)
 
   useEffect((): any => {

--- a/packages/ui/src/proposals/modals/AddNewProposal/AddNewProposalModal.tsx
+++ b/packages/ui/src/proposals/modals/AddNewProposal/AddNewProposalModal.tsx
@@ -22,6 +22,7 @@ import {
 import { camelCaseToText } from '@/common/helpers'
 import { useApi } from '@/common/hooks/useApi'
 import { useModal } from '@/common/hooks/useModal'
+import { useObservable } from '@/common/hooks/useObservable'
 import { getSteps, Step } from '@/common/model/machines/getSteps'
 import { useMember } from '@/memberships/hooks/useMembership'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
@@ -81,9 +82,18 @@ export const AddNewProposalModal = () => {
     ...(state.context.triggerBlock ? { exact_execution_block: state.context.triggerBlock } : {}),
   }
 
+  const stakingAccountInfo = useObservable(
+    state.context.stakingAccount
+      ? api?.query.members.stakingAccountIdMemberStatus(state.context.stakingAccount.address)
+      : undefined,
+    [api, state.context?.stakingAccount?.address]
+  )
+
   const transaction = useMemo(() => {
     if (activeMember && api) {
       const txSpecificParameters = getSpecificParameters(api, state as AddNewProposalMachineState)
+
+      console.log(stakingAccountInfo)
 
       return api.tx.utility.batch([
         api.tx.members.confirmStakingAccount(activeMember.id, state?.context?.stakingAccount?.address ?? ''),
@@ -148,7 +158,7 @@ export const AddNewProposalModal = () => {
       const alreadyBounded = member.boundAccounts.includes(state.context?.stakingAccount.address)
       send(alreadyBounded ? 'BOUNDED' : 'UNBOUNDED')
     }
-  }, [state, member?.id, state.context?.stakingAccount])
+  }, [state, member?.id, state.context?.stakingAccount?.address])
 
   if (!api || !activeMember || !transaction || !feeInfo) {
     return null

--- a/packages/ui/src/proposals/modals/AddNewProposal/AddNewProposalModal.tsx
+++ b/packages/ui/src/proposals/modals/AddNewProposal/AddNewProposalModal.tsx
@@ -93,8 +93,6 @@ export const AddNewProposalModal = () => {
     if (activeMember && api) {
       const txSpecificParameters = getSpecificParameters(api, state as AddNewProposalMachineState)
 
-      console.log(stakingAccountInfo)
-
       return api.tx.utility.batch([
         api.tx.members.confirmStakingAccount(activeMember.id, state?.context?.stakingAccount?.address ?? ''),
         api.tx.proposalsCodex.createProposal(txBaseParams, txSpecificParameters),

--- a/packages/ui/src/proposals/modals/AddNewProposal/AddNewProposalModal.tsx
+++ b/packages/ui/src/proposals/modals/AddNewProposal/AddNewProposalModal.tsx
@@ -154,7 +154,7 @@ export const AddNewProposalModal = () => {
 
   useEffect(() => {
     if (state.matches('beforeTransaction')) {
-      send(stakingStatus === 'free' ? 'REQUIRES_STAKING_CANDIDATE' : 'BOUNDED')
+      send(stakingStatus === 'free' ? 'REQUIRES_STAKING_CANDIDATE' : 'BOUND')
     }
   }, [state, stakingStatus])
 

--- a/packages/ui/src/proposals/modals/AddNewProposal/AddNewProposalModal.tsx
+++ b/packages/ui/src/proposals/modals/AddNewProposal/AddNewProposalModal.tsx
@@ -71,7 +71,7 @@ export const AddNewProposalModal = () => {
     constants?.requiredStake.toNumber() || 0
   )
   const [isValidNext, setValidNext] = useState<boolean>(false)
-  const stakingState = useStakingAccountStatus(state.context.stakingAccount?.address, activeMember?.id)
+  const stakingStatus = useStakingAccountStatus(state.context.stakingAccount?.address, activeMember?.id)
 
   const txBaseParams: BaseProposalParams = {
     member_id: activeMember?.id,
@@ -85,7 +85,7 @@ export const AddNewProposalModal = () => {
     if (activeMember && api) {
       const txSpecificParameters = getSpecificParameters(api, state as AddNewProposalMachineState)
 
-      if (stakingState === 'confirmed') {
+      if (stakingStatus === 'confirmed') {
         return api.tx.proposalsCodex.createProposal(txBaseParams, txSpecificParameters)
       }
 
@@ -94,7 +94,7 @@ export const AddNewProposalModal = () => {
         api.tx.proposalsCodex.createProposal(txBaseParams, txSpecificParameters),
       ])
     }
-  }, [JSON.stringify(txBaseParams), JSON.stringify(state.context.specifics), connectionState, stakingState])
+  }, [JSON.stringify(txBaseParams), JSON.stringify(state.context.specifics), connectionState, stakingStatus])
 
   const feeInfo = useTransactionFee(activeMember?.controllerAccount, transaction)
 
@@ -126,8 +126,8 @@ export const AddNewProposalModal = () => {
     if (
       state.matches('generalParameters.stakingAccount') &&
       state.context.stakingAccount &&
-      stakingState !== 'unknown' &&
-      stakingState !== 'other'
+      stakingStatus !== 'unknown' &&
+      stakingStatus !== 'other'
     ) {
       return setValidNext(true)
     }
@@ -150,13 +150,13 @@ export const AddNewProposalModal = () => {
     }
 
     return setValidNext(false)
-  }, [state, activeMember?.id, stakingState])
+  }, [state, activeMember?.id, stakingStatus])
 
   useEffect(() => {
-    if (state.matches('beforeTransaction') && state.context?.stakingAccount) {
-      send(stakingState === 'free' ? 'REQUIRES_STAKING_CANDIDATE' : 'BOUNDED')
+    if (state.matches('beforeTransaction')) {
+      send(stakingStatus === 'free' ? 'REQUIRES_STAKING_CANDIDATE' : 'BOUNDED')
     }
-  }, [state, state.context?.stakingAccount?.address])
+  }, [state, stakingStatus])
 
   if (!api || !activeMember || !transaction || !feeInfo) {
     return null

--- a/packages/ui/src/proposals/modals/AddNewProposal/machine.ts
+++ b/packages/ui/src/proposals/modals/AddNewProposal/machine.ts
@@ -477,7 +477,7 @@ export const addNewProposalMachine = createMachine<AddNewProposalContext, AddNew
       id: 'beforeTransaction',
       on: {
         BOUNDED: 'transaction',
-        UNBOUNDED: 'transaction',
+        UNBOUNDED: 'bindStakingAccount',
       },
     },
     bindStakingAccount: {

--- a/packages/ui/src/proposals/modals/AddNewProposal/machine.ts
+++ b/packages/ui/src/proposals/modals/AddNewProposal/machine.ts
@@ -166,7 +166,7 @@ export type AddNewProposalEvent =
   | SetRewardPerBlock
   | SetRuntime
   | SetSlashingAmount
-  | { type: 'BOUNDED' }
+  | { type: 'BOUND' }
   | { type: 'REQUIRES_STAKING_CANDIDATE' }
 
 export type AddNewProposalMachineState = State<
@@ -476,7 +476,7 @@ export const addNewProposalMachine = createMachine<AddNewProposalContext, AddNew
     beforeTransaction: {
       id: 'beforeTransaction',
       on: {
-        BOUNDED: 'transaction',
+        BOUND: 'transaction',
         REQUIRES_STAKING_CANDIDATE: 'bindStakingAccount',
       },
     },

--- a/packages/ui/src/proposals/modals/AddNewProposal/machine.ts
+++ b/packages/ui/src/proposals/modals/AddNewProposal/machine.ts
@@ -119,6 +119,7 @@ export type AddNewProposalState =
       value: { specificParameters: { createWorkingGroupLeadOpening: 'stakingPolicyAndReward' } }
       context: StakingPolicyAndRewardContext
     }
+  | { value: 'beforeTransaction'; context: Required<AddNewProposalContext> }
   | { value: 'bindStakingAccount'; context: Required<AddNewProposalContext> }
   | { value: 'transaction'; context: Required<AddNewProposalContext> }
   | { value: 'success'; context: Required<AddNewProposalContext> }
@@ -165,6 +166,8 @@ export type AddNewProposalEvent =
   | SetRewardPerBlock
   | SetRuntime
   | SetSlashingAmount
+  | { type: 'BOUNDED' }
+  | { type: 'UNBOUNDED' }
 
 export type AddNewProposalMachineState = State<
   AddNewProposalContext,
@@ -302,7 +305,7 @@ export const addNewProposalMachine = createMachine<AddNewProposalContext, AddNew
       meta: { isStep: true, stepTitle: 'Specific parameters' },
       on: {
         BACK: 'generalParameters.triggerAndDiscussion',
-        NEXT: 'bindStakingAccount',
+        NEXT: 'beforeTransaction',
       },
       initial: 'entry',
       states: {
@@ -468,6 +471,13 @@ export const addNewProposalMachine = createMachine<AddNewProposalContext, AddNew
             },
           },
         },
+      },
+    },
+    beforeTransaction: {
+      id: 'beforeTransaction',
+      on: {
+        BOUNDED: 'transaction',
+        UNBOUNDED: 'bindStakingAccount',
       },
     },
     bindStakingAccount: {

--- a/packages/ui/src/proposals/modals/AddNewProposal/machine.ts
+++ b/packages/ui/src/proposals/modals/AddNewProposal/machine.ts
@@ -477,7 +477,7 @@ export const addNewProposalMachine = createMachine<AddNewProposalContext, AddNew
       id: 'beforeTransaction',
       on: {
         BOUNDED: 'transaction',
-        UNBOUNDED: 'bindStakingAccount',
+        UNBOUNDED: 'transaction',
       },
     },
     bindStakingAccount: {

--- a/packages/ui/src/proposals/modals/AddNewProposal/machine.ts
+++ b/packages/ui/src/proposals/modals/AddNewProposal/machine.ts
@@ -167,7 +167,7 @@ export type AddNewProposalEvent =
   | SetRuntime
   | SetSlashingAmount
   | { type: 'BOUNDED' }
-  | { type: 'UNBOUNDED' }
+  | { type: 'REQUIRES_STAKING_CANDIDATE' }
 
 export type AddNewProposalMachineState = State<
   AddNewProposalContext,
@@ -477,7 +477,7 @@ export const addNewProposalMachine = createMachine<AddNewProposalContext, AddNew
       id: 'beforeTransaction',
       on: {
         BOUNDED: 'transaction',
-        UNBOUNDED: 'bindStakingAccount',
+        REQUIRES_STAKING_CANDIDATE: 'bindStakingAccount',
       },
     },
     bindStakingAccount: {

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
@@ -14,6 +14,7 @@ import { useApi } from '@/common/hooks/useApi'
 import { useModal } from '@/common/hooks/useModal'
 import { getEventParam, metadataToBytes } from '@/common/model/JoystreamNode'
 import { getSteps } from '@/common/model/machines/getSteps'
+import { useMember } from '@/memberships/hooks/useMembership'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 import { BindStakingAccountModal } from '@/memberships/modals/BindStakingAccountModal/BindStakingAccountModal'
 import { SwitchMemberModalCall } from '@/memberships/modals/SwitchMemberModal'
@@ -37,27 +38,28 @@ const transactionsSteps = [{ title: 'Bind account for staking' }, { title: 'Appl
 
 export const ApplyForRoleModal = () => {
   const { api, connectionState } = useApi()
-  const { active } = useMyMemberships()
+  const { active: activeMember } = useMyMemberships()
+  const { member } = useMember(activeMember?.id)
   const { hideModal, modalData, showModal } = useModal<ApplyForRoleModalCall>()
   const [state, send, service] = useMachine(applyForRoleMachine)
   const opening = modalData.opening
   const requiredStake = opening.stake.toNumber()
   const { hasRequiredStake, transferableAccounts, accountsWithLockedFounds } = useHasRequiredStake(requiredStake)
   const transaction = useMemo(() => {
-    if (active && api) {
+    if (activeMember && api) {
       return getGroup(api, opening.groupName as GroupName)?.applyOnOpening({
-        member_id: active?.id,
+        member_id: activeMember?.id,
         opening_id: opening.runtimeId,
-        role_account_id: active?.controllerAccount,
-        reward_account_id: active?.controllerAccount,
+        role_account_id: activeMember?.controllerAccount,
+        reward_account_id: activeMember?.controllerAccount,
         stake_parameters: {
           stake: opening.stake,
-          staking_account_id: active?.controllerAccount,
+          staking_account_id: activeMember?.controllerAccount,
         },
       })
     }
-  }, [active?.id, connectionState])
-  const feeInfo = useTransactionFee(active?.controllerAccount, transaction)
+  }, [activeMember?.id, connectionState])
+  const feeInfo = useTransactionFee(activeMember?.controllerAccount, transaction)
 
   useEffect(() => {
     if (!state.matches('requirementsVerification')) {
@@ -73,27 +75,38 @@ export const ApplyForRoleModal = () => {
       return
     }
 
-    if (active && feeInfo?.canAfford) {
+    if (activeMember && feeInfo?.canAfford) {
       send('PASS')
       return
     }
 
-    if (!active && hasRequiredStake) {
+    if (!activeMember && hasRequiredStake) {
       showModal<SwitchMemberModalCall>({ modal: 'SwitchMember' })
     }
 
     if (feeInfo && !feeInfo.canAfford) {
       send('FAIL')
     }
-  }, [state.value, active?.id, JSON.stringify(feeInfo), hasRequiredStake])
+  }, [state.value, activeMember?.id, JSON.stringify(feeInfo), hasRequiredStake])
 
-  if (!active || !feeInfo || hasRequiredStake === false) {
+  useEffect(() => {
+    if (state.matches('beforeTransaction') && state.context?.stake.account && member) {
+      const alreadyBounded = member.boundAccounts.includes(state.context?.stake.account.address)
+      send(alreadyBounded ? 'BOUNDED' : 'UNBOUNDED')
+    }
+  }, [state, member?.id, state.context?.stake?.account?.address])
+
+  if (!activeMember || !feeInfo || hasRequiredStake === false) {
     return null
   }
 
   if (state.matches('requirementsFailed')) {
     return (
-      <InsufficientFundsModal onClose={hideModal} address={active.controllerAccount} amount={feeInfo.transactionFee} />
+      <InsufficientFundsModal
+        onClose={hideModal}
+        address={activeMember.controllerAccount}
+        amount={feeInfo.transactionFee}
+      />
     )
   }
 
@@ -111,21 +124,21 @@ export const ApplyForRoleModal = () => {
     const { stake } = state.context
     const stakingAccount = stake.account?.address
 
-    const transaction = api.tx.members.addStakingAccountCandidate(active.id)
+    const transaction = api.tx.members.addStakingAccountCandidate(activeMember.id)
 
     return (
       <BindStakingAccountModal
         onClose={hideModal}
         transaction={transaction}
         signer={stakingAccount}
-        memberId={active.id}
+        memberId={activeMember.id}
         service={bindStakingAccountService}
         steps={transactionsSteps}
       />
     )
   }
 
-  const signer = active?.controllerAccount
+  const signer = activeMember?.controllerAccount
   const transactionService = state.children.transaction
 
   if (state.matches('transaction') && signer && api && transactionService) {
@@ -133,9 +146,9 @@ export const ApplyForRoleModal = () => {
 
     const transaction = getGroup(api, opening.groupName as GroupName)?.applyOnOpening({
       opening_id: opening.runtimeId,
-      member_id: active?.id,
-      role_account_id: active?.controllerAccount,
-      reward_account_id: active?.rootAccount,
+      member_id: activeMember?.id,
+      role_account_id: activeMember?.controllerAccount,
+      reward_account_id: activeMember?.rootAccount,
       description: metadataToBytes(ApplicationMetadata, { answers: Object.values(answers) }),
       stake_parameters: {
         stake: stake.amount,
@@ -143,10 +156,15 @@ export const ApplyForRoleModal = () => {
       },
     })
 
+    const batch = api.tx.utility.batch([
+      transaction,
+      api.tx.members.confirmStakingAccount(activeMember?.id, stake.account.address),
+    ])
+
     return (
       <ApplyForRoleSignModal
         onClose={hideModal}
-        transaction={transaction}
+        transaction={batch}
         signer={signer}
         stake={new BN(state.context.stake.amount)}
         service={transactionService}

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
@@ -161,8 +161,8 @@ export const ApplyForRoleModal = () => {
       transaction = applyOnOpeningTransaction
     } else {
       transaction = api.tx.utility.batch([
-        applyOnOpeningTransaction,
         api.tx.members.confirmStakingAccount(activeMember?.id, stake.account.address),
+        applyOnOpeningTransaction,
       ])
     }
 

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
@@ -93,7 +93,7 @@ export const ApplyForRoleModal = () => {
 
   useEffect(() => {
     if (state.matches('beforeTransaction')) {
-      send(stakingStatus === 'free' ? 'UNBOUNDED' : 'BOUNDED')
+      send(stakingStatus === 'free' ? 'UNBOUND' : 'BOUND')
     }
   }, [state, stakingStatus])
 

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/machine.ts
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/machine.ts
@@ -40,8 +40,8 @@ export type ApplyForRoleEvent =
   | { type: 'PASS' }
   | ValidStakeStepEvent
   | ValidApplicationStepEvent
-  | { type: 'BOUNDED' }
-  | { type: 'UNBOUNDED' }
+  | { type: 'BOUND' }
+  | { type: 'UNBOUND' }
 
 export const applyForRoleMachine = createMachine<ApplyForRoleContext, ApplyForRoleEvent, ApplyForRoleState>({
   initial: 'requirementsVerification',
@@ -78,8 +78,8 @@ export const applyForRoleMachine = createMachine<ApplyForRoleContext, ApplyForRo
     beforeTransaction: {
       id: 'beforeTransaction',
       on: {
-        BOUNDED: 'transaction',
-        UNBOUNDED: 'bindStakingAccount',
+        BOUND: 'transaction',
+        UNBOUND: 'bindStakingAccount',
       },
     },
     bindStakingAccount: {

--- a/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
@@ -537,7 +537,7 @@ describe('UI: AddNewProposalModal', () => {
         })
       })
 
-      describe('Staking account is candidate', () => {
+      describe('Staking account is a candidate', () => {
         beforeEach(async () => {
           stubQuery(
             api,

--- a/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
@@ -73,7 +73,7 @@ describe('UI: AddNewProposalModal', () => {
   }
 
   let useAccounts: UseAccounts
-  let tx: any
+  let batchTx: any
   let bindAccountTx: any
 
   const server = setupMockServer({ noCleanupAfterEach: true })
@@ -94,7 +94,9 @@ describe('UI: AddNewProposalModal', () => {
 
     stubDefaultBalances(api)
     stubProposalConstants(api)
-    tx = stubTransaction(api, 'api.tx.proposalsCodex.createProposal', 25)
+    stubTransaction(api, 'api.tx.proposalsCodex.createProposal', 25)
+    stubTransaction(api, 'api.tx.members.confirmStakingAccount', 25)
+    batchTx = stubTransaction(api, 'api.tx.utility.batch')
     bindAccountTx = stubTransaction(api, 'api.tx.members.addStakingAccountCandidate', 42)
   })
 
@@ -110,7 +112,7 @@ describe('UI: AddNewProposalModal', () => {
     })
 
     it('Insufficient funds', async () => {
-      stubTransaction(api, 'api.tx.proposalsCodex.createProposal', 10000)
+      stubTransaction(api, 'api.tx.utility.batch', 10000)
 
       const { findByText } = renderModal()
 
@@ -502,7 +504,7 @@ describe('UI: AddNewProposalModal', () => {
           stubTransactionSuccess(bindAccountTx, [], 'members', '')
           fireEvent.click(screen.getByText(/^Sign transaction/i))
           stubTransactionSuccess(
-            tx,
+            batchTx,
             ['EventParams', registry.createType('ProposalId', 1337)],
             'proposalsEngine',
             'ProposalCreated'
@@ -516,7 +518,7 @@ describe('UI: AddNewProposalModal', () => {
         it('Create proposal failure', async () => {
           stubTransactionSuccess(bindAccountTx, [], 'members', '')
           fireEvent.click(screen.getByText(/^Sign transaction/i))
-          stubTransactionFailure(tx)
+          stubTransactionFailure(batchTx)
 
           fireEvent.click(await screen.getByText(/^Sign transaction and Create$/i))
 
@@ -545,7 +547,7 @@ describe('UI: AddNewProposalModal', () => {
 
         it('Create proposal success', async () => {
           stubTransactionSuccess(
-            tx,
+            batchTx,
             ['EventParams', registry.createType('ProposalId', 1337)],
             'proposalsEngine',
             'ProposalCreated'
@@ -557,7 +559,7 @@ describe('UI: AddNewProposalModal', () => {
         })
 
         it('Create proposal failure', async () => {
-          stubTransactionFailure(tx)
+          stubTransactionFailure(batchTx)
 
           fireEvent.click(await screen.getByText(/^Sign transaction and Create$/i))
 

--- a/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
@@ -96,11 +96,11 @@ describe('UI: AddNewProposalModal', () => {
     stubProposalConstants(api)
     tx = stubTransaction(api, 'api.tx.proposalsCodex.createProposal', 25)
     bindAccountTx = stubTransaction(api, 'api.tx.members.addStakingAccountCandidate', 42)
-
-    await renderModal()
   })
 
   describe('Requirements', () => {
+    beforeEach(renderModal)
+
     it('No active member', async () => {
       useMyMemberships.active = undefined
 
@@ -119,6 +119,8 @@ describe('UI: AddNewProposalModal', () => {
   })
 
   describe('Warning modal', () => {
+    beforeEach(renderModal)
+
     it('Not checked', async () => {
       const button = await getWarningNextButton()
 
@@ -526,7 +528,7 @@ describe('UI: AddNewProposalModal', () => {
         beforeEach(async () => {
           const member = server.server?.schema.find('Membership', '0') as any
           member.boundAccounts = [alice.address]
-          member.save()
+          await member.save()
 
           await finishWarning()
           await finishProposalType('fundingRequest')
@@ -537,7 +539,7 @@ describe('UI: AddNewProposalModal', () => {
         })
 
         it('Create proposal step', async () => {
-          expect(screen.getByText(/You intend to create a proposa/i)).not.toBeNull()
+          expect(await screen.findByText(/You intend to create a proposa/i)).not.toBeNull()
           expect((await screen.findByText(/^Transaction fee:/i))?.nextSibling?.textContent).toBe('25')
         })
 
@@ -586,6 +588,8 @@ describe('UI: AddNewProposalModal', () => {
   })
 
   async function finishWarning() {
+    await renderModal()
+
     const button = await getWarningNextButton()
 
     const checkbox = await screen.findByRole('checkbox')

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -61,7 +61,7 @@ describe('UI: ApplyForRoleModal', () => {
   }
 
   let useAccounts: UseAccounts
-  let tx: any
+  let batchTx: any
   let bindAccountTx: any
 
   const server = setupMockServer({ noCleanupAfterEach: true })
@@ -88,7 +88,9 @@ describe('UI: ApplyForRoleModal', () => {
     useMyMemberships.setActive(getMember('alice'))
 
     stubDefaultBalances(api)
-    tx = stubTransaction(api, 'api.tx.forumWorkingGroup.applyOnOpening')
+    stubTransaction(api, 'api.tx.forumWorkingGroup.applyOnOpening')
+    stubTransaction(api, 'api.tx.members.confirmStakingAccount')
+    batchTx = stubTransaction(api, 'api.tx.utility.batch')
     bindAccountTx = stubTransaction(api, 'api.tx.members.addStakingAccountCandidate', 42)
   })
 
@@ -113,7 +115,7 @@ describe('UI: ApplyForRoleModal', () => {
     })
 
     it('Insufficient funds', async () => {
-      tx = stubTransaction(api, 'api.tx.forumWorkingGroup.applyOnOpening', 10_000)
+      batchTx = stubTransaction(api, 'api.tx.forumWorkingGroup.applyOnOpening', 10_000)
 
       renderModal()
 
@@ -225,7 +227,7 @@ describe('UI: ApplyForRoleModal', () => {
       it('Apply on opening success', async () => {
         stubTransactionSuccess(bindAccountTx, [], 'members', '')
         stubTransactionSuccess(
-          tx,
+          batchTx,
           ['EventParams', registry.createType('ApplicationId', 1337)],
           'workingGroup',
           'AppliedOnOpening'
@@ -241,9 +243,47 @@ describe('UI: ApplyForRoleModal', () => {
 
       it('Apply on opening failure', async () => {
         stubTransactionSuccess(bindAccountTx, [], 'members', '')
-        stubTransactionFailure(tx)
+        stubTransactionFailure(batchTx)
         await fillSteps()
         fireEvent.click(screen.getByText(/^Sign transaction/i))
+
+        fireEvent.click(screen.getByText(/^Sign transaction/i))
+
+        expect(await screen.findByText('Failure')).toBeDefined()
+      })
+    })
+
+    describe('Staking account is already bounded', () => {
+      beforeEach(async () => {
+        const member = server.server?.schema.find('Membership', '0') as any
+        member.boundAccounts = [alice.address]
+        await member.save()
+      })
+
+      it('Apply on opening step', async () => {
+        await fillSteps()
+
+        expect(await screen.findByText(/You intend to apply for a role/i)).toBeDefined()
+        expect((await screen.findByText(/^Transaction fee:/i))?.nextSibling?.textContent).toBe('25')
+      })
+
+      it('Apply on opening success', async () => {
+        stubTransactionSuccess(
+          batchTx,
+          ['EventParams', registry.createType('ApplicationId', 1337)],
+          'workingGroup',
+          'AppliedOnOpening'
+        )
+        await fillSteps()
+        fireEvent.click(screen.getByText(/^Sign transaction/i))
+
+        expect(await screen.findByText('Application submitted!')).toBeDefined()
+        expect(await screen.findByText(/application id: 1337/i)).toBeDefined()
+      })
+
+      it('Apply on opening failure', async () => {
+        stubTransactionFailure(batchTx)
+        await fillSteps()
 
         fireEvent.click(screen.getByText(/^Sign transaction/i))
 


### PR DESCRIPTION
Closes #1171

This PR adds the real-world handling of the two-step modals (mostly those that require staking). It is not ideal as it has some code duplication for the modal and for the machine as well. However, I thought that it is OK for now as we have only two modals that require staking.

It would be nice that you could verify (for instance for proposals) that this works. I was able to test that using two steps:

*   at a first run, I used an account that was not bounded and I've passed two transactions (staking + proposal creation)
*   for the second check, I've used the same account for bonding (so it was already bounded) so I had only one transaction (proposal creation)