### PR TITLE
🕳 Add Thread/Category Created forum activities

### DIFF
--- a/packages/ui/src/common/components/Activities/ActivityContent.tsx
+++ b/packages/ui/src/common/components/Activities/ActivityContent.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from 'react'
 import { Activity, ActivityCategory, BaseActivity } from '@/common/types/Activity'
 import { PostAddedContent } from '@/forum/components/Activities/PostAddedContent'
 import { PostEditedContent } from '@/forum/components/Activities/PostEditedContent'
+import { ThreadCreatedContent } from '@/forum/components/Activities/ThreadCreatedContent'
 import { ApplicationWithdrawnContent } from '@/working-groups/components/Activities/ApplicationWithdrawnContent'
 import { AppliedOnOpeningContent } from '@/working-groups/components/Activities/AppliedOnOpeningContent'
 import { BudgetSetContent } from '@/working-groups/components/Activities/BudgetSetContent'
@@ -45,6 +46,7 @@ const ActivityMap: Record<ActivityCategory, ActivityContentComponent<any>> = {
   WorkerRewardAmountUpdatedEvent: WorkerRewardAmountUpdatedContent,
   PostAddedEvent: PostAddedContent,
   PostTextUpdatedEvent: PostEditedContent,
+  ThreadCreatedEvent: ThreadCreatedContent,
 }
 
 export const ActivityContent = React.memo(({ activity, isOwn }: { activity: Activity; isOwn?: boolean }) => {

--- a/packages/ui/src/common/components/Activities/ActivityContent.tsx
+++ b/packages/ui/src/common/components/Activities/ActivityContent.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react'
 
 import { Activity, ActivityCategory, BaseActivity } from '@/common/types/Activity'
+import { CategoryCreatedContent } from '@/forum/components/Activities/CategoryCreatedContent'
 import { PostAddedContent } from '@/forum/components/Activities/PostAddedContent'
 import { PostEditedContent } from '@/forum/components/Activities/PostEditedContent'
 import { ThreadCreatedContent } from '@/forum/components/Activities/ThreadCreatedContent'
@@ -47,6 +48,7 @@ const ActivityMap: Record<ActivityCategory, ActivityContentComponent<any>> = {
   PostAddedEvent: PostAddedContent,
   PostTextUpdatedEvent: PostEditedContent,
   ThreadCreatedEvent: ThreadCreatedContent,
+  CategoryCreatedEvent: CategoryCreatedContent,
 }
 
 export const ActivityContent = React.memo(({ activity, isOwn }: { activity: Activity; isOwn?: boolean }) => {

--- a/packages/ui/src/common/components/Activities/ActivityToIconMap.tsx
+++ b/packages/ui/src/common/components/Activities/ActivityToIconMap.tsx
@@ -40,4 +40,5 @@ export const ActivityToIconMap: Record<ActivityCategory, [JSXElementConstructor<
   WorkerRewardAmountUpdatedEvent: [RewardIcon, 'joystream'],
   PostAddedEvent: [CreatedIcon, 'joystream'],
   PostTextUpdatedEvent: [UpcomingIcon, 'joystream'],
+  ThreadCreatedEvent: [CreatedIcon, 'joystream'],
 }

--- a/packages/ui/src/common/components/Activities/ActivityToIconMap.tsx
+++ b/packages/ui/src/common/components/Activities/ActivityToIconMap.tsx
@@ -41,4 +41,5 @@ export const ActivityToIconMap: Record<ActivityCategory, [JSXElementConstructor<
   PostAddedEvent: [CreatedIcon, 'joystream'],
   PostTextUpdatedEvent: [UpcomingIcon, 'joystream'],
   ThreadCreatedEvent: [CreatedIcon, 'joystream'],
+  CategoryCreatedEvent: [CreatedIcon, 'joystream'],
 }

--- a/packages/ui/src/common/types/Activity.ts
+++ b/packages/ui/src/common/types/Activity.ts
@@ -13,3 +13,10 @@ export interface BaseActivity {
 }
 
 export type MemberDisplayFields = Pick<Member, 'id' | 'handle'>
+
+export function asBaseActivity(activity: BaseActivity): BaseActivity {
+  return {
+    id: activity.id,
+    createdAt: activity.createdAt,
+  }
+}

--- a/packages/ui/src/forum/components/Activities/CategoryCreatedContent.tsx
+++ b/packages/ui/src/forum/components/Activities/CategoryCreatedContent.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
+import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
+import { ForumRoutes } from '@/forum/constant'
+import { CategoryCreatedActivity } from '@/forum/types/ForumActivity'
+
+export const CategoryCreatedContent: ActivityContentComponent<CategoryCreatedActivity> = ({ activity }) => {
+  return activity.parentCategory ? (
+    <>
+      Category{' '}
+      <ActivityRouterLink to={`${ForumRoutes.category}/${activity.category.id}`}>
+        {activity.category.title}
+      </ActivityRouterLink>{' '}
+      has been created in{' '}
+      <ActivityRouterLink to={`${ForumRoutes.category}/${activity.parentCategory.id}`}>
+        {activity.parentCategory.title}
+      </ActivityRouterLink>
+      .
+    </>
+  ) : (
+    <>
+      Category{' '}
+      <ActivityRouterLink to={`${ForumRoutes.category}/${activity.category.id}`}>
+        {activity.category.title}
+      </ActivityRouterLink>{' '}
+      has been created.
+    </>
+  )
+}

--- a/packages/ui/src/forum/components/Activities/ThreadCreatedContent.tsx
+++ b/packages/ui/src/forum/components/Activities/ThreadCreatedContent.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import { ActivityContentComponent } from '@/common/components/Activities/ActivityContent'
+import { ActivityRouterLink } from '@/common/components/Activities/ActivityRouterLink'
+import { ForumRoutes } from '@/forum/constant'
+import { ThreadCreatedActivity } from '@/forum/types/ForumActivity'
+import { MemberModalLink } from '@/memberships/components/MemberModalLink'
+
+export const ThreadCreatedContent: ActivityContentComponent<ThreadCreatedActivity> = ({ activity }) => (
+  <>
+    <MemberModalLink call={{ modal: 'Member', data: { id: activity.author.id } }}>
+      {activity.author.handle}
+    </MemberModalLink>{' '}
+    has created a thread "
+    <ActivityRouterLink to={`${ForumRoutes.thread}/${activity.thread.id}`}>{activity.thread.title}</ActivityRouterLink>
+    ".
+  </>
+)

--- a/packages/ui/src/forum/hooks/useForumActivities.ts
+++ b/packages/ui/src/forum/hooks/useForumActivities.ts
@@ -1,5 +1,5 @@
 import { useGetForumEventsQuery } from '../queries/__generated__/forumEvents.generated'
-import { asPostActivity, asThreadCreatedActivity } from '../types/ForumActivity'
+import { asCategoryCreatedActivity, asPostActivity, asThreadCreatedActivity } from '../types/ForumActivity'
 
 export const useForumActivities = () => {
   const { loading, data } = useGetForumEventsQuery()
@@ -8,7 +8,8 @@ export const useForumActivities = () => {
         ...data.postAddedEvents.map(asPostActivity),
         ...data.postTextUpdatedEvents.map(asPostActivity),
         ...data.threadCreatedEvents.map(asThreadCreatedActivity),
-      ]
+        ...data.categoryCreatedEvents.map(asCategoryCreatedActivity),
+      ].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
     : []
 
   return { isLoading: loading, activities }

--- a/packages/ui/src/forum/hooks/useForumActivities.ts
+++ b/packages/ui/src/forum/hooks/useForumActivities.ts
@@ -1,10 +1,14 @@
 import { useGetForumEventsQuery } from '../queries/__generated__/forumEvents.generated'
-import { asPostActivity } from '../types/ForumActivity'
+import { asPostActivity, asThreadCreatedActivity } from '../types/ForumActivity'
 
 export const useForumActivities = () => {
   const { loading, data } = useGetForumEventsQuery()
   const activities = data
-    ? [...data.postAddedEvents.map(asPostActivity), ...data.postTextUpdatedEvents.map(asPostActivity)]
+    ? [
+        ...data.postAddedEvents.map(asPostActivity),
+        ...data.postTextUpdatedEvents.map(asPostActivity),
+        ...data.threadCreatedEvents.map(asThreadCreatedActivity),
+      ]
     : []
 
   return { isLoading: loading, activities }

--- a/packages/ui/src/forum/queries/__generated__/forumEvents.generated.tsx
+++ b/packages/ui/src/forum/queries/__generated__/forumEvents.generated.tsx
@@ -39,6 +39,18 @@ export type ThreadCreatedEventFieldsFragment = {
   }
 }
 
+export type CategoryCreatedEventFieldsFragment = {
+  __typename: 'CategoryCreatedEvent'
+  id: string
+  createdAt: any
+  category: {
+    __typename: 'ForumCategory'
+    id: string
+    title: string
+    parent?: Types.Maybe<{ __typename: 'ForumCategory'; id: string; title: string }>
+  }
+}
+
 export type GetForumEventsQueryVariables = Types.Exact<{ [key: string]: never }>
 
 export type GetForumEventsQuery = {
@@ -46,6 +58,7 @@ export type GetForumEventsQuery = {
   postAddedEvents: Array<{ __typename: 'PostAddedEvent' } & PostAddedEventFieldsFragment>
   postTextUpdatedEvents: Array<{ __typename: 'PostTextUpdatedEvent' } & PostTextUpdatedEventFieldsFragment>
   threadCreatedEvents: Array<{ __typename: 'ThreadCreatedEvent' } & ThreadCreatedEventFieldsFragment>
+  categoryCreatedEvents: Array<{ __typename: 'CategoryCreatedEvent' } & CategoryCreatedEventFieldsFragment>
 }
 
 export const PostAddedEventFieldsFragmentDoc = gql`
@@ -94,6 +107,20 @@ export const ThreadCreatedEventFieldsFragmentDoc = gql`
     }
   }
 `
+export const CategoryCreatedEventFieldsFragmentDoc = gql`
+  fragment CategoryCreatedEventFields on CategoryCreatedEvent {
+    id
+    createdAt
+    category {
+      id
+      title
+      parent {
+        id
+        title
+      }
+    }
+  }
+`
 export const GetForumEventsDocument = gql`
   query GetForumEvents {
     postAddedEvents(orderBy: createdAt_DESC, limit: 10) {
@@ -102,13 +129,17 @@ export const GetForumEventsDocument = gql`
     postTextUpdatedEvents(orderBy: createdAt_DESC, limit: 10) {
       ...PostTextUpdatedEventFields
     }
-    threadCreatedEvents(orderBy: createdAt_DESC, limit: 10) {
+    threadCreatedEvents(orderBy: createdAt_DESC, limit: 5) {
       ...ThreadCreatedEventFields
+    }
+    categoryCreatedEvents(orderBy: createdAt_DESC, limit: 5) {
+      ...CategoryCreatedEventFields
     }
   }
   ${PostAddedEventFieldsFragmentDoc}
   ${PostTextUpdatedEventFieldsFragmentDoc}
   ${ThreadCreatedEventFieldsFragmentDoc}
+  ${CategoryCreatedEventFieldsFragmentDoc}
 `
 
 /**

--- a/packages/ui/src/forum/queries/__generated__/forumEvents.generated.tsx
+++ b/packages/ui/src/forum/queries/__generated__/forumEvents.generated.tsx
@@ -31,7 +31,12 @@ export type ThreadCreatedEventFieldsFragment = {
   __typename: 'ThreadCreatedEvent'
   id: string
   createdAt: any
-  thread: { __typename: 'ForumThread'; id: string; title: string }
+  thread: {
+    __typename: 'ForumThread'
+    id: string
+    title: string
+    author: { __typename: 'Membership'; id: string; handle: string }
+  }
 }
 
 export type GetForumEventsQueryVariables = Types.Exact<{ [key: string]: never }>
@@ -82,6 +87,10 @@ export const ThreadCreatedEventFieldsFragmentDoc = gql`
     thread {
       id
       title
+      author {
+        id
+        handle
+      }
     }
   }
 `

--- a/packages/ui/src/forum/queries/__generated__/forumEvents.generated.tsx
+++ b/packages/ui/src/forum/queries/__generated__/forumEvents.generated.tsx
@@ -27,12 +27,20 @@ export type PostTextUpdatedEventFieldsFragment = {
   }
 }
 
+export type ThreadCreatedEventFieldsFragment = {
+  __typename: 'ThreadCreatedEvent'
+  id: string
+  createdAt: any
+  thread: { __typename: 'ForumThread'; id: string; title: string }
+}
+
 export type GetForumEventsQueryVariables = Types.Exact<{ [key: string]: never }>
 
 export type GetForumEventsQuery = {
   __typename: 'Query'
   postAddedEvents: Array<{ __typename: 'PostAddedEvent' } & PostAddedEventFieldsFragment>
   postTextUpdatedEvents: Array<{ __typename: 'PostTextUpdatedEvent' } & PostTextUpdatedEventFieldsFragment>
+  threadCreatedEvents: Array<{ __typename: 'ThreadCreatedEvent' } & ThreadCreatedEventFieldsFragment>
 }
 
 export const PostAddedEventFieldsFragmentDoc = gql`
@@ -67,6 +75,16 @@ export const PostTextUpdatedEventFieldsFragmentDoc = gql`
     }
   }
 `
+export const ThreadCreatedEventFieldsFragmentDoc = gql`
+  fragment ThreadCreatedEventFields on ThreadCreatedEvent {
+    id
+    createdAt
+    thread {
+      id
+      title
+    }
+  }
+`
 export const GetForumEventsDocument = gql`
   query GetForumEvents {
     postAddedEvents(orderBy: createdAt_DESC, limit: 10) {
@@ -75,9 +93,13 @@ export const GetForumEventsDocument = gql`
     postTextUpdatedEvents(orderBy: createdAt_DESC, limit: 10) {
       ...PostTextUpdatedEventFields
     }
+    threadCreatedEvents(orderBy: createdAt_DESC, limit: 10) {
+      ...ThreadCreatedEventFields
+    }
   }
   ${PostAddedEventFieldsFragmentDoc}
   ${PostTextUpdatedEventFieldsFragmentDoc}
+  ${ThreadCreatedEventFieldsFragmentDoc}
 `
 
 /**

--- a/packages/ui/src/forum/queries/forumEvents.graphql
+++ b/packages/ui/src/forum/queries/forumEvents.graphql
@@ -28,11 +28,23 @@ fragment PostTextUpdatedEventFields on PostTextUpdatedEvent {
   }
 }
 
+fragment ThreadCreatedEventFields on ThreadCreatedEvent {
+  id
+  createdAt
+  thread {
+    id
+    title
+  }
+}
+
 query GetForumEvents {
   postAddedEvents(orderBy: createdAt_DESC, limit: 10) {
     ...PostAddedEventFields
   }
   postTextUpdatedEvents(orderBy: createdAt_DESC, limit: 10) {
     ...PostTextUpdatedEventFields
+  }
+  threadCreatedEvents(orderBy: createdAt_DESC, limit: 10) {
+    ...ThreadCreatedEventFields
   }
 }

--- a/packages/ui/src/forum/queries/forumEvents.graphql
+++ b/packages/ui/src/forum/queries/forumEvents.graphql
@@ -34,6 +34,10 @@ fragment ThreadCreatedEventFields on ThreadCreatedEvent {
   thread {
     id
     title
+    author {
+      id
+      handle
+    }
   }
 }
 

--- a/packages/ui/src/forum/queries/forumEvents.graphql
+++ b/packages/ui/src/forum/queries/forumEvents.graphql
@@ -41,6 +41,19 @@ fragment ThreadCreatedEventFields on ThreadCreatedEvent {
   }
 }
 
+fragment CategoryCreatedEventFields on CategoryCreatedEvent {
+  id
+  createdAt
+  category {
+    id
+    title
+    parent {
+      id
+      title
+    }
+  }
+}
+
 query GetForumEvents {
   postAddedEvents(orderBy: createdAt_DESC, limit: 10) {
     ...PostAddedEventFields
@@ -48,7 +61,10 @@ query GetForumEvents {
   postTextUpdatedEvents(orderBy: createdAt_DESC, limit: 10) {
     ...PostTextUpdatedEventFields
   }
-  threadCreatedEvents(orderBy: createdAt_DESC, limit: 10) {
+  threadCreatedEvents(orderBy: createdAt_DESC, limit: 5) {
     ...ThreadCreatedEventFields
+  }
+  categoryCreatedEvents(orderBy: createdAt_DESC, limit: 5) {
+    ...CategoryCreatedEventFields
   }
 }

--- a/packages/ui/src/forum/types/ForumActivity/casts.ts
+++ b/packages/ui/src/forum/types/ForumActivity/casts.ts
@@ -1,9 +1,11 @@
+import { asBaseActivity } from '@/common/types'
 import {
   PostAddedEventFieldsFragment,
   PostTextUpdatedEventFieldsFragment,
+  ThreadCreatedEventFieldsFragment,
 } from '@/forum/queries/__generated__/forumEvents.generated'
 
-import { PostAddedActivity, PostEditedActivity } from './types'
+import { PostAddedActivity, PostEditedActivity, ThreadCreatedActivity } from './types'
 
 export function asPostActivity(
   fields: PostAddedEventFieldsFragment | PostTextUpdatedEventFieldsFragment
@@ -18,5 +20,17 @@ export function asPostActivity(
       id: fields.post.author.id,
       handle: fields.post.author.handle,
     },
+  }
+}
+
+export function asThreadCreatedActivity(fields: ThreadCreatedEventFieldsFragment): ThreadCreatedActivity {
+  return {
+    eventType: fields.__typename,
+    ...asBaseActivity(fields),
+    thread: {
+      id: fields.thread.id,
+      title: fields.thread.title,
+    },
+    author: fields.thread.author,
   }
 }

--- a/packages/ui/src/forum/types/ForumActivity/casts.ts
+++ b/packages/ui/src/forum/types/ForumActivity/casts.ts
@@ -1,11 +1,12 @@
 import { asBaseActivity } from '@/common/types'
 import {
+  CategoryCreatedEventFieldsFragment,
   PostAddedEventFieldsFragment,
   PostTextUpdatedEventFieldsFragment,
   ThreadCreatedEventFieldsFragment,
 } from '@/forum/queries/__generated__/forumEvents.generated'
 
-import { PostAddedActivity, PostEditedActivity, ThreadCreatedActivity } from './types'
+import { CategoryCreatedActivity, PostAddedActivity, PostEditedActivity, ThreadCreatedActivity } from './types'
 
 export function asPostActivity(
   fields: PostAddedEventFieldsFragment | PostTextUpdatedEventFieldsFragment
@@ -32,5 +33,17 @@ export function asThreadCreatedActivity(fields: ThreadCreatedEventFieldsFragment
       title: fields.thread.title,
     },
     author: fields.thread.author,
+  }
+}
+
+export function asCategoryCreatedActivity(fields: CategoryCreatedEventFieldsFragment): CategoryCreatedActivity {
+  return {
+    eventType: fields.__typename,
+    ...asBaseActivity(fields),
+    category: {
+      id: fields.category.id,
+      title: fields.category.title,
+    },
+    parentCategory: fields.category.parent ? fields.category.parent : undefined,
   }
 }

--- a/packages/ui/src/forum/types/ForumActivity/types.ts
+++ b/packages/ui/src/forum/types/ForumActivity/types.ts
@@ -1,6 +1,6 @@
 import { BaseActivity, MemberDisplayFields } from '@/common/types'
 
-export type ForumActivity = PostAddedActivity | PostEditedActivity | ThreadCreatedActivity
+export type ForumActivity = PostAddedActivity | PostEditedActivity | ThreadCreatedActivity | CategoryCreatedActivity
 
 interface PostActivity extends BaseActivity {
   postId: string
@@ -23,4 +23,16 @@ export interface ThreadCreatedActivity extends BaseActivity {
     title: string
   }
   author: MemberDisplayFields
+}
+
+export interface CategoryCreatedActivity extends BaseActivity {
+  eventType: 'CategoryCreatedEvent'
+  category: {
+    id: string
+    title: string
+  }
+  parentCategory?: {
+    id: string
+    title: string
+  }
 }

--- a/packages/ui/src/forum/types/ForumActivity/types.ts
+++ b/packages/ui/src/forum/types/ForumActivity/types.ts
@@ -1,6 +1,6 @@
 import { BaseActivity, MemberDisplayFields } from '@/common/types'
 
-export type ForumActivity = PostAddedActivity | PostEditedActivity
+export type ForumActivity = PostAddedActivity | PostEditedActivity | ThreadCreatedActivity
 
 interface PostActivity extends BaseActivity {
   postId: string
@@ -14,4 +14,13 @@ export interface PostAddedActivity extends PostActivity {
 
 export interface PostEditedActivity extends PostActivity {
   eventType: 'PostTextUpdatedEvent'
+}
+
+export interface ThreadCreatedActivity extends BaseActivity {
+  eventType: 'ThreadCreatedEvent'
+  thread: {
+    id: string
+    title: string
+  }
+  author: MemberDisplayFields
 }


### PR DESCRIPTION
Just two activities for forum. Without mocks, since they can now be witnessed on testnet.
There are a bunch more activities designed, but I'm kinda skeptical as to whether users would want to see them/ have some of their actions announced (like deleting a post). I think Proposals still use a mocked hook for activities, so I'll take a look at that in the meantime.