### PR TITLE
🥴 Handle actions on success and canceled/failed post editing

### DIFF
--- a/packages/ui/src/common/components/CKEditor/CKEditor.tsx
+++ b/packages/ui/src/common/components/CKEditor/CKEditor.tsx
@@ -1,5 +1,5 @@
 import { useApolloClient } from '@apollo/client'
-import React, { useCallback, useEffect, useRef } from 'react'
+import React, { Ref, RefObject, useCallback, useEffect, useRef } from 'react'
 
 import { debounce } from '@/common/utils'
 import { SearchMembersDocument, SearchMembersQuery, SearchMembersQueryVariables } from '@/memberships/queries'
@@ -18,103 +18,106 @@ export interface CKEditorProps {
   inline?: boolean
 }
 
-export const CKEditor = ({ disabled, onBlur, onChange, onFocus, onReady, inline }: CKEditorProps) => {
-  const ref = useRef<HTMLDivElement | null>(null)
-  const editorRef = useRef<Editor | null>(null)
+export const CKEditor = React.forwardRef(
+  ({ disabled, onBlur, onChange, onFocus, onReady, inline }: CKEditorProps, ref?: Ref<HTMLDivElement>) => {
+    const localRef = useRef<HTMLDivElement>(null)
+    const elementRef: RefObject<HTMLDivElement> = (ref || localRef) as RefObject<HTMLDivElement>
+    const editorRef = useRef<Editor | null>(null)
 
-  useEffect(() => {
-    if (!editorRef.current) {
-      return
-    }
+    useEffect(() => {
+      if (!editorRef.current) {
+        return
+      }
 
-    editorRef.current.isReadOnly = !!disabled
-  }, [disabled])
+      editorRef.current.isReadOnly = !!disabled
+    }, [disabled])
 
-  const client = useApolloClient()
-  const mentionFeed = useCallback(
-    debounce(async (text: string) => {
-      const { data } = await client.query<SearchMembersQuery, SearchMembersQueryVariables>({
-        query: SearchMembersDocument,
-        variables: { text, limit: 10 },
-      })
-      return data.memberships.map(({ id, handle }) => ({ id: `@${handle}`, memberId: id }))
-    }),
-    [client]
-  )
+    const client = useApolloClient()
+    const mentionFeed = useCallback(
+      debounce(async (text: string) => {
+        const { data } = await client.query<SearchMembersQuery, SearchMembersQueryVariables>({
+          query: SearchMembersDocument,
+          variables: { text, limit: 10 },
+        })
+        return data.memberships.map(({ id, handle }) => ({ id: `@${handle}`, memberId: id }))
+      }),
+      [client]
+    )
 
-  useEffect(() => {
-    const createPromise: Promise<Editor> = (inline ? InlineMarkdownEditor : MarkdownEditor)
-      .create(ref.current || '', {
-        toolbar: {
-          items: [
-            'heading',
-            '|',
-            'bold',
-            'italic',
-            'link',
-            'strikethrough',
-            '|',
-            'bulletedList',
-            'numberedList',
-            'outdent',
-            'indent',
-            '|',
-            'uploadImage',
-            'blockQuote',
-            'undo',
-            'redo',
-          ],
-        },
-        mention: {
-          feeds: [{ marker: '@', feed: mentionFeed, minimumCharacters: 1 }],
-        },
-        image: {
-          toolbar: ['imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative'],
-        },
-        // This value must be kept in sync with the language defined in webpack.config.js.
-        language: 'en',
-      })
-      .then((editor) => {
-        if (onReady) {
-          onReady(editor)
-        }
-
-        editorRef.current = editor
-        editor.isReadOnly = disabled ?? false
-
-        const modelDocument = editor.model.document
-        const viewDocument = editor.editing.view.document
-
-        modelDocument.on('change:data', (event: EventInfo) => {
-          if (onChange) {
-            onChange(event, editor)
+    useEffect(() => {
+      const createPromise: Promise<Editor> = (inline ? InlineMarkdownEditor : MarkdownEditor)
+        .create(elementRef.current || '', {
+          toolbar: {
+            items: [
+              'heading',
+              '|',
+              'bold',
+              'italic',
+              'link',
+              'strikethrough',
+              '|',
+              'bulletedList',
+              'numberedList',
+              'outdent',
+              'indent',
+              '|',
+              'uploadImage',
+              'blockQuote',
+              'undo',
+              'redo',
+            ],
+          },
+          mention: {
+            feeds: [{ marker: '@', feed: mentionFeed, minimumCharacters: 1 }],
+          },
+          image: {
+            toolbar: ['imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative'],
+          },
+          // This value must be kept in sync with the language defined in webpack.config.js.
+          language: 'en',
+        })
+        .then((editor) => {
+          if (onReady) {
+            onReady(editor)
           }
+
+          editorRef.current = editor
+          editor.isReadOnly = disabled ?? false
+
+          const modelDocument = editor.model.document
+          const viewDocument = editor.editing.view.document
+
+          modelDocument.on('change:data', (event: EventInfo) => {
+            if (onChange) {
+              onChange(event, editor)
+            }
+          })
+
+          viewDocument.on('focus', (event: EventInfo) => {
+            if (onFocus) {
+              onFocus(event, editor)
+            }
+          })
+
+          viewDocument.on('blur', (event: EventInfo) => {
+            if (onBlur) {
+              onBlur(event, editor)
+            }
+          })
+
+          return editor
         })
 
-        viewDocument.on('focus', (event: EventInfo) => {
-          if (onFocus) {
-            onFocus(event, editor)
-          }
-        })
+      return () => {
+        createPromise.then((editor) => editor.destroy())
+      }
+    }, [elementRef.current])
 
-        viewDocument.on('blur', (event: EventInfo) => {
-          if (onBlur) {
-            onBlur(event, editor)
-          }
-        })
-
-        return editor
-      })
-
-    return () => {
-      createPromise.then((editor) => editor.destroy())
-    }
-  }, [ref.current])
-
-  return (
-    <>
-      <CKEditorStylesOverrides />
-      <div ref={ref} />
-    </>
-  )
-}
+    return (
+      <>
+        <CKEditorStylesOverrides />
+        <div ref={elementRef} />
+      </>
+    )
+  }
+)

--- a/packages/ui/src/forum/components/PostList/PostEditor.tsx
+++ b/packages/ui/src/forum/components/PostList/PostEditor.tsx
@@ -1,5 +1,5 @@
 import { createType } from '@joystream/types'
-import React, { ForwardedRef, MutableRefObject, Ref, useCallback, useMemo, useRef, useState } from 'react'
+import React, { MutableRefObject, Ref, useCallback, useMemo, useRef, useState } from 'react'
 
 import { ButtonGhost, ButtonPrimary, ButtonsGroup } from '@/common/components/buttons'
 import { CKEditor } from '@/common/components/CKEditor'

--- a/packages/ui/src/forum/components/PostList/PostEditor.tsx
+++ b/packages/ui/src/forum/components/PostList/PostEditor.tsx
@@ -16,9 +16,10 @@ interface Props {
   post: ForumPost
   onCancel: () => void
   type: PostListItemType
+  onSuccessfulEdit: (newText: string) => void
 }
 
-export const PostEditor = ({ post, onCancel, type }: Props) => {
+export const PostEditor = ({ post, onCancel, type, onSuccessfulEdit }: Props) => {
   const { api, connectionState } = useApi()
   const [newText, setNewText] = useState(post.text)
   const { showModal } = useModal()
@@ -64,6 +65,7 @@ export const PostEditor = ({ post, onCancel, type }: Props) => {
                 postText: newText,
                 replyTo: post.repliesTo,
                 transaction: getEditPostTransaction(newText),
+                onSuccessfulEdit,
               },
             })
           }

--- a/packages/ui/src/forum/components/Thread/NewThreadPost.tsx
+++ b/packages/ui/src/forum/components/Thread/NewThreadPost.tsx
@@ -50,7 +50,7 @@ export const NewThreadPost = React.forwardRef(
                 </Badge>
               </div>
               <div>
-                <ButtonPrimary size="small" onClick={removeReply}>
+                <ButtonPrimary size="small" square onClick={removeReply}>
                   <CrossIcon />
                 </ButtonPrimary>
               </div>

--- a/packages/ui/src/forum/modals/PostActionModal/DeletePostModal/DeletePostModal.tsx
+++ b/packages/ui/src/forum/modals/PostActionModal/DeletePostModal/DeletePostModal.tsx
@@ -48,6 +48,7 @@ export const DeletePostModal = () => {
     const controllerAccount = accountOrNamed(allAccounts, post.author.controllerAccount, 'Controller Account')
     return (
       <PostActionSignModal
+        onClose={hideModal}
         transaction={transaction}
         service={service}
         controllerAccount={controllerAccount}

--- a/packages/ui/src/forum/modals/PostActionModal/EditPostModal/EditPostModal.tsx
+++ b/packages/ui/src/forum/modals/PostActionModal/EditPostModal/EditPostModal.tsx
@@ -1,5 +1,5 @@
 import { useMachine } from '@xstate/react'
-import React, { useCallback, useEffect } from 'react'
+import React, { useEffect } from 'react'
 
 import { useMyAccounts } from '@/accounts/hooks/useMyAccounts'
 import { useTransactionFee } from '@/accounts/hooks/useTransactionFee'

--- a/packages/ui/src/forum/modals/PostActionModal/EditPostModal/EditPostModal.tsx
+++ b/packages/ui/src/forum/modals/PostActionModal/EditPostModal/EditPostModal.tsx
@@ -18,7 +18,7 @@ import { EditPostModalCall } from '.'
 
 export const EditPostModal = () => {
   const {
-    modalData: { postAuthor, postText, replyTo, transaction },
+    modalData: { postAuthor, postText, replyTo, transaction, onSuccessfulEdit },
     hideModal,
   } = useModal<EditPostModalCall>()
 
@@ -30,6 +30,10 @@ export const EditPostModal = () => {
   const feeInfo = useTransactionFee(active?.controllerAccount, transaction)
 
   useEffect(() => {
+    if (state.matches('success')) {
+      onSuccessfulEdit(postText)
+    }
+
     if (!state.matches('requirementsVerification')) {
       return
     }

--- a/packages/ui/src/forum/modals/PostActionModal/EditPostModal/index.ts
+++ b/packages/ui/src/forum/modals/PostActionModal/EditPostModal/index.ts
@@ -13,5 +13,6 @@ export type EditPostModalCall = ModalWithDataCall<
     postText: string
     replyTo?: ForumPost
     transaction?: SubmittableExtrinsic<'rxjs', ISubmittableResult>
+    onSuccessfulEdit: (newText: string) => void
   }
 >

--- a/packages/ui/src/forum/modals/PostActionModal/EditPostModal/index.ts
+++ b/packages/ui/src/forum/modals/PostActionModal/EditPostModal/index.ts
@@ -14,5 +14,6 @@ export type EditPostModalCall = ModalWithDataCall<
     replyTo?: ForumPost
     transaction?: SubmittableExtrinsic<'rxjs', ISubmittableResult>
     onSuccessfulEdit: (newText: string) => void
+    onFailedEdit: () => void
   }
 >

--- a/packages/ui/src/forum/modals/PostActionModal/PostActionSignModal.tsx
+++ b/packages/ui/src/forum/modals/PostActionModal/PostActionSignModal.tsx
@@ -14,7 +14,6 @@ import { ModalBody, ModalFooter, TransactionInfoContainer } from '@/common/compo
 import { RowGapBlock } from '@/common/components/page/PageContent'
 import { TransactionInfo } from '@/common/components/TransactionInfo'
 import { TextMedium, TokenValue } from '@/common/components/typography'
-import { useModal } from '@/common/hooks/useModal'
 import { useSignAndSendTransaction } from '@/common/hooks/useSignAndSendTransaction'
 import { TransactionModal } from '@/common/modals/TransactionModal'
 import { PreviewPostButton } from '@/forum/components/PreviewPostButton'

--- a/packages/ui/src/forum/modals/PostActionModal/PostActionSignModal.tsx
+++ b/packages/ui/src/forum/modals/PostActionModal/PostActionSignModal.tsx
@@ -22,6 +22,7 @@ import { ForumPost } from '@/forum/types'
 import { Member } from '@/memberships/types'
 
 interface PostActionSignModalCommonProps {
+  onClose: () => void
   transaction: SubmittableExtrinsic<'rxjs', ISubmittableResult>
   service: ActorRef<any>
   controllerAccount: Account
@@ -57,8 +58,8 @@ export const PostActionSignModal = ({
   author,
   newText,
   replyTo,
+  onClose,
 }: PostActionSignModalProps) => {
-  const { hideModal } = useModal()
   const { paymentInfo } = useSignAndSendTransaction({ transaction, signer: controllerAccount.address, service })
   const [state, send] = useActor(service)
   const balance = useBalance(controllerAccount.address)
@@ -73,7 +74,7 @@ export const PostActionSignModal = ({
 
   return (
     <>
-      <TransactionModal onClose={hideModal} service={service}>
+      <TransactionModal onClose={onClose} service={service}>
         <ModalBody>
           <RowGapBlock gap={24}>
             <RowGapBlock gap={16}>

--- a/packages/ui/test/forum/components/PostEditor.test.tsx
+++ b/packages/ui/test/forum/components/PostEditor.test.tsx
@@ -59,7 +59,7 @@ describe('UI: PostEditor', () => {
         <MockQueryNodeProviders>
           <MockKeyringProvider>
             <ApiContext.Provider value={api}>
-              <PostEditor post={post} onCancel={() => null} type="forum" />
+              <PostEditor post={post} onCancel={() => null} onSuccessfulEdit={() => true} type="forum" />
             </ApiContext.Provider>
           </MockKeyringProvider>
         </MockQueryNodeProviders>

--- a/packages/ui/test/forum/modals/EditPostModal.test.tsx
+++ b/packages/ui/test/forum/modals/EditPostModal.test.tsx
@@ -38,6 +38,7 @@ describe('UI: EditPostModal', () => {
     postText: 'Lorem ipsum',
     transaction: api.api.tx.forum.editPostText(1, 1, 1, 1, ''),
     onSuccessfulEdit: () => true,
+    onFailedEdit: () => true,
   }
 
   const useModal: UseModal<any> = {

--- a/packages/ui/test/forum/modals/EditPostModal.test.tsx
+++ b/packages/ui/test/forum/modals/EditPostModal.test.tsx
@@ -37,6 +37,7 @@ describe('UI: EditPostModal', () => {
     postAuthor: getMember('alice'),
     postText: 'Lorem ipsum',
     transaction: api.api.tx.forum.editPostText(1, 1, 1, 1, ''),
+    onSuccessfulEdit: () => true,
   }
 
   const useModal: UseModal<any> = {


### PR DESCRIPTION
See #1465

Alright, it was pretty hard to make perfect UX. 

I've come up with these solutions:
1) On success - we update text and time of post
2) On error or on canceling modal - we focus user back to inline editor. Previously it was looking really weird.

Regarding 2nd point - that was the big fight against react ref types. But it works nice as I think