### PR TITLE
🦵 Set discussion mode when creating a proposal

### DIFF
--- a/packages/ui/src/proposals/modals/ChangeThreadMode/SignTransactionModal.tsx
+++ b/packages/ui/src/proposals/modals/ChangeThreadMode/SignTransactionModal.tsx
@@ -1,6 +1,5 @@
 import { SubmittableExtrinsic } from '@polkadot/api/types'
 import { ISubmittableResult } from '@polkadot/types/types'
-import BN from 'bn.js'
 import React, { useEffect, useState } from 'react'
 import { ActorRef } from 'xstate'
 
@@ -61,7 +60,7 @@ export const SignTransactionModal = ({ onClose, transaction, signer, service, st
           />
         </TransactionInfoContainer>
         <ButtonPrimary size="medium" onClick={sign} disabled={signDisabled}>
-          Sign transaction and Create
+          Sign transaction and change mode
         </ButtonPrimary>
       </ModalFooter>
     </TransactionModal>

--- a/packages/ui/src/proposals/modals/ChangeThreadMode/SignTransactionModal.tsx
+++ b/packages/ui/src/proposals/modals/ChangeThreadMode/SignTransactionModal.tsx
@@ -1,0 +1,69 @@
+import { SubmittableExtrinsic } from '@polkadot/api/types'
+import { ISubmittableResult } from '@polkadot/types/types'
+import BN from 'bn.js'
+import React, { useEffect, useState } from 'react'
+import { ActorRef } from 'xstate'
+
+import { SelectedAccount } from '@/accounts/components/SelectAccount'
+import { useBalance } from '@/accounts/hooks/useBalance'
+import { useMyAccounts } from '@/accounts/hooks/useMyAccounts'
+import { accountOrNamed } from '@/accounts/model/accountOrNamed'
+import { ButtonPrimary } from '@/common/components/buttons'
+import { ModalBody, ModalFooter, Row, TransactionInfoContainer } from '@/common/components/Modal'
+import { TransactionInfo } from '@/common/components/TransactionInfo'
+import { TextMedium, TokenValue } from '@/common/components/typography'
+import { useSignAndSendTransaction } from '@/common/hooks/useSignAndSendTransaction'
+import { TransactionModal, TransactionStep } from '@/common/modals/TransactionModal'
+import { Address } from '@/common/types'
+
+interface SignTransactionModalProps {
+  onClose: () => void
+  transaction: SubmittableExtrinsic<'rxjs', ISubmittableResult> | undefined
+  signer: Address
+  service: ActorRef<any>
+  steps?: TransactionStep[]
+}
+
+export const SignTransactionModal = ({ onClose, transaction, signer, service, steps }: SignTransactionModalProps) => {
+  const { allAccounts } = useMyAccounts()
+  const signerAccount = accountOrNamed(allAccounts, signer, 'ControllerAccount')
+  const { paymentInfo, sign, isReady } = useSignAndSendTransaction({ transaction, signer, service })
+  const [hasFunds, setHasFunds] = useState(false)
+  const balance = useBalance(signer)
+  const transferable = balance?.transferable
+  const partialFee = paymentInfo?.partialFee
+
+  useEffect(() => {
+    if (transferable && partialFee) {
+      setHasFunds(transferable.gte(partialFee))
+    }
+  }, [partialFee?.toString(), transferable?.toString()])
+
+  const signDisabled = !isReady || !hasFunds
+
+  return (
+    <TransactionModal onClose={onClose} service={service} useMultiTransaction={steps && { steps, active: 2 }}>
+      <ModalBody>
+        <TextMedium>You intend to change the proposal discussion thread mode.</TextMedium>
+        <TextMedium>
+          Fees of <TokenValue value={partialFee?.toBn()} /> will be applied to the transaction.
+        </TextMedium>
+        <Row>
+          <SelectedAccount account={signerAccount} />
+        </Row>
+      </ModalBody>
+      <ModalFooter>
+        <TransactionInfoContainer>
+          <TransactionInfo
+            title="Transaction fee:"
+            value={partialFee?.toBn()}
+            tooltipText={'Lorem ipsum dolor sit amet consectetur, adipisicing elit.'}
+          />
+        </TransactionInfoContainer>
+        <ButtonPrimary size="medium" onClick={sign} disabled={signDisabled}>
+          Sign transaction and Create
+        </ButtonPrimary>
+      </ModalFooter>
+    </TransactionModal>
+  )
+}


### PR DESCRIPTION
Closes #1509 
Added a transaction for setting the discussion mode; the transaction modal is located in a separate dir called `ChangeThreadMode`, since I expect that a standalone functionality for changing the thread mode will be added as well.