### PR TITLE
⛓ Allow linking to candidate preview

### DIFF
--- a/packages/ui/src/app/pages/Council/Election.tsx
+++ b/packages/ui/src/app/pages/Council/Election.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import { PageHeaderRow, PageHeaderWrapper, PageLayout } from '@/app/components/PageLayout'
 import { ButtonsGroup, CopyButtonTemplate } from '@/common/components/buttons'
@@ -9,11 +9,15 @@ import { PageTitle } from '@/common/components/page/PageTitle'
 import { BlockDurationStatistics, StatisticItem, Statistics } from '@/common/components/statistics'
 import { TextHuge } from '@/common/components/typography'
 import { camelCaseToText } from '@/common/helpers'
+import { useModal } from '@/common/hooks/useModal'
+import { useRouteQuery } from '@/common/hooks/useRouteQuery'
+import { isNumber } from '@/common/utils'
 import { AnnounceCandidacyButton } from '@/council/components/election/announcing/AnnounceCandidacyButton'
 import { AnnouncingStage } from '@/council/components/election/announcing/AnnouncingStage'
 import { useCurrentElection } from '@/council/hooks/useCurrentElection'
 import { useElectionRemainingPeriod } from '@/council/hooks/useElectionRemainingPeriod'
 import { useElectionStage } from '@/council/hooks/useElectionStage'
+import { CandidacyPreviewModalCall } from '@/council/modals/CandidacyPreview/types'
 
 import { CouncilTabs } from './components/CouncilTabs'
 
@@ -21,6 +25,17 @@ export const Election = () => {
   const { isLoading: isLoadingElection, election } = useCurrentElection()
   const { isLoading: isLoadingElectionStage, stage: electionStage } = useElectionStage()
   const remainingPeriod = useElectionRemainingPeriod(electionStage)
+
+  const { showModal } = useModal()
+  const query = useRouteQuery()
+  const candidateId = query.get('candidate')
+  const cycle = query.get('cycle')
+  useEffect(() => {
+    const cycleId = cycle && Number.parseInt(cycle)
+    if (candidateId && isNumber(cycleId) && !isNaN(cycleId)) {
+      showModal<CandidacyPreviewModalCall>({ modal: 'CandidacyPreview', data: { id: candidateId } })
+    }
+  }, [candidateId, cycle])
 
   if (isLoadingElection || isLoadingElectionStage) {
     return <PageLayout header={null} main={<Loading />} />

--- a/packages/ui/src/app/pages/Council/Election.tsx
+++ b/packages/ui/src/app/pages/Council/Election.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect } from 'react'
 
 import { PageHeaderRow, PageHeaderWrapper, PageLayout } from '@/app/components/PageLayout'
 import { ButtonsGroup, CopyButtonTemplate } from '@/common/components/buttons'
@@ -33,7 +33,7 @@ export const Election = () => {
   useEffect(() => {
     const cycleId = cycle && Number.parseInt(cycle)
     if (candidateId && isNumber(cycleId) && !isNaN(cycleId)) {
-      showModal<CandidacyPreviewModalCall>({ modal: 'CandidacyPreview', data: { id: candidateId } })
+      showModal<CandidacyPreviewModalCall>({ modal: 'CandidacyPreview', data: { id: candidateId, cycleId } })
     }
   }, [candidateId, cycle])
 

--- a/packages/ui/src/council/modals/CandidacyPreview/CandidacyPreview.tsx
+++ b/packages/ui/src/council/modals/CandidacyPreview/CandidacyPreview.tsx
@@ -67,7 +67,7 @@ export const CandidacyPreview = React.memo(() => {
           <CopyButtonTemplate
             square
             size="small"
-            textToCopy={`${window.location.host}/#/council/election?candidate=${candidate?.member.id}&cycle=${modalData.cycleId}`}
+            textToCopy={`${window.location.host}/#/council/election?candidate=${candidate?.id}&cycle=${modalData.cycleId}`}
             icon={<LinkIcon />}
           />
         </SidePaneTopButtonsGroup>

--- a/packages/ui/test/council/modals/CandidacyPreview.test.tsx
+++ b/packages/ui/test/council/modals/CandidacyPreview.test.tsx
@@ -30,11 +30,8 @@ describe('UI: CandidacyPreview', () => {
       seedElectedCouncil(
         {
           id,
-          endedAtBlock: {
-            inBlock: 100,
-            createdAt: '2021-10-05T10:12:36.972Z',
-            network: 'OLYMPIA',
-          },
+          electedAtBlock: 100,
+          endedAtBlock: 200,
         },
         server.server
       )


### PR DESCRIPTION
Closes #1590 
One possible inconsistency I can see with this is that the Elections page can't normally be navigated to if the user isn't connected to Joystream node, but I'm not sure if this can potentially break the page, and how.