### PR TITLE
🩹 Remove isCouncil from member query

### DIFF
--- a/packages/ui/src/memberships/queries/__generated__/members.generated.tsx
+++ b/packages/ui/src/memberships/queries/__generated__/members.generated.tsx
@@ -11,7 +11,6 @@ export type MemberFieldsFragment = {
   handle: string
   isVerified: boolean
   isFoundingMember: boolean
-  isCouncilMember: boolean
   inviteCount: number
   createdAt: any
   metadata: { __typename: 'MemberMetadata'; name?: Types.Maybe<string>; about?: Types.Maybe<string> }
@@ -117,7 +116,6 @@ export const MemberFieldsFragmentDoc = gql`
     }
     isVerified
     isFoundingMember
-    isCouncilMember
     inviteCount
     roles {
       id

--- a/packages/ui/src/memberships/queries/members.graphql
+++ b/packages/ui/src/memberships/queries/members.graphql
@@ -11,7 +11,8 @@ fragment MemberFields on Membership {
   }
   isVerified
   isFoundingMember
-  isCouncilMember
+  # isCouncilMember
+  # See https://github.com/Joystream/pioneer/issues/1536
   inviteCount
   roles {
     id

--- a/packages/ui/src/memberships/types/casting.ts
+++ b/packages/ui/src/memberships/types/casting.ts
@@ -12,7 +12,8 @@ export const asMember = (data: Omit<MemberFieldsFragment, '__typename'>): Member
   avatar: undefined,
   inviteCount: data.inviteCount,
   isFoundingMember: data.isFoundingMember,
-  isCouncilMember: data.isCouncilMember,
+  // See https://github.com/Joystream/pioneer/issues/1536
+  isCouncilMember: false, // data.isCouncilMember,
   isVerified: data.isVerified,
   rootAccount: data.rootAccount,
   controllerAccount: data.controllerAccount,

--- a/packages/ui/test/_mocks/server/seeds/index.ts
+++ b/packages/ui/test/_mocks/server/seeds/index.ts
@@ -15,7 +15,6 @@ export const MEMBER_ALICE_DATA: MockMember = {
   },
   isVerified: true,
   isFoundingMember: true,
-  isCouncilMember: false,
   inviteCount: 5,
   entry: {
     __typename: '',


### PR DESCRIPTION
Fixes temporary error with fetching members from testnet – see https://github.com/Joystream/pioneer/issues/1536