### PR TITLE
📨 Last message info placeholder

### DIFF
--- a/packages/ui/src/council/modals/CandidacyPreview/CandidacyDetails.tsx
+++ b/packages/ui/src/council/modals/CandidacyPreview/CandidacyDetails.tsx
@@ -34,7 +34,7 @@ export const CandidacyDetails = ({ candidate }: Props) => {
         </MessagesButton>
         <LastMessageInfo>
           <TextInlineSmall lighter>
-            last message from <TextInlineSmall bold>Alice</TextInlineSmall> 1 hour ago
+            last message from <TextInlineSmall bold>Agatha</TextInlineSmall> 1 hour ago
           </TextInlineSmall>
         </LastMessageInfo>
       </RowGapBlock>


### PR DESCRIPTION
Closes #1637 

In `<LastMessageInfo>` should be added component with avatar of last message author. Name of author in this component should be a link to open info about this member.