### PR TITLE
🚚 Move 'module' sub-switches to pages

### DIFF
--- a/packages/ui/src/app/App.tsx
+++ b/packages/ui/src/app/App.tsx
@@ -1,27 +1,27 @@
 import React from 'react'
 import { Redirect, Route, Switch } from 'react-router-dom'
 
+import { CouncilModule } from '@/app/pages/Council/CouncilModule'
 import { NotFound } from '@/app/pages/NotFound'
 import { ConnectionStatus } from '@/common/components/ConnectionStatus'
 import { Page } from '@/common/components/page/Page'
 import { NotificationsHolder } from '@/common/components/page/SideNotification'
-import { CouncilModule } from '@/council/components/CouncilModule'
 import { CouncilRoutes } from '@/council/constants'
 import { ForumRoutes } from '@/forum/constant'
-import { ProposalsModule } from '@/proposals/components/ProposalsModule'
 import { ProposalsRoutes } from '@/proposals/constants/routes'
 import { WorkingGroupsRoutes } from '@/working-groups/constants/routes'
-import { WorkingGroupsModule } from '@/working-groups/WorkingGroupsModule'
 
 import { ExtensionWarning } from './components/ExtensionWarning'
 import { SideBar } from './components/SideBar'
 import { MembersRoutes, ProfileRoutes, SettingsRoutes } from './constants/routes'
 import { GlobalModals } from './GlobalModals'
-import { Forum } from './pages/Forum'
+import { ForumModule } from './pages/Forum'
 import { Members } from './pages/Members/Members'
 import { MyAccounts } from './pages/Profile/MyAccounts'
 import { MyMemberships } from './pages/Profile/MyMemberships'
+import { ProposalsModule } from './pages/Proposals/ProposalsModule'
 import { Settings } from './pages/Settings/Settings'
+import { WorkingGroupsModule } from './pages/WorkingGroups/WorkingGroupsModule'
 import { Providers } from './Providers'
 
 export const App = () => (
@@ -32,7 +32,7 @@ export const App = () => (
         <Route path={WorkingGroupsRoutes.groups} component={WorkingGroupsModule} />
         <Route path={ProposalsRoutes.home} component={ProposalsModule} />
         <Route path={CouncilRoutes.council} component={CouncilModule} />
-        <Route path={ForumRoutes.forum} component={Forum} />
+        <Route path={ForumRoutes.forum} component={ForumModule} />
         <Route exact path={ProfileRoutes.profile} component={MyAccounts} />
         <Route exact path={ProfileRoutes.memberships} component={MyMemberships} />
         <Route exact path={MembersRoutes.members} component={Members} />

--- a/packages/ui/src/app/pages/Council/CouncilModule.tsx
+++ b/packages/ui/src/app/pages/Council/CouncilModule.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { Route, Switch } from 'react-router'
 
-import { Council } from '@/app/pages/Council/Council'
-import { Election } from '@/app/pages/Council/Election'
-import { PastCouncils } from '@/app/pages/Council/PastCouncils'
-import { PastElections } from '@/app/pages/Council/PastElections'
-import { PastVotes } from '@/app/pages/Council/PastVotes'
+import { CouncilRoutes } from '@/council/constants'
 
-import { CouncilRoutes } from '../constants'
+import { Council } from './Council'
+import { Election } from './Election'
+import { PastCouncils } from './PastCouncils'
+import { PastElections } from './PastElections'
+import { PastVotes } from './PastVotes'
 
 export const CouncilModule = () => {
   return (

--- a/packages/ui/src/app/pages/Forum/ForumModule.tsx
+++ b/packages/ui/src/app/pages/Forum/ForumModule.tsx
@@ -11,7 +11,7 @@ import { ForumMyThreads } from './ForumMyThreads'
 import { ForumOverview } from './ForumOverview'
 import { LatestThreads } from './LatestThreads'
 
-export const Forum = () => {
+export const ForumModule = () => {
   return (
     <Switch>
       <Route path={ForumRoutes.forum} exact component={ForumCategories} />

--- a/packages/ui/src/app/pages/Forum/index.ts
+++ b/packages/ui/src/app/pages/Forum/index.ts
@@ -1,1 +1,1 @@
-export * from './Forum'
+export * from './ForumModule'

--- a/packages/ui/src/app/pages/Proposals/ProposalsModule.tsx
+++ b/packages/ui/src/app/pages/Proposals/ProposalsModule.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Route, Switch } from 'react-router'
 
-import { PastProposals } from '@/app/pages/Proposals/PastProposals'
-import { ProposalPreview } from '@/app/pages/Proposals/ProposalPreview'
-import { Proposals } from '@/app/pages/Proposals/Proposals'
+import { ProposalsRoutes } from '@/proposals/constants/routes'
 
-import { ProposalsRoutes } from '../constants/routes'
+import { PastProposals } from './PastProposals'
+import { ProposalPreview } from './ProposalPreview'
+import { Proposals } from './Proposals'
 
 export const ProposalsModule = () => {
   return (

--- a/packages/ui/src/app/pages/WorkingGroups/WorkingGroupsModule.tsx
+++ b/packages/ui/src/app/pages/WorkingGroups/WorkingGroupsModule.tsx
@@ -1,16 +1,16 @@
 import React from 'react'
 import { Route, Switch } from 'react-router'
 
-import { MyApplications } from '@/app/pages/WorkingGroups/MyApplications'
-import { MyRole } from '@/app/pages/WorkingGroups/MyRoles/MyRole'
-import { MyRoles } from '@/app/pages/WorkingGroups/MyRoles/MyRoles'
-import { UpcomingOpening } from '@/app/pages/WorkingGroups/UpcomingOpening'
-import { WorkingGroup } from '@/app/pages/WorkingGroups/WorkingGroup'
-import { WorkingGroups } from '@/app/pages/WorkingGroups/WorkingGroups'
-import { WorkingGroupOpening } from '@/app/pages/WorkingGroups/WorkingGroupsOpening'
-import { WorkingGroupsOpenings } from '@/app/pages/WorkingGroups/WorkingGroupsOpenings'
+import { WorkingGroupsRoutes } from '@/working-groups/constants'
 
-import { WorkingGroupsRoutes } from './constants'
+import { MyApplications } from './MyApplications'
+import { MyRole } from './MyRoles/MyRole'
+import { MyRoles } from './MyRoles/MyRoles'
+import { UpcomingOpening } from './UpcomingOpening'
+import { WorkingGroup } from './WorkingGroup'
+import { WorkingGroups } from './WorkingGroups'
+import { WorkingGroupOpening } from './WorkingGroupsOpening'
+import { WorkingGroupsOpenings } from './WorkingGroupsOpenings'
 
 export const WorkingGroupsModule = () => (
   <Switch>


### PR DESCRIPTION
I forgot to organize them correctly with the link handler PR, this is just to tidy up a bit