### PR TITLE
🤖 Generate chain specs which force an election stage

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+COMPOSE_PROJECT_NAME=pioneer-joystream-node
+COMPOSE_FILE=packages/ui/dev/chain-spec/docker-compose.yml
+
+RUNTIME=9079be466b42a95e18830711ef520c91c614b772

--- a/packages/ui/dev/chain-spec/configs/announcing.ts
+++ b/packages/ui/dev/chain-spec/configs/announcing.ts
@@ -1,0 +1,19 @@
+export default {
+  genesis: {
+    runtime: {
+      council: {
+        stage: {
+          stage: {
+            Announcing: {
+              candidates_count: 0,
+            },
+            Election: undefined,
+          },
+        },
+      },
+      referendumInstance1: {
+        stage: 'Inactive',
+      },
+    },
+  },
+}

--- a/packages/ui/dev/chain-spec/configs/index.ts
+++ b/packages/ui/dev/chain-spec/configs/index.ts
@@ -1,0 +1,5 @@
+import announcing from './announcing'
+import revealing from './revealing'
+import voting from './voting'
+
+export default { announcing, voting, revealing }

--- a/packages/ui/dev/chain-spec/configs/revealing.ts
+++ b/packages/ui/dev/chain-spec/configs/revealing.ts
@@ -1,0 +1,26 @@
+export default {
+  genesis: {
+    runtime: {
+      council: {
+        stage: {
+          stage: {
+            Announcing: undefined,
+            Election: {
+              candidates_count: 0,
+            },
+          },
+        },
+      },
+      referendumInstance1: {
+        stage: {
+          Revealing: {
+            started: 10000,
+            winning_target_count: 3,
+            current_cycle_id: 4,
+            intermediate_winners: [],
+          },
+        },
+      },
+    },
+  },
+}

--- a/packages/ui/dev/chain-spec/configs/voting.ts
+++ b/packages/ui/dev/chain-spec/configs/voting.ts
@@ -1,0 +1,25 @@
+export default {
+  genesis: {
+    runtime: {
+      council: {
+        stage: {
+          stage: {
+            Announcing: undefined,
+            Election: {
+              candidates_count: 0,
+            },
+          },
+        },
+      },
+      referendumInstance1: {
+        stage: {
+          Voting: {
+            started: 10000,
+            winning_target_count: 3,
+            current_cycle_id: 4,
+          },
+        },
+      },
+    },
+  },
+}

--- a/packages/ui/dev/chain-spec/docker-compose.yml
+++ b/packages/ui/dev/chain-spec/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.4'
+
+x-joystream-node: &default
+  image: joystream/node:${RUNTIME}
+  volumes: [./data:/data]
+
+services:
+  node:
+    <<: *default
+    command: |
+      --tmp --alice --validator
+      --unsafe-ws-external --unsafe-rpc-external --rpc-cors=all
+      --chain /data/chain-spec.json --log runtime
+    ports:
+      - '127.0.0.1:9944:9944'
+      - '127.0.0.1:9933:9933'
+
+  # Rebuild a chain spec from the current runtime
+  build:
+    <<: *default
+    entrypoint: ''
+    command: bash -c './node build-spec --dev > /data/chain-spec.json'
+
+  validate:
+    <<: *default
+    entrypoint: ''
+    command: |
+      bash -c
+      './node build-spec --raw --chain /data/chain-spec.json > /dev/null'
+
+  bash:
+    <<: *default
+    entrypoint: ''
+    command: /bin/bash

--- a/packages/ui/dev/chain-spec/index.ts
+++ b/packages/ui/dev/chain-spec/index.ts
@@ -1,0 +1,23 @@
+import fs from 'fs'
+
+import { DeepMerger } from '@apollo/client/utilities'
+import yargs from 'yargs'
+
+import configs from './configs'
+import spec from './data/chain-spec.json'
+
+const handlerFor = (stage: 'announcing' | 'voting' | 'revealing') => () => {
+  const merger = new DeepMerger()
+  const newSpec = merger.merge(spec, configs[stage])
+  const pathName = `${__dirname}/data/chain-spec.json`
+  const content = JSON.stringify(newSpec, null, 2) + '\n'
+  fs.writeFileSync(pathName, content)
+}
+
+yargs(process.argv.slice(2))
+  .usage('yarn set-chain-spec <command>')
+  .scriptName('')
+  .command('announcing', 'Make the node start at the Announcing stage', handlerFor('announcing'))
+  .command('voting', 'Make the node start at the Voting stage', handlerFor('voting'))
+  .command('revealing', 'Make the node start at the Revealing stage', handlerFor('revealing'))
+  .demandCommand().argv

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,7 @@
     "node-mocks": "ts-node dev/node-mocks/index.ts",
     "queries:generate": "graphql-codegen --config codegen.config.yml && yarn lint:fix",
     "query-node-mocks": "ts-node dev/query-node-mocks/generateMocks.ts",
+    "set-chain-spec": "ts-node dev/chain-spec/index.ts",
     "start": "cross-env NODE_OPTIONS=--max_old_space_size=8192 webpack serve --mode development --progress",
     "storybook": "start-storybook -p 6006 -s public --no-manager-cache",
     "test": "jest"


### PR DESCRIPTION
It needs some documentation.

In the meantime (with all commands ran from the repository root):
1. The chain spec (`packages/ui/dev/chain-spec/data/chain-spec.json`) is at `Announcing` by default. To switch the stage:
   - `yarn workspace ui run set-chain-spec <stage>` (the stages are lowercase)
2. The node can be run either with:
   - docker compose: `docker-compose up node`
   - or `<path to the runtime> --tmp --alice --validator --unsafe-ws-external --unsafe-rpc-external --rpc-cors=all --chain packages/ui/dev/chain-spec/data/chain-spec.json --log runtime`
3. When the runtime is changed the default chain spec might need to be rebuilt (I used docker for this):
   - `docker-compose run --rm build`

Both voting and revealing periods are extra long regardless of the chosen `olympia` runtime thanks to the `referendumInstance1.stage.{STAGE}.started` value.

Currently the docker image is [`joystream/node:9079be466b42a95e18830711ef520c91c614b772`](https://hub.docker.com/layers/joystream/node/9079be466b42a95e18830711ef520c91c614b772/images/sha256-26614a099b3cc35b3471dba1890706c369fe7328d4922783d61602b770e20c86) which might be outdated but it worked fine for me so far.

Finally no Member/Candidate/Vote is set for now.