### PR TITLE
🍜 Change fetching policy

### DIFF
--- a/packages/ui/src/app/providers/QueryNodeProvider.tsx
+++ b/packages/ui/src/app/providers/QueryNodeProvider.tsx
@@ -49,5 +49,18 @@ const getApolloClient = (network: 'local' | 'olympia-testnet') => {
     link: from([errorLink, httpLink]),
     cache: new InMemoryCache(),
     connectToDevTools: true,
+    defaultOptions: {
+      watchQuery: {
+        fetchPolicy: 'cache-and-network',
+        errorPolicy: 'all',
+      },
+      query: {
+        fetchPolicy: 'standby',
+        errorPolicy: 'all',
+      },
+      mutate: {
+        errorPolicy: 'all',
+      },
+    },
   })
 }

--- a/packages/ui/src/forum/hooks/useForumThreadPosts.ts
+++ b/packages/ui/src/forum/hooks/useForumThreadPosts.ts
@@ -1,7 +1,7 @@
 import { LazyQueryResult } from '@apollo/client'
 import { useEffect, useMemo } from 'react'
 
-import { ForumPostWhereInput } from '@/common/api/queries'
+import { ForumPostOrderByInput, ForumPostWhereInput } from '@/common/api/queries'
 import { Defined } from '@/common/types/helpers'
 import { isDefined } from '@/common/utils'
 import { useGetForumPostsCountQuery, useGetForumPostsIdsLazyQuery, useGetForumPostsLazyQuery } from '@/forum/queries'
@@ -37,9 +37,9 @@ export const useForumThreadPosts = (threadId: string, navigation: ThreadPostsNav
 
   useEffect(() => {
     if (isDefined(offset)) {
-      getPosts({ variables: { where, offset, limit: POSTS_PER_PAGE } })
+      getPosts({ variables: { where, offset, limit: POSTS_PER_PAGE, orderBy: ForumPostOrderByInput.CreatedAtAsc } })
     } else {
-      getPostIds({ variables: { where, limit: 100000 } })
+      getPostIds({ variables: { where, limit: 100000, orderBy: ForumPostOrderByInput.CreatedAtAsc } })
     }
   }, [where, offset])
 

--- a/packages/ui/src/forum/hooks/useForumThreadPosts.ts
+++ b/packages/ui/src/forum/hooks/useForumThreadPosts.ts
@@ -43,7 +43,9 @@ export const useForumThreadPosts = (threadId: string, navigation: ThreadPostsNav
     }
   }, [where, offset])
 
-  const { loading: loadingCount, data: countData } = useGetForumPostsCountQuery({ variables: { where } })
+  const { loading: loadingCount, data: countData } = useGetForumPostsCountQuery({
+    variables: { where },
+  })
   const totalCount = countData?.forumPostsConnection.totalCount
 
   return {

--- a/packages/ui/test/forum/hooks/useForumThreadPosts.test.ts
+++ b/packages/ui/test/forum/hooks/useForumThreadPosts.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks'
 
+import { ForumPostOrderByInput } from '@/common/api/queries'
 import { repeat } from '@/common/utils'
 import { useForumThreadPosts } from '@/forum/hooks/useForumThreadPosts'
 import { useGetForumPostsCountQuery, useGetForumPostsIdsLazyQuery, useGetForumPostsLazyQuery } from '@/forum/queries'
@@ -21,7 +22,7 @@ jest.mock('../../../src/forum/queries', () => ({
 const mockedPostsLazyQuery = useGetForumPostsLazyQuery as jest.Mock
 const mockedPostsIdsLazyQuery = useGetForumPostsIdsLazyQuery as jest.Mock
 const mockedPostsCountQuery = useGetForumPostsCountQuery as jest.Mock
-
+const orderFieldAndDirection = ForumPostOrderByInput.CreatedAtAsc
 // NOTE the tests assume `POSTS_PER_PAGE` to be 10
 describe('useForumThreadPosts', () => {
   beforeEach(() => {
@@ -49,13 +50,13 @@ describe('useForumThreadPosts', () => {
 
     expect(mockedPostsCountQuery).toBeCalledWith({ variables: { where } })
     expect(getPostIds).not.toHaveBeenCalled()
-    expect(getPosts).toBeCalledWith({ variables: { where, offset: 0, limit: 10 } })
+    expect(getPosts).toBeCalledWith({ variables: { where, offset: 0, limit: 10, orderBy: orderFieldAndDirection } })
     expect(result.current).toMatchObject({ page: 1, pageCount: 5, posts: [] })
 
     rerender(['0', { post: null, page: '3' }])
 
     expect(getPostIds).not.toHaveBeenCalled()
-    expect(getPosts).toBeCalledWith({ variables: { where, offset: 0, limit: 10 } })
+    expect(getPosts).toBeCalledWith({ variables: { where, offset: 0, limit: 10, orderBy: orderFieldAndDirection } })
     expect(result.current).toMatchObject({ page: 3, pageCount: 5, posts: [] })
   })
 
@@ -66,8 +67,8 @@ describe('useForumThreadPosts', () => {
     rerender()
 
     expect(mockedPostsCountQuery).toBeCalledWith({ variables: { where } })
-    expect(getPostIds).toBeCalledWith({ variables: { where, limit: 100000 } })
-    expect(getPosts).toBeCalledWith({ variables: { where, offset: 0, limit: 10 } })
+    expect(getPostIds).toBeCalledWith({ variables: { where, limit: 100000, orderBy: orderFieldAndDirection } })
+    expect(getPosts).toBeCalledWith({ variables: { where, offset: 0, limit: 10, orderBy: orderFieldAndDirection } })
     expect(result.current).toMatchObject({ page: 1, pageCount: 5, posts: [] })
   })
 })


### PR DESCRIPTION
Closes #1683

I've forced watch queries to have `cache-and-network` policy and common queries to have `standby` - seems working nice for our case.

 fetchPolicy determines where the client may return a result from. The options are:
 * cache-first (default): return result from cache. Only fetch from network if cached result is not available.
 * cache-and-network: return result from cache first (if it exists), then return network result once it's available.
 * cache-only: return result from cache if available, fail otherwise.
 * no-cache: return result from network, fail if network call doesn't succeed, don't save to cache
 * network-only: return result from network, fail if network call doesn't succeed, save to cache
 * standby: only for queries that aren't actively watched, but should be available for refetch and updateQueries.

 https://medium.com/@galen.corey/understanding-apollo-fetch-policies-705b5ad71980
 

Also thread posts were not sorted and displayed in random order.
In this PR I've forced them to order by `createdAt` desc