### PR TITLE
1566 - Allow user to change height of the editor

### DIFF
--- a/packages/ui/src/common/components/CKEditor/CKEditorStylesOverrides.tsx
+++ b/packages/ui/src/common/components/CKEditor/CKEditorStylesOverrides.tsx
@@ -18,6 +18,7 @@ export const CKEditorStylesOverrides = createGlobalStyle<{ minRows: number; maxR
   .ck.ck-editor__main > .ck.ck-content {
     max-height: ${({ maxRows }) => maxRows * (EDITOR_LINE_HEIGHT + EDITOR_LINE_SPACING) + EDITOR_LINE_SPACING}em;
     min-height: ${({ minRows }) => minRows * (EDITOR_LINE_HEIGHT + EDITOR_LINE_SPACING) + EDITOR_LINE_SPACING}em;
+    resize: vertical;
   }
 
   .ck.ck-content p,

--- a/packages/ui/src/common/components/Modal/Modal.tsx
+++ b/packages/ui/src/common/components/Modal/Modal.tsx
@@ -228,6 +228,8 @@ export const ModalWrap = styled.section<ModalWrapProps>`
     }
   }};
   height: ${({ modalHeight }) => (modalHeight === 'xl' ? '100%' : 'min-content')};
+  max-height: 800px;
+  overflow: auto;
   border-radius: ${BorderRad.s};
   box-shadow: ${Shadows.common};
   ${Animations.showModalBlock};


### PR DESCRIPTION
I propose a fix for the Issue https://github.com/Joystream/pioneer/issues/1566

Add `resize: vertical;` to CKEditor to allow changing CKEdit height.
Add `max-height: 800px;` and  `overflow: auto;` to the modal to be able to scroll the modal in case when CKEditor is resized and modal is bigger than the screen.