### PR TITLE
1480 - Hiring complete is wrongfully displayed

### DIFF
--- a/packages/ui/src/working-groups/components/ApplicantsList.tsx
+++ b/packages/ui/src/working-groups/components/ApplicantsList.tsx
@@ -29,7 +29,9 @@ export const ApplicantsList = ({ hired, allApplicants, myApplication, hiringComp
           />
         </ContentWithTabs>
       )}
-      {hiringComplete && <Warning title={'Hiring complete!'} content={'We are very sorry, you haven’t been chosen.'} />}
+      {hiringComplete && myApplication && !hired && (
+        <Warning title={'Hiring complete!'} content={'We are very sorry, you haven’t been chosen.'} />
+      )}
       {hired && (
         <ContentWithTabs>
           <Label>Hired</Label>


### PR DESCRIPTION
Issue: https://github.com/Joystream/pioneer/issues/1480
Show warning only in case there is an application and a member is not hired.