### PR TITLE
📠 Add a FileInput component

### DIFF
--- a/packages/ui/src/common/components/buttons/LinkButtons.tsx
+++ b/packages/ui/src/common/components/buttons/LinkButtons.tsx
@@ -172,7 +172,7 @@ export const BasicLinkButtonStyles = css<BasicLinkButtonStylesProps>`
   }
 `
 
-export const LinkButtonPrimaryStyles = styled(Link)<LinkButtonStyleProps>`
+export const BasicLinkButtonPrimaryStyles = css<BasicLinkButtonStylesProps>`
   ${BasicLinkButtonStyles};
 
   &,
@@ -202,6 +202,10 @@ export const LinkButtonPrimaryStyles = styled(Link)<LinkButtonStyleProps>`
       border-color: ${Colors.Blue[700]};
     }
   }
+`
+
+export const LinkButtonPrimaryStyles = styled(Link)<LinkButtonStyleProps>`
+  ${BasicLinkButtonPrimaryStyles};
 `
 
 export const LinkButtonSecondaryStyles = styled(Link)<LinkButtonStyleProps>`

--- a/packages/ui/src/common/components/forms/FileInput.stories.tsx
+++ b/packages/ui/src/common/components/forms/FileInput.stories.tsx
@@ -21,7 +21,7 @@ const Template: Story<FileInputProps & { filesAreValid: boolean }> = ({ filesAre
 
 export const Defaults = Template.bind({})
 Defaults.args = {
-  title: 'You can drag and drop json files here !',
+  title: 'Drag and drop file here to upload',
   accept: 'application/json',
   multiple: false,
   filesAreValid: false,

--- a/packages/ui/src/common/components/forms/FileInput.stories.tsx
+++ b/packages/ui/src/common/components/forms/FileInput.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, Story } from '@storybook/react'
+import React from 'react'
+
+import { FileInput, FileInputProps } from './FileInput'
+
+export default {
+  title: 'Common/Forms/FileInput',
+  component: FileInput,
+  argTypes: {
+    onChange: { action: 'Change' },
+  },
+} as Meta
+
+const Template: Story<FileInputProps> = (args) => <FileInput {...args} />
+
+export const Defaults = Template.bind({})
+Defaults.args = {
+  title: 'You can drag and drop files here !',
+  multiple: false,
+}

--- a/packages/ui/src/common/components/forms/FileInput.stories.tsx
+++ b/packages/ui/src/common/components/forms/FileInput.stories.tsx
@@ -1,21 +1,29 @@
 import { Meta, Story } from '@storybook/react'
-import React from 'react'
+import React, { useMemo, useReducer } from 'react'
+import { ValidationError } from 'yup'
 
 import { FileInput, FileInputProps } from './FileInput'
 
 export default {
   title: 'Common/Forms/FileInput',
   component: FileInput,
-  argTypes: {
-    onChange: { action: 'Change' },
-  },
 } as Meta
 
-const Template: Story<FileInputProps> = (args) => <FileInput {...args} />
+const Template: Story<FileInputProps & { filesAreValid: boolean }> = ({ filesAreValid, ...args }) => {
+  const [files, dispatch] = useReducer(
+    (files: File[], newFiles: File[]) => (args.multiple ? [...files, ...newFiles] : [newFiles[0]]),
+    []
+  )
+  const value = useMemo(() => files.map((file) => ({ file, errors: filesAreValid ? [] : ERRORS })), [files])
+
+  return <FileInput {...args} value={value} onChange={dispatch} />
+}
 
 export const Defaults = Template.bind({})
 Defaults.args = {
   title: 'You can drag and drop json files here !',
   accept: 'application/json',
   multiple: false,
+  filesAreValid: false,
 }
+const ERRORS = [new ValidationError('Commodo est officia consequat ex')]

--- a/packages/ui/src/common/components/forms/FileInput.stories.tsx
+++ b/packages/ui/src/common/components/forms/FileInput.stories.tsx
@@ -15,6 +15,7 @@ const Template: Story<FileInputProps> = (args) => <FileInput {...args} />
 
 export const Defaults = Template.bind({})
 Defaults.args = {
-  title: 'You can drag and drop files here !',
+  title: 'You can drag and drop json files here !',
+  accept: 'application/json',
   multiple: false,
 }

--- a/packages/ui/src/common/components/forms/FileInput.tsx
+++ b/packages/ui/src/common/components/forms/FileInput.tsx
@@ -1,0 +1,120 @@
+import React, {
+  ChangeEventHandler,
+  DragEventHandler,
+  InputHTMLAttributes,
+  useCallback,
+  useEffect,
+  useReducer,
+} from 'react'
+import styled from 'styled-components'
+
+import { BasicLinkButtonPrimaryStyles } from '@/common/components/buttons/LinkButtons'
+import { FileIcon } from '@/common/components/icons'
+import { TextInlineSmall } from '@/common/components/typography'
+import { Colors, Fonts } from '@/common/constants'
+
+export interface FileInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'onChange'> {
+  title?: string
+  onChange: (files: File[]) => void
+}
+
+export const FileInput = ({ title = 'Drag and drop files here', onChange, ...inputProps }: FileInputProps) => {
+  const [files, addFiles] = useReducer(
+    (files: File[], newFiles: File[]): File[] => (inputProps.multiple ? [...files, ...(newFiles ?? [])] : newFiles),
+    []
+  )
+  useEffect(() => onChange(files), [files])
+
+  const onUpload: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      event.preventDefault()
+      addFiles(Array.from(event.target.files ?? []))
+    },
+    [files]
+  )
+
+  const onDrop: DragEventHandler<HTMLDivElement> = useCallback(
+    (event) => {
+      event.preventDefault()
+      const newFiles = Array.from(event.dataTransfer.items)
+        .slice(0, inputProps.multiple ? undefined : 1)
+        .flatMap((dropped) => (dropped?.kind === 'file' && dropped.getAsFile()) || [])
+
+      if (newFiles.length) addFiles(newFiles)
+    },
+    [files, inputProps.multiple]
+  )
+
+  const onDragOver: DragEventHandler<HTMLDivElement> = useCallback((event) => {
+    event.preventDefault()
+  }, [])
+
+  return (
+    <>
+      <FileInputContainer onDrop={onDrop} onDragOver={onDragOver}>
+        <FileIcon />
+
+        <h5>{title}</h5>
+
+        <p>
+          <LighterText>or</LighterText>{' '}
+          <BrowseButton size="small">
+            Browse for file <input type="file" onChange={onUpload} {...inputProps} />
+          </BrowseButton>
+        </p>
+      </FileInputContainer>
+
+      {files?.map((file, index) => (
+        <FileEntry key={index}>
+          <LighterText>{file.name}</LighterText>
+        </FileEntry>
+      ))}
+    </>
+  )
+}
+
+const BrowseButton = styled.label`
+  ${BasicLinkButtonPrimaryStyles};
+`
+const FileInputContainer = styled.div`
+  background: ${Colors.Black[25]};
+  border: 2px dotted ${Colors.Black[300]};
+  display: grid;
+  gap: 10px;
+  height: 204px;
+  place-content: center;
+  place-items: center;
+
+  ${BrowseButton} {
+    display: inline-flex;
+  }
+
+  input {
+    opacity: 0;
+    position: absolute;
+    pointer-events: none;
+  }
+`
+
+const FileEntry = styled.div`
+  align-items: center;
+  background: ${Colors.Black[25]};
+  display: flex;
+  margin-top: 16px;
+  height: 56px;
+
+  &::before {
+    background-color: ${Colors.Blue[200]};
+    border-bottom-left-radius: 4px;
+    border-top-left-radius: 4px;
+    content: '';
+    display: block;
+    margin-right: 16px;
+    height: 100%;
+    width: 4px;
+  }
+`
+
+const LighterText = styled(TextInlineSmall).attrs({ lighter: true })`
+  font-family: ${Fonts.Inter};
+`

--- a/packages/ui/src/common/components/forms/FileInput.tsx
+++ b/packages/ui/src/common/components/forms/FileInput.tsx
@@ -1,12 +1,13 @@
-import React, { ChangeEventHandler, DragEventHandler, InputHTMLAttributes, useCallback } from 'react'
+import React, { useState, ChangeEventHandler, DragEventHandler, InputHTMLAttributes, useCallback } from 'react'
 import styled from 'styled-components'
 import { ValidationError } from 'yup'
 
 import { BasicLinkButtonPrimaryStyles } from '@/common/components/buttons/LinkButtons'
-import { FileIcon } from '@/common/components/icons'
 import { TextInlineSmall } from '@/common/components/typography'
-import { Colors, Fonts } from '@/common/constants'
+import { BorderRad, Colors, Fonts, Transitions } from '@/common/constants'
 import { partition } from '@/common/utils'
+
+import { DropFileIcon } from '../icons/DropFileIcon'
 
 import { ControlProps, InputArea, InputComponent, InputContainer } from '.'
 
@@ -21,6 +22,7 @@ export interface FileInputProps extends ControlProps<FileEntry[], File[]>, Nativ
 }
 
 export const FileInput = ({ title = 'Drag and drop files here', value, onChange, ...inputProps }: FileInputProps) => {
+  const [fileInZone, setFileInZone] = useState(false)
   const onUpload: ChangeEventHandler<HTMLInputElement> = useCallback(
     (event) => {
       event.preventDefault()
@@ -57,14 +59,20 @@ export const FileInput = ({ title = 'Drag and drop files here', value, onChange,
 
   const onDragOver: DragEventHandler<HTMLDivElement> = useCallback((event) => {
     event.preventDefault()
+    setFileInZone(true)
+  }, [])
+
+  const onDragLeave: DragEventHandler<HTMLDivElement> = useCallback((event) => {
+    event.preventDefault()
+    setFileInZone(false)
   }, [])
 
   return (
     <>
-      <FileInputContainer onDrop={onDrop} onDragOver={onDragOver}>
-        <FileIcon />
+      <FileInputContainer onDrop={onDrop} onDragOver={onDragOver} onDragLeave={onDragLeave} fileInZone={fileInZone}>
+        <FileInputIcon />
 
-        <h5>{title}</h5>
+        <FileInputTitle>{title}</FileInputTitle>
 
         <p>
           <LighterText>or</LighterText>{' '}
@@ -89,15 +97,23 @@ export const FileInput = ({ title = 'Drag and drop files here', value, onChange,
 
 const BrowseButton = styled.label`
   ${BasicLinkButtonPrimaryStyles};
+
+  margin-left: 10px;
+  text-transform: none;
 `
-const FileInputContainer = styled.div`
-  background: ${Colors.Black[25]};
-  border: 2px dotted ${Colors.Black[300]};
-  display: grid;
-  gap: 10px;
-  height: 204px;
-  place-content: center;
-  place-items: center;
+
+const FileInputContainer = styled.div<{ fileInZone?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 204px;
+  border: 2px dashed ${({ fileInZone }) => (fileInZone ? Colors.Blue[500] : Colors.Black[300])};
+  border-radius: ${BorderRad.m};
+  background-color: ${Colors.Black[25]};
+  box-shadow: ${({ fileInZone }) =>
+    fileInZone ? `inset 0px 0px 104px ${Colors.Blue[500] + '29'}` : 'inset 0px 0px 0px transparent'};
+  transition: ${Transitions.all};
 
   ${BrowseButton} {
     display: inline-flex;
@@ -108,6 +124,26 @@ const FileInputContainer = styled.div`
     position: absolute;
     pointer-events: none;
   }
+
+  &:hover,
+  &:focus,
+  &:focus-within {
+    border-color: ${Colors.Blue[500]};
+    ${BrowseButton} {
+      &:before {
+        transform: translate(-50%, -50%);
+      }
+    }
+  }
+`
+
+const FileInputIcon = styled(DropFileIcon)`
+  margin: 8px 0;
+  color: ${Colors.Black[400]};
+`
+
+const FileInputTitle = styled.h5`
+  margin: 10px auto;
 `
 
 const FilePreview = styled(InputComponent)`

--- a/packages/ui/src/common/components/icons/DropFileIcon.tsx
+++ b/packages/ui/src/common/components/icons/DropFileIcon.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import { Icon } from './Icon'
+
+interface DropFileIconProps {
+  size?: number
+  className?: string
+}
+
+export const DropFileIcon = React.memo(({ size = 48, className }: DropFileIconProps) => (
+  <Icon
+    size={size}
+    viewBox="0 0 48 48"
+    preserveAspectRatio="xMidYMid meet"
+    fill="none"
+    color="currentColor"
+    className={className}
+  >
+    <path
+      d="M25 36H5C4.44772 36 4 35.5523 4 35V3C4 2.44772 4.44772 2 5 2H28M36 25V9.5M28 2V8.5C28 9.05228 28.4477 9.5 29 9.5H36M28 2L36 9.5"
+      stroke="currentColor"
+      strokeWidth="2"
+    />
+    <path
+      d="M36 44H29C28.4477 44 28 43.5523 28 43V29C28 28.4477 28.4477 28 29 28H43C43.5523 28 44 28.4477 44 29V43C44 43.5523 43.5523 44 43 44H40"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeMiterlimit="10"
+      strokeLinecap="square"
+    />
+    <path d="M36 44L36 34" stroke="currentColor" strokeWidth="2" strokeMiterlimit="10" />
+    <path d="M33 37L36 34L39 37" stroke="currentColor" strokeWidth="2" strokeMiterlimit="10" strokeLinecap="square" />
+  </Icon>
+))

--- a/packages/ui/src/common/utils.ts
+++ b/packages/ui/src/common/utils.ts
@@ -54,10 +54,8 @@ export const equals = <T extends any>(
 
 export const merge = <A extends Obj, B extends Obj = Partial<A>>(a: A, b: B): A & B => ({ ...a, ...b })
 
-export const propsEquals =
-  <T extends Obj>(...keys: (keyof T)[]) =>
-  (a: T, b: T) =>
-    keys.every((key) => a[key] === b[key])
+export const propsEquals = <T extends Obj>(...keys: (keyof T)[]) => (a: T, b: T) =>
+  keys.every((key) => a[key] === b[key])
 
 // Lists:
 
@@ -66,6 +64,13 @@ export const intersperse = <T extends any, S extends any>(
   toSeparator: (index: number, list: T[]) => S
 ): (T | S)[] =>
   list.length < 2 ? list : [list[0], ...list.slice(1).flatMap((item, index) => [toSeparator(index, list), item])]
+
+export const partition = <T extends any>(list: T[], predicate: (x: T) => boolean): [T[], T[]] =>
+  list.reduce(
+    ([pass, fail]: [T[], T[]], item): [T[], T[]] =>
+      predicate(item) ? [[...pass, item], fail] : [pass, [...fail, item]],
+    [[], []]
+  )
 
 export const repeat = <T extends any>(getItem: (index: number) => T, times: number): T[] =>
   Array.from({ length: times }, (_, i) => getItem(i))

--- a/packages/ui/src/common/utils.ts
+++ b/packages/ui/src/common/utils.ts
@@ -54,8 +54,10 @@ export const equals = <T extends any>(
 
 export const merge = <A extends Obj, B extends Obj = Partial<A>>(a: A, b: B): A & B => ({ ...a, ...b })
 
-export const propsEquals = <T extends Obj>(...keys: (keyof T)[]) => (a: T, b: T) =>
-  keys.every((key) => a[key] === b[key])
+export const propsEquals =
+  <T extends Obj>(...keys: (keyof T)[]) =>
+  (a: T, b: T) =>
+    keys.every((key) => a[key] === b[key])
 
 // Lists:
 


### PR DESCRIPTION
See #1633

Here are the wireframes: [@figma](https://www.figma.com/file/Z3KcRoAll3JGEY622o0iZu/Council?node-id=1752%3A36146)
Because only one file is needed to restore the votes I didn't implement the delete file/dust bin button.