### PR TITLE
🏡 Use local query-node instance

### DIFF
--- a/packages/ui/src/app/pages/Settings/Settings.tsx
+++ b/packages/ui/src/app/pages/Settings/Settings.tsx
@@ -7,17 +7,14 @@ import { SimpleSelect } from '@/common/components/selects'
 import { NetworkType, useNetwork } from '@/common/hooks/useNetwork'
 
 export const Settings = () => {
-  const options: NetworkType[] = ['local', 'olympia-testnet']
+  const options: NetworkType[] = ['local', 'local-mocks', 'olympia-testnet']
   const [network, setNetwork] = useNetwork()
 
-  const switchNetwork = () => {
-    if (network === 'local') {
-      setNetwork('olympia-testnet')
-    } else {
-      setNetwork('local')
+  const switchNetwork = (network: NetworkType | null) => {
+    if (network) {
+      setNetwork(network)
+      window.location.reload()
     }
-
-    window.location.reload()
   }
 
   return (

--- a/packages/ui/src/app/providers/QueryNodeProvider.tsx
+++ b/packages/ui/src/app/providers/QueryNodeProvider.tsx
@@ -17,24 +17,25 @@ const QUERY_NODE_GRAPHQL_SUBSCRIPTION_URL = 'wss://olympia-dev.joystream.app/que
 
 const ENDPOINTS: Record<NetworkType, string> = {
   local: 'http://localhost:8081/graphql',
+  'local-mocks': 'http://localhost:8081/graphql',
   'olympia-testnet': 'https://olympia-dev.joystream.app/query/server/graphql',
 }
 
 export const QueryNodeProvider = ({ children }: Props) => {
   const [network] = useNetwork()
 
-  if (network === 'olympia-testnet') {
-    return <ApolloProvider client={getApolloClient(network)}>{children}</ApolloProvider>
+  if (network === 'local-mocks') {
+    return (
+      <ServerContextProvider value={makeServer()}>
+        <ApolloProvider client={getApolloClient(network)}>{children}</ApolloProvider>
+      </ServerContextProvider>
+    )
   }
 
-  return (
-    <ServerContextProvider value={makeServer()}>
-      <ApolloProvider client={getApolloClient(network)}>{children}</ApolloProvider>
-    </ServerContextProvider>
-  )
+  return <ApolloProvider client={getApolloClient(network)}>{children}</ApolloProvider>
 }
 
-const getApolloClient = (network: 'local' | 'olympia-testnet') => {
+const getApolloClient = (network: NetworkType) => {
   const httpLink = new HttpLink({
     uri: ENDPOINTS[network],
   })

--- a/packages/ui/src/app/providers/QueryNodeProvider.tsx
+++ b/packages/ui/src/app/providers/QueryNodeProvider.tsx
@@ -13,7 +13,11 @@ interface Props {
   children: ReactNode
 }
 
-const QUERY_NODE_GRAPHQL_SUBSCRIPTION_URL = 'wss://olympia-dev.joystream.app/query/server/graphql'
+const SUBSCRIPTION_ENDPOINTS: Record<NetworkType, string> = {
+  local: 'ws://localhost:8081/graphql',
+  'local-mocks': 'ws://localhost:8081/graphql',
+  'olympia-testnet': 'wss://olympia-dev.joystream.app/query/server/graphql',
+}
 
 const ENDPOINTS: Record<NetworkType, string> = {
   local: 'http://localhost:8081/graphql',
@@ -52,7 +56,7 @@ const getApolloClient = (network: NetworkType) => {
 
   const queryLink = from([errorLink, httpLink])
   const subscriptionLink = new WebSocketLink({
-    uri: QUERY_NODE_GRAPHQL_SUBSCRIPTION_URL,
+    uri: SUBSCRIPTION_ENDPOINTS[network],
     options: {
       reconnect: true,
       reconnectionAttempts: 5,

--- a/packages/ui/src/common/hooks/useNetwork.ts
+++ b/packages/ui/src/common/hooks/useNetwork.ts
@@ -1,6 +1,6 @@
 import { useLocalStorage } from './useLocalStorage'
 
-export type NetworkType = 'local' | 'olympia-testnet'
+export type NetworkType = 'local' | 'local-mocks' | 'olympia-testnet'
 
 export const useNetwork = () => {
   const [network, setNetwork] = useLocalStorage<NetworkType>('network')

--- a/packages/ui/src/common/providers/api/provider.tsx
+++ b/packages/ui/src/common/providers/api/provider.tsx
@@ -43,6 +43,7 @@ export type UseApi = APIConnecting | APIConnected | APIDisconnected
 
 const endpoints: Record<NetworkType, string> = {
   local: 'ws://127.0.0.1:9944',
+  'local-mocks': 'ws://127.0.0.1:9944',
   'olympia-testnet': 'wss://olympia-dev.joystream.app/rpc',
 }
 


### PR DESCRIPTION
This is a simple update to the network settings:

- added new network type `local-mocks` (will work as current `local`)
- removes MirageJS mocks from `local` (to enable `query-node` actions)
- updated settings page to handle any network type