### PR TITLE
🧂 Proposal properties style improvements

### DIFF
--- a/packages/ui/src/app/pages/WorkingGroups/WorkingGroup/WorkingGroup.tsx
+++ b/packages/ui/src/app/pages/WorkingGroups/WorkingGroup/WorkingGroup.tsx
@@ -72,6 +72,7 @@ export function WorkingGroup() {
       main={displayTabsContent()}
       sidebar={displayTabsSidebar()}
       sidebarScrollable
+      lastBreadcrumb={group?.name}
     />
   )
 }

--- a/packages/ui/src/proposals/components/ProposalDetails/renderers/ProposalLink.tsx
+++ b/packages/ui/src/proposals/components/ProposalDetails/renderers/ProposalLink.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { generatePath, useHistory } from 'react-router'
+import styled from 'styled-components'
 
 import { ArrowRightIcon } from '@/common/components/icons'
 import { StatisticButton } from '@/common/components/statistics/StatisticButton'
@@ -22,9 +23,17 @@ export const ProposalLink = ({ label, value }: Props) => {
       title={label}
       icon={<ArrowRightIcon />}
     >
-      <TextInlineBig bold value>
-        {value.title}
-      </TextInlineBig>
+      <LeftAlignedItem>
+        <TextInlineBig bold value>
+          {value.title}
+        </TextInlineBig>
+      </LeftAlignedItem>
     </StatisticButton>
   )
 }
+
+const LeftAlignedItem = styled.div`
+  align-items: left;
+  text-align: left;
+  width: 100%;
+`

--- a/packages/ui/src/working-groups/types/WorkingGroup.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroup.ts
@@ -58,9 +58,8 @@ export const asDetailedWorkingGroup = (group: WorkingGroupDetailedFieldsFragment
     : {}),
 })
 
-export const asWorkingGroupName = (name: string) => {
-  return name
+export const asWorkingGroupName = (name: string) =>
+  name
     .replace('WorkingGroup', '')
     .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .toLowerCase()
-}
+    .replace(/^[a-z]/, (match) => match.toUpperCase())

--- a/packages/ui/test/council/pages/PastCouncil.test.tsx
+++ b/packages/ui/test/council/pages/PastCouncil.test.tsx
@@ -390,7 +390,7 @@ describe('UI: Past Council page', () => {
           const workingGroupTotalBudget = workingGroupItem?.children.item(3)?.textContent
           const workingGroupBudgetPercentage = workingGroupItem?.children.item(4)?.textContent
 
-          expect(workingGroupName).toBe('forum')
+          expect(workingGroupName).toBe('Forum')
           expect(workingGroupPaidRewards).toBe('6,050')
           expect(workingGroupMissedRewards).toBe('3,145')
           expect(workingGroupTotalBudget).toBe('80,000')

--- a/packages/ui/test/working-groups/model/workingGroupName.test.ts
+++ b/packages/ui/test/working-groups/model/workingGroupName.test.ts
@@ -1,4 +1,5 @@
 import { groupNameToURLParam, urlParamToWorkingGroupId } from '@/working-groups/model/workingGroupName'
+import { asWorkingGroupName } from '@/working-groups/types'
 
 describe('urlParamToWorkingGroupId()', () => {
   it('forum', () => {
@@ -23,7 +24,22 @@ describe('groupNameToURLParam()', () => {
     expect(groupNameToURLParam('content directory')).toBe('content-directory')
   })
 
+  it('Content Directory', () => {
+    expect(groupNameToURLParam('Content Directory')).toBe('content-directory')
+  })
+
   it('CONTENT DIRECTORY', () => {
     expect(groupNameToURLParam('CONTENT DIRECTORY')).toBe('content-directory')
+  })
+})
+
+describe('asWorkingGroupName', () => {
+  it('Single word name', () => {
+    expect(asWorkingGroupName('forumWorkingGroup')).toBe('Forum')
+    expect(asWorkingGroupName('ForumWorkingGroup')).toBe('Forum')
+  })
+
+  it('Multiple word name', () => {
+    expect(asWorkingGroupName('contentDirectoryWorkingGroup')).toBe('Content Directory')
   })
 })


### PR DESCRIPTION
Closes #1864 
In addition to these small changes, I've decided to change the way working groups' display names are shown. I think the original intent was for them to be proper names, so I've changed the name strings to always have capital first letters.