### PR TITLE
🌇 Sync schema for council block & date

### DIFF
--- a/packages/ui/src/app/pages/Council/Council.tsx
+++ b/packages/ui/src/app/pages/Council/Council.tsx
@@ -17,7 +17,7 @@ import { CouncilTabs } from './components/CouncilTabs'
 
 export const Council = () => {
   const { council, isLoading } = useElectedCouncil()
-  const { idlePeriodRemaining, budget, reward } = useCouncilStatistics(council?.electedAtBlock)
+  const { idlePeriodRemaining, budget, reward } = useCouncilStatistics(council?.electedAt.number)
   const { activities } = useCouncilActivities()
 
   const [order, setOrder] = useState<CouncilOrder>({ key: 'member' })

--- a/packages/ui/src/app/pages/Council/PastCouncils/PastCouncil.tsx
+++ b/packages/ui/src/app/pages/Council/PastCouncils/PastCouncil.tsx
@@ -54,16 +54,7 @@ export const PastCouncil = () => {
             <BadgeStatus inverted size="l">
               Past Council
             </BadgeStatus>
-            <BlockTime
-              block={{
-                network: 'OLYMPIA',
-                timestamp: new Date().toString(),
-                number: council.endedAtBlock,
-              }}
-              lessInfo
-              dateLabel="Term ended at"
-              layout="row"
-            />
+            <BlockTime block={council.endedAt} lessInfo dateLabel="Term ended at" layout="row" />
           </BadgesRow>
         </RowGapBlock>
       </PageHeaderWrapper>

--- a/packages/ui/src/common/api/queries/__generated__/baseTypes.generated.ts
+++ b/packages/ui/src/common/api/queries/__generated__/baseTypes.generated.ts
@@ -4150,8 +4150,16 @@ export type ElectedCouncil = BaseGraphQlObject & {
   deletedById?: Maybe<Scalars['String']>
   /** Block number at which the council was elected. */
   electedAtBlock: Scalars['Int']
+  /** Network running at the time of election. */
+  electedAtNetwork: Network
+  /** Time at which the council was elected. */
+  electedAtTime: Scalars['DateTime']
   /** Block number at which the council reign ended and a new council was elected. */
   endedAtBlock?: Maybe<Scalars['Int']>
+  /** Network running at the time of resignation. */
+  endedAtNetwork?: Maybe<Network>
+  /** Time at which the council reign ended and a new council was elected. */
+  endedAtTime?: Maybe<Scalars['DateTime']>
   id: Scalars['ID']
   /** Sign if council is already resigned. */
   isResigned: Scalars['Boolean']
@@ -4172,7 +4180,11 @@ export type ElectedCouncilConnection = {
 
 export type ElectedCouncilCreateInput = {
   electedAtBlock: Scalars['Float']
+  electedAtNetwork: Network
+  electedAtTime: Scalars['DateTime']
   endedAtBlock?: InputMaybe<Scalars['Float']>
+  endedAtNetwork?: InputMaybe<Network>
+  endedAtTime?: InputMaybe<Scalars['DateTime']>
   isResigned: Scalars['Boolean']
 }
 
@@ -4189,8 +4201,16 @@ export enum ElectedCouncilOrderByInput {
   DeletedAtDesc = 'deletedAt_DESC',
   ElectedAtBlockAsc = 'electedAtBlock_ASC',
   ElectedAtBlockDesc = 'electedAtBlock_DESC',
+  ElectedAtNetworkAsc = 'electedAtNetwork_ASC',
+  ElectedAtNetworkDesc = 'electedAtNetwork_DESC',
+  ElectedAtTimeAsc = 'electedAtTime_ASC',
+  ElectedAtTimeDesc = 'electedAtTime_DESC',
   EndedAtBlockAsc = 'endedAtBlock_ASC',
   EndedAtBlockDesc = 'endedAtBlock_DESC',
+  EndedAtNetworkAsc = 'endedAtNetwork_ASC',
+  EndedAtNetworkDesc = 'endedAtNetwork_DESC',
+  EndedAtTimeAsc = 'endedAtTime_ASC',
+  EndedAtTimeDesc = 'endedAtTime_DESC',
   IsResignedAsc = 'isResigned_ASC',
   IsResignedDesc = 'isResigned_DESC',
   UpdatedAtAsc = 'updatedAt_ASC',
@@ -4199,7 +4219,11 @@ export enum ElectedCouncilOrderByInput {
 
 export type ElectedCouncilUpdateInput = {
   electedAtBlock?: InputMaybe<Scalars['Float']>
+  electedAtNetwork?: InputMaybe<Network>
+  electedAtTime?: InputMaybe<Scalars['DateTime']>
   endedAtBlock?: InputMaybe<Scalars['Float']>
+  endedAtNetwork?: InputMaybe<Network>
+  endedAtTime?: InputMaybe<Scalars['DateTime']>
   isResigned?: InputMaybe<Scalars['Boolean']>
 }
 
@@ -4233,12 +4257,26 @@ export type ElectedCouncilWhereInput = {
   electedAtBlock_in?: InputMaybe<Array<Scalars['Int']>>
   electedAtBlock_lt?: InputMaybe<Scalars['Int']>
   electedAtBlock_lte?: InputMaybe<Scalars['Int']>
+  electedAtNetwork_eq?: InputMaybe<Network>
+  electedAtNetwork_in?: InputMaybe<Array<Network>>
+  electedAtTime_eq?: InputMaybe<Scalars['DateTime']>
+  electedAtTime_gt?: InputMaybe<Scalars['DateTime']>
+  electedAtTime_gte?: InputMaybe<Scalars['DateTime']>
+  electedAtTime_lt?: InputMaybe<Scalars['DateTime']>
+  electedAtTime_lte?: InputMaybe<Scalars['DateTime']>
   endedAtBlock_eq?: InputMaybe<Scalars['Int']>
   endedAtBlock_gt?: InputMaybe<Scalars['Int']>
   endedAtBlock_gte?: InputMaybe<Scalars['Int']>
   endedAtBlock_in?: InputMaybe<Array<Scalars['Int']>>
   endedAtBlock_lt?: InputMaybe<Scalars['Int']>
   endedAtBlock_lte?: InputMaybe<Scalars['Int']>
+  endedAtNetwork_eq?: InputMaybe<Network>
+  endedAtNetwork_in?: InputMaybe<Array<Network>>
+  endedAtTime_eq?: InputMaybe<Scalars['DateTime']>
+  endedAtTime_gt?: InputMaybe<Scalars['DateTime']>
+  endedAtTime_gte?: InputMaybe<Scalars['DateTime']>
+  endedAtTime_lt?: InputMaybe<Scalars['DateTime']>
+  endedAtTime_lte?: InputMaybe<Scalars['DateTime']>
   id_eq?: InputMaybe<Scalars['ID']>
   id_in?: InputMaybe<Array<Scalars['ID']>>
   isResigned_eq?: InputMaybe<Scalars['Boolean']>

--- a/packages/ui/src/common/api/schemas/schema.graphql
+++ b/packages/ui/src/common/api/schemas/schema.graphql
@@ -4501,6 +4501,26 @@ type ElectedCouncil implements BaseGraphQLObject {
   Block number at which the council reign ended and a new council was elected.
   """
   endedAtBlock: Int
+
+  """
+  Time at which the council was elected.
+  """
+  electedAtTime: DateTime!
+
+  """
+  Time at which the council reign ended and a new council was elected.
+  """
+  endedAtTime: DateTime
+
+  """
+  Network running at the time of election.
+  """
+  electedAtNetwork: Network!
+
+  """
+  Network running at the time of resignation.
+  """
+  endedAtNetwork: Network
   councilElections: [ElectionRound!]!
   nextCouncilElections: [ElectionRound!]!
 
@@ -4520,6 +4540,10 @@ type ElectedCouncilConnection {
 input ElectedCouncilCreateInput {
   electedAtBlock: Float!
   endedAtBlock: Float
+  electedAtTime: DateTime!
+  endedAtTime: DateTime
+  electedAtNetwork: Network!
+  endedAtNetwork: Network
   isResigned: Boolean!
 }
 
@@ -4539,6 +4563,14 @@ enum ElectedCouncilOrderByInput {
   electedAtBlock_DESC
   endedAtBlock_ASC
   endedAtBlock_DESC
+  electedAtTime_ASC
+  electedAtTime_DESC
+  endedAtTime_ASC
+  endedAtTime_DESC
+  electedAtNetwork_ASC
+  electedAtNetwork_DESC
+  endedAtNetwork_ASC
+  endedAtNetwork_DESC
   isResigned_ASC
   isResigned_DESC
 }
@@ -4546,6 +4578,10 @@ enum ElectedCouncilOrderByInput {
 input ElectedCouncilUpdateInput {
   electedAtBlock: Float
   endedAtBlock: Float
+  electedAtTime: DateTime
+  endedAtTime: DateTime
+  electedAtNetwork: Network
+  endedAtNetwork: Network
   isResigned: Boolean
 }
 
@@ -4586,6 +4622,20 @@ input ElectedCouncilWhereInput {
   endedAtBlock_lt: Int
   endedAtBlock_lte: Int
   endedAtBlock_in: [Int!]
+  electedAtTime_eq: DateTime
+  electedAtTime_lt: DateTime
+  electedAtTime_lte: DateTime
+  electedAtTime_gt: DateTime
+  electedAtTime_gte: DateTime
+  endedAtTime_eq: DateTime
+  endedAtTime_lt: DateTime
+  endedAtTime_lte: DateTime
+  endedAtTime_gt: DateTime
+  endedAtTime_gte: DateTime
+  electedAtNetwork_eq: Network
+  electedAtNetwork_in: [Network!]
+  endedAtNetwork_eq: Network
+  endedAtNetwork_in: [Network!]
   isResigned_eq: Boolean
   isResigned_in: [Boolean!]
   councilMembers_none: CouncilMemberWhereInput

--- a/packages/ui/src/council/components/pastCouncil/PastCouncilsList/PastCouncilListItem.tsx
+++ b/packages/ui/src/council/components/pastCouncil/PastCouncilsList/PastCouncilListItem.tsx
@@ -31,15 +31,7 @@ export const PastCouncilListItem = ({ council }: Props) => {
       to={generatePath(CouncilRoutes.pastCouncil, { id: council.id })}
     >
       <Info>#{council.id}</Info>
-      <BlockTime
-        block={{
-          network: 'OLYMPIA',
-          timestamp: new Date().toString(),
-          number: council.endedAtBlock,
-        }}
-        layout="reverse-start"
-        lessInfo
-      />
+      <BlockTime block={council.endedAt} layout="reverse-start" lessInfo />
       {isLoading ? <Loading /> : <TokenValue value={totalSpent} />}
       {isLoading ? <Loading /> : <TokenValue value={spentOnProposals} />}
       {isLoading ? <Loading /> : <CountInfo count={proposalsApproved} />}

--- a/packages/ui/src/council/components/pastCouncil/PastCouncilsList/PastCouncilsList.stories.tsx
+++ b/packages/ui/src/council/components/pastCouncil/PastCouncilsList/PastCouncilsList.stories.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router'
 
 import { PastCouncilsList } from '@/council/components/pastCouncil/PastCouncilsList/PastCouncilsList'
 import { PastCouncil } from '@/council/types/PastCouncil'
+import { randomBlock } from '@/mocks/helpers/randomBlock'
 
 export default {
   title: 'Council/PastCouncils',
@@ -28,9 +29,9 @@ export const Default = Template.bind({})
 
 Default.args = {
   councils: [
-    { id: '0', endedAtBlock: 112145 },
-    { id: '1', endedAtBlock: 222346 },
-    { id: '1', endedAtBlock: 45233 },
+    { id: '0', endedAt: randomBlock() },
+    { id: '1', endedAt: randomBlock() },
+    { id: '1', endedAt: randomBlock() },
   ],
   isLoading: false,
 }

--- a/packages/ui/src/council/queries/__generated__/council.generated.tsx
+++ b/packages/ui/src/council/queries/__generated__/council.generated.tsx
@@ -122,6 +122,8 @@ export type ElectedCouncilFieldsFragment = {
   __typename: 'ElectedCouncil'
   id: string
   electedAtBlock: number
+  electedAtTime: any
+  electedAtNetwork: Types.Network
   councilMembers: Array<{
     __typename: 'CouncilMember'
     id: string
@@ -155,12 +157,16 @@ export type PastCouncilFieldsFragment = {
   __typename: 'ElectedCouncil'
   id: string
   endedAtBlock?: number | null | undefined
+  endedAtNetwork?: Types.Network | null | undefined
+  endedAtTime?: any | null | undefined
 }
 
 export type PastCouncilDetailedFieldsFragment = {
   __typename: 'ElectedCouncil'
   id: string
   endedAtBlock?: number | null | undefined
+  endedAtNetwork?: Types.Network | null | undefined
+  endedAtTime?: any | null | undefined
   councilMembers: Array<{ __typename: 'CouncilMember'; accumulatedReward: any; unpaidReward: any }>
 }
 
@@ -456,6 +462,8 @@ export type GetElectedCouncilQuery = {
     __typename: 'ElectedCouncil'
     id: string
     electedAtBlock: number
+    electedAtTime: any
+    electedAtNetwork: Types.Network
     councilMembers: Array<{
       __typename: 'CouncilMember'
       id: string
@@ -494,7 +502,13 @@ export type GetPastCouncilsQueryVariables = Types.Exact<{
 
 export type GetPastCouncilsQuery = {
   __typename: 'Query'
-  electedCouncils: Array<{ __typename: 'ElectedCouncil'; id: string; endedAtBlock?: number | null | undefined }>
+  electedCouncils: Array<{
+    __typename: 'ElectedCouncil'
+    id: string
+    endedAtBlock?: number | null | undefined
+    endedAtNetwork?: Types.Network | null | undefined
+    endedAtTime?: any | null | undefined
+  }>
 }
 
 export type GetPastCouncilsCountQueryVariables = Types.Exact<{ [key: string]: never }>
@@ -517,6 +531,8 @@ export type GetPastCouncilQuery = {
         __typename: 'ElectedCouncil'
         id: string
         endedAtBlock?: number | null | undefined
+        endedAtNetwork?: Types.Network | null | undefined
+        endedAtTime?: any | null | undefined
         councilMembers: Array<{ __typename: 'CouncilMember'; accumulatedReward: any; unpaidReward: any }>
       }
     | null
@@ -1220,6 +1236,8 @@ export const ElectedCouncilFieldsFragmentDoc = gql`
   fragment ElectedCouncilFields on ElectedCouncil {
     id
     electedAtBlock
+    electedAtTime
+    electedAtNetwork
     councilMembers {
       ...CouncilMemberFields
     }
@@ -1230,6 +1248,8 @@ export const PastCouncilFieldsFragmentDoc = gql`
   fragment PastCouncilFields on ElectedCouncil {
     id
     endedAtBlock
+    endedAtNetwork
+    endedAtTime
   }
 `
 export const PastCouncilDetailedFieldsFragmentDoc = gql`

--- a/packages/ui/src/council/queries/council.graphql
+++ b/packages/ui/src/council/queries/council.graphql
@@ -42,6 +42,8 @@ fragment PastCouncilNewMissedRewardLevelReachedEventFields on NewMissedRewardLev
 fragment ElectedCouncilFields on ElectedCouncil {
   id
   electedAtBlock
+  electedAtTime
+  electedAtNetwork
   councilMembers {
     ...CouncilMemberFields
   }
@@ -50,6 +52,8 @@ fragment ElectedCouncilFields on ElectedCouncil {
 fragment PastCouncilFields on ElectedCouncil {
   id
   endedAtBlock
+  endedAtNetwork
+  endedAtTime
 }
 
 fragment PastCouncilDetailedFields on ElectedCouncil {

--- a/packages/ui/src/council/types/ElectedCouncil.ts
+++ b/packages/ui/src/council/types/ElectedCouncil.ts
@@ -1,15 +1,20 @@
+import { asBlock, Block } from '@/common/types'
 import { ElectedCouncilFieldsFragment } from '@/council/queries'
 
 import { asCouncilor, Councilor } from './Councilor'
 
 export interface ElectedCouncil {
   id: string
-  electedAtBlock: number
+  electedAt: Block
   councilors: Councilor[]
 }
 
 export const asElectedCouncil = (fields: ElectedCouncilFieldsFragment): ElectedCouncil => ({
   id: fields.id,
-  electedAtBlock: fields.electedAtBlock,
   councilors: fields.councilMembers.map(asCouncilor),
+  electedAt: asBlock({
+    createdAt: fields.electedAtTime,
+    inBlock: fields.electedAtBlock,
+    network: fields.electedAtNetwork,
+  }),
 })

--- a/packages/ui/src/council/types/PastCouncil.ts
+++ b/packages/ui/src/council/types/PastCouncil.ts
@@ -1,6 +1,8 @@
 import { BN_ZERO } from '@polkadot/util'
 import BN from 'bn.js'
 
+import { Network } from '@/common/api/queries'
+import { asBlock, Block } from '@/common/types'
 import {
   CouncilSpendingEventFieldsFragment,
   FundingRequestApprovedFragment,
@@ -11,7 +13,7 @@ import { asProposalDetails, DetailsFragment, FundingRequestDetails } from '@/pro
 
 export interface PastCouncil {
   id: string
-  endedAtBlock: number
+  endedAt: Block
 }
 
 export interface PastCouncilWithDetails extends PastCouncil {
@@ -23,7 +25,11 @@ export interface PastCouncilWithDetails extends PastCouncil {
 
 export const asPastCouncil = (fields: PastCouncilFieldsFragment): PastCouncil => ({
   id: fields.id,
-  endedAtBlock: fields.endedAtBlock as number,
+  endedAt: asBlock({
+    createdAt: fields.endedAtTime,
+    inBlock: fields.endedAtBlock ?? -1,
+    network: fields.endedAtNetwork ?? Network.Olympia,
+  }),
 })
 
 export const getTotalSpent = (spendingEvents: CouncilSpendingEventFieldsFragment[]) =>


### PR DESCRIPTION
See #1825

This PR adds handling of expected schema upgrade for councils "atBlock" dates: elected at and terminated at.

I suppose that this could work, but more work on mocks might be needed.