### PR TITLE
🔧 Fix the PastElections page crashing

### DIFF
--- a/packages/ui/src/common/utils/bn.ts
+++ b/packages/ui/src/common/utils/bn.ts
@@ -1,0 +1,8 @@
+import BN from 'bn.js'
+
+import { BN_ZERO } from '@/common/constants'
+
+type BNParam = number | string | number[] | Uint8Array | Buffer | BN
+
+export const sumStakes = (entities: { stake: BNParam }[]) =>
+  entities.reduce((total, { stake }) => total.add(new BN(stake)), BN_ZERO)

--- a/packages/ui/src/council/hooks/useElectionVotes.ts
+++ b/packages/ui/src/council/hooks/useElectionVotes.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 
 import { useMyAccounts } from '@/accounts/hooks/useMyAccounts'
 import { BN_ZERO } from '@/common/constants'
+import { sumStakes } from '@/common/utils/bn'
 
 import { useGetCouncilVotesQuery } from '../queries'
 import { asVote, ElectionCandidate, Vote } from '../types'
@@ -73,7 +74,7 @@ export const useElectionVotes = (election?: Election) => {
     return Object.values(candidateStats).sort((a, b) => b.totalStake.sub(a.totalStake).toNumber())
   }, [votes?.length, myCastVotes?.length])
 
-  const sumOfStakes = useMemo(() => votes?.reduce((acc, vote) => acc.add(vote.stake), BN_ZERO), [votes])
+  const sumOfStakes = useMemo(() => votes && sumStakes(votes), [votes])
 
   return {
     votesPerCandidate,

--- a/packages/ui/src/working-groups/model/getAverageStake.ts
+++ b/packages/ui/src/working-groups/model/getAverageStake.ts
@@ -1,9 +1,5 @@
-import BN from 'bn.js'
-
+import { sumStakes } from '@/common/utils/bn'
 import { WorkerFieldsFragment } from '@/working-groups/queries'
 
-export const getAverageStake = (workers: Pick<WorkerFieldsFragment, 'stake'>[]): BN => {
-  const totalStake = workers.reduce((a, b) => a.add(new BN(b.stake)), new BN(0))
-
-  return totalStake.divn(workers.length)
-}
+export const getAverageStake = (workers: Pick<WorkerFieldsFragment, 'stake'>[]) =>
+  sumStakes(workers).divn(workers.length)


### PR DESCRIPTION
After an election was completed successfully the PastElections page was crashing, because of a `BN::addn` being used to sum the candidates stakes which are strings.