### PR TITLE
🪃 Hide normal period remaining length when election is in progress

### DIFF
--- a/packages/ui/src/app/pages/Council/Council.tsx
+++ b/packages/ui/src/app/pages/Council/Council.tsx
@@ -8,9 +8,11 @@ import { SidePanel } from '@/common/components/page/SidePanel'
 import { BlockDurationStatistics, MultiValueStat, Statistics } from '@/common/components/statistics'
 import { NotFoundText } from '@/common/components/typography/NotFoundText'
 import { CouncilList, CouncilOrder } from '@/council/components/councilList'
+import { ViewElectionButton } from '@/council/components/ViewElectionButton'
 import { useCouncilActivities } from '@/council/hooks/useCouncilActivities'
 import { useCouncilStatistics } from '@/council/hooks/useCouncilStatistics'
 import { useElectedCouncil } from '@/council/hooks/useElectedCouncil'
+import { useElectionStage } from '@/council/hooks/useElectionStage'
 import { Councilor } from '@/council/types'
 
 import { CouncilTabs } from './components/CouncilTabs'
@@ -19,6 +21,7 @@ export const Council = () => {
   const { council, isLoading } = useElectedCouncil()
   const { idlePeriodRemaining, budget, reward } = useCouncilStatistics(council?.electedAtBlock)
   const { activities } = useCouncilActivities()
+  const { stage: electionStage } = useElectionStage()
 
   const [order, setOrder] = useState<CouncilOrder>({ key: 'member' })
   const councilors = useMemo(() => council?.councilors.slice(0).sort(sortBy(order)) ?? [], [council])
@@ -28,7 +31,11 @@ export const Council = () => {
   const main = (
     <MainPanel>
       <Statistics>
-        <BlockDurationStatistics title="Normal period remaining length" value={idlePeriodRemaining} />
+        {electionStage === 'inactive' ? (
+          <BlockDurationStatistics title="Normal period remaining length" value={idlePeriodRemaining} />
+        ) : (
+          <ViewElectionButton />
+        )}
         <MultiValueStat
           title="Budget"
           values={[

--- a/packages/ui/src/council/components/ViewElectionButton.tsx
+++ b/packages/ui/src/council/components/ViewElectionButton.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { useHistory } from 'react-router-dom'
+
+import { ArrowRightIcon } from '@/common/components/icons'
+import { StatisticButton } from '@/common/components/statistics/StatisticButton'
+import { TextInlineMedium } from '@/common/components/typography'
+
+import { ElectionRoutes } from '../constants'
+
+export const ViewElectionButton = () => {
+  const history = useHistory()
+  return (
+    <StatisticButton
+      title="Status"
+      onClick={() => history.push(ElectionRoutes.currentElection)}
+      icon={<ArrowRightIcon />}
+    >
+      <TextInlineMedium bold>Election in progress</TextInlineMedium>
+    </StatisticButton>
+  )
+}


### PR DESCRIPTION
Closes #1914 
According to the [Joystream handbook](https://joystream.gitbook.io/joystream-handbook/governance/council#council), Normal Period and Election Period are mutually exclusive. This would mean that the normal period remaining length shouldn't be displayed during the election period; instead, I decided to display a link to the election module instead.