### PR TITLE
🎁 Introduce basic bounty withdraw contribution modal

### DIFF
--- a/packages/ui/src/app/GlobalModals.tsx
+++ b/packages/ui/src/app/GlobalModals.tsx
@@ -3,6 +3,10 @@ import React, { ReactElement } from 'react'
 import { MoveFundsModal, MoveFundsModalCall } from '@/accounts/modals/MoveFoundsModal'
 import { RecoverBalanceModal, RecoverBalanceModalCall } from '@/accounts/modals/RecoverBalance'
 import { TransferModal, TransferModalCall } from '@/accounts/modals/TransferModal'
+import {
+  BountyWithdrawContributionModalCall,
+  WithdrawContributionModal,
+} from '@/bounty/modals/WithdrawContributionModal'
 import { SearchResultsModal, SearchResultsModalCall } from '@/common/components/Search/SearchResultsModal'
 import { useModal } from '@/common/hooks/useModal'
 import { OnBoardingModal, OnBoardingModalCall } from '@/common/modals/OnBoardingModal'
@@ -37,10 +41,6 @@ import {
   IncreaseWorkerStakeModalCall,
 } from '@/working-groups/modals/IncreaseWorkerStakeModal'
 import { LeaveRoleModal, LeaveRoleModalCall } from '@/working-groups/modals/LeaveRoleModal'
-import {
-  BountyWithdrawContributionModalCall,
-  WithdrawContributionModal,
-} from '@/bounty/modals/WithdrawContributionModal'
 
 export type ModalNames =
   | ModalName<TransferInvitesModalCall>

--- a/packages/ui/src/app/GlobalModals.tsx
+++ b/packages/ui/src/app/GlobalModals.tsx
@@ -37,6 +37,10 @@ import {
   IncreaseWorkerStakeModalCall,
 } from '@/working-groups/modals/IncreaseWorkerStakeModal'
 import { LeaveRoleModal, LeaveRoleModalCall } from '@/working-groups/modals/LeaveRoleModal'
+import {
+  BountyWithdrawContributionModalCall,
+  WithdrawContributionModal,
+} from '@/bounty/modals/WithdrawContributionModal'
 
 export type ModalNames =
   | ModalName<TransferInvitesModalCall>
@@ -68,6 +72,7 @@ export type ModalNames =
   | ModalName<IncreaseWorkerStakeModalCall>
   | ModalName<OnBoardingModalCall>
   | ModalName<RestoreVotesModalCall>
+  | ModalName<BountyWithdrawContributionModalCall>
 
 const modals: Record<ModalNames, ReactElement> = {
   Member: <MemberProfile />,
@@ -99,6 +104,7 @@ const modals: Record<ModalNames, ReactElement> = {
   IncreaseWorkerStake: <IncreaseWorkerStakeModal />,
   OnBoardingModal: <OnBoardingModal />,
   RestoreVotes: <RestoreVotesModal />,
+  BountyWithdrawContributionModal: <WithdrawContributionModal />,
 }
 
 export const GlobalModals = () => {

--- a/packages/ui/src/bounty/modals/WithdrawContributionModal/WithdrawContributionModal.tsx
+++ b/packages/ui/src/bounty/modals/WithdrawContributionModal/WithdrawContributionModal.tsx
@@ -14,14 +14,14 @@ import { useModal } from '@/common/hooks/useModal'
 import { defaultTransactionModalMachine } from '@/common/model/machines/defaultTransactionModalMachine'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 
-import { WithdrawFundingModalCall } from '.'
+import { BountyWithdrawContributionModalCall } from '.'
 
 export const WithdrawContributionModal = () => {
   const { api, connectionState } = useApi()
   const {
     modalData: { bountyId },
     hideModal,
-  } = useModal<WithdrawFundingModalCall>()
+  } = useModal<BountyWithdrawContributionModalCall>()
 
   const [state, send] = useMachine(defaultTransactionModalMachine)
 

--- a/packages/ui/src/bounty/modals/WithdrawContributionModal/WithdrawContributionModal.tsx
+++ b/packages/ui/src/bounty/modals/WithdrawContributionModal/WithdrawContributionModal.tsx
@@ -1,0 +1,93 @@
+import { useMachine } from '@xstate/react'
+import React, { useEffect, useMemo } from 'react'
+
+import { useMyAccounts } from '@/accounts/hooks/useMyAccounts'
+import { useTransactionFee } from '@/accounts/hooks/useTransactionFee'
+import { InsufficientFundsModal } from '@/accounts/modals/InsufficientFundsModal'
+import { accountOrNamed } from '@/accounts/model/accountOrNamed'
+import { WithdrawContributionSignModal } from '@/bounty/modals/WithdrawContributionModal/WithdrawContributionSignModal'
+import { FailureModal } from '@/common/components/FailureModal'
+import { SuccessModal } from '@/common/components/SuccessModal'
+import { WaitModal } from '@/common/components/WaitModal'
+import { useApi } from '@/common/hooks/useApi'
+import { useModal } from '@/common/hooks/useModal'
+import { defaultTransactionModalMachine } from '@/common/model/machines/defaultTransactionModalMachine'
+import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
+
+import { WithdrawFundingModalCall } from '.'
+
+export const WithdrawContributionModal = () => {
+  const { api, connectionState } = useApi()
+  const {
+    modalData: { bountyId },
+    hideModal,
+  } = useModal<WithdrawFundingModalCall>()
+
+  const [state, send] = useMachine(defaultTransactionModalMachine)
+
+  const { active: activeMember } = useMyMemberships()
+  const { allAccounts } = useMyAccounts()
+
+  const transaction = useMemo(() => {
+    if (api && connectionState === 'connected' && activeMember) {
+      return api.tx.bounty.withdrawFunding({ Member: activeMember.id }, bountyId)
+    }
+  }, [JSON.stringify(activeMember), connectionState])
+
+  const feeInfo = useTransactionFee(activeMember?.controllerAccount, transaction)
+
+  useEffect(() => {
+    if (state.matches('requirementsVerification')) {
+      if (transaction && feeInfo && activeMember) {
+        feeInfo.canAfford && send('PASS')
+        !feeInfo.canAfford && send('FAIL')
+      }
+    }
+  }, [state.value, transaction, feeInfo?.canAfford])
+
+  if (state.matches('requirementsVerification')) {
+    return <WaitModal title="Please wait..." description="Checking requirements" onClose={hideModal} />
+  }
+
+  if (!api || !activeMember || !transaction || !feeInfo) {
+    return null
+  }
+
+  if (state.matches('transaction')) {
+    const service = state.children.transaction
+    const controllerAccount = accountOrNamed(allAccounts, activeMember.controllerAccount, 'Controller Account')
+
+    return (
+      <WithdrawContributionSignModal
+        onClose={hideModal}
+        transaction={transaction}
+        service={service}
+        controllerAccount={controllerAccount}
+      />
+    )
+  }
+
+  if (state.matches('success')) {
+    return <SuccessModal onClose={hideModal} text="Your contribution has been successfully withdrawn." />
+  }
+
+  if (state.matches('error')) {
+    return (
+      <FailureModal onClose={hideModal} events={state.context.transactionEvents}>
+        There was a problem while withdrawing your contribution.
+      </FailureModal>
+    )
+  }
+
+  if (state.matches('requirementsFailed')) {
+    return (
+      <InsufficientFundsModal
+        onClose={hideModal}
+        address={activeMember.controllerAccount}
+        amount={feeInfo.transactionFee}
+      />
+    )
+  }
+
+  return null
+}

--- a/packages/ui/src/bounty/modals/WithdrawContributionModal/WithdrawContributionSignModal.tsx
+++ b/packages/ui/src/bounty/modals/WithdrawContributionModal/WithdrawContributionSignModal.tsx
@@ -35,7 +35,7 @@ export const WithdrawContributionSignModal = ({ onClose, transaction, service, c
   return (
     <TransactionModal onClose={onClose} service={service}>
       <ModalBody>
-        <TextMedium light>You intend to withdraw your contribution from this bounty.</TextMedium>
+        <TextMedium light>You intend to withdraw your contribution for this bounty.</TextMedium>
         <TextMedium light>
           Fees of <TokenValue value={paymentInfo?.partialFee.toBn()} /> will be applied to the transaction.
         </TextMedium>

--- a/packages/ui/src/bounty/modals/WithdrawContributionModal/WithdrawContributionSignModal.tsx
+++ b/packages/ui/src/bounty/modals/WithdrawContributionModal/WithdrawContributionSignModal.tsx
@@ -1,0 +1,62 @@
+import { SubmittableExtrinsic } from '@polkadot/api/types'
+import { ISubmittableResult } from '@polkadot/types/types'
+import React from 'react'
+import { ActorRef } from 'xstate'
+
+import { SelectedAccount } from '@/accounts/components/SelectAccount'
+import { useMyAccounts } from '@/accounts/hooks/useMyAccounts'
+import { accountOrNamed } from '@/accounts/model/accountOrNamed'
+import { Account } from '@/accounts/types'
+import { ButtonPrimary } from '@/common/components/buttons'
+import { InputComponent } from '@/common/components/forms'
+import { Arrow } from '@/common/components/icons'
+import { ModalBody, ModalFooter, TransactionInfoContainer } from '@/common/components/Modal'
+import { TransactionInfo } from '@/common/components/TransactionInfo'
+import { TextMedium, TokenValue } from '@/common/components/typography'
+import { useSignAndSendTransaction } from '@/common/hooks/useSignAndSendTransaction'
+import { TransactionModal } from '@/common/modals/TransactionModal'
+
+interface Props {
+  onClose: () => void
+  transaction: SubmittableExtrinsic<'rxjs', ISubmittableResult>
+  service: ActorRef<any>
+  controllerAccount: Account
+}
+
+export const WithdrawContributionSignModal = ({ onClose, transaction, service, controllerAccount }: Props) => {
+  const { allAccounts } = useMyAccounts()
+
+  const { sign, isReady, paymentInfo } = useSignAndSendTransaction({
+    service,
+    transaction,
+    signer: controllerAccount.address,
+  })
+
+  return (
+    <TransactionModal onClose={onClose} service={service}>
+      <ModalBody>
+        <TextMedium light>You intend to withdraw your contribution from this bounty.</TextMedium>
+        <TextMedium light>
+          Fees of <TokenValue value={paymentInfo?.partialFee.toBn()} /> will be applied to the transaction.
+        </TextMedium>
+
+        <InputComponent label="Fee sending from account" inputSize="l">
+          <SelectedAccount account={accountOrNamed(allAccounts, controllerAccount.address, 'Account')} />
+        </InputComponent>
+      </ModalBody>
+      <ModalFooter>
+        <TransactionInfoContainer>
+          <TransactionInfo
+            title="Transaction fee:"
+            value={paymentInfo?.partialFee.toBn()}
+            tooltipText="Lorem ipsum dolor sit amet consectetur, adipisicing elit."
+          />
+        </TransactionInfoContainer>
+        <ButtonPrimary size="medium" disabled={!isReady} onClick={sign}>
+          Sign and withdraw
+          <Arrow direction="right" />
+        </ButtonPrimary>
+      </ModalFooter>
+    </TransactionModal>
+  )
+}

--- a/packages/ui/src/bounty/modals/WithdrawContributionModal/index.ts
+++ b/packages/ui/src/bounty/modals/WithdrawContributionModal/index.ts
@@ -1,4 +1,7 @@
 import { ModalWithDataCall } from '@/common/providers/modal/types'
 
 export * from './WithdrawContributionModal'
-export type WithdrawFundingModalCall = ModalWithDataCall<'WithdrawContributionModal', { bountyId: string }>
+export type BountyWithdrawContributionModalCall = ModalWithDataCall<
+  'BountyWithdrawContributionModal',
+  { bountyId: string }
+>

--- a/packages/ui/src/bounty/modals/WithdrawContributionModal/index.ts
+++ b/packages/ui/src/bounty/modals/WithdrawContributionModal/index.ts
@@ -1,0 +1,4 @@
+import { ModalWithDataCall } from '@/common/providers/modal/types'
+
+export * from './WithdrawContributionModal'
+export type WithdrawFundingModalCall = ModalWithDataCall<'WithdrawContributionModal', { bountyId: string }>

--- a/packages/ui/src/common/components/SuccessModal.tsx
+++ b/packages/ui/src/common/components/SuccessModal.tsx
@@ -8,7 +8,7 @@ interface Props {
   text: string
 }
 
-export const PostActionSuccessModal = ({ onClose, text }: Props) => (
+export const SuccessModal = ({ onClose, text }: Props) => (
   <Modal onClose={onClose} modalSize="m">
     <ModalHeader onClick={onClose} title="Success!" />
     <ModalBody>

--- a/packages/ui/src/common/model/machines/defaultTransactionModalMachine.ts
+++ b/packages/ui/src/common/model/machines/defaultTransactionModalMachine.ts
@@ -6,7 +6,7 @@ import {
   isTransactionError,
   isTransactionSuccess,
   transactionMachine,
-} from '@/common/model/machines'
+} from '@/common/model/machines/index'
 import { EmptyObject } from '@/common/types'
 
 interface TransactionContext {
@@ -20,9 +20,9 @@ type PostActionState =
   | { value: 'success'; context: EmptyObject }
   | { value: 'error'; context: Required<TransactionContext> }
 
-export type PostActionEvent = { type: 'FAIL' } | { type: 'PASS' }
+export type ActionEvents = { type: 'FAIL' } | { type: 'PASS' }
 
-export const postActionMachine = createMachine<TransactionContext, PostActionEvent, PostActionState>({
+export const defaultTransactionModalMachine = createMachine<TransactionContext, ActionEvents, PostActionState>({
   initial: 'requirementsVerification',
   states: {
     requirementsVerification: {

--- a/packages/ui/src/forum/modals/PostActionModal/CreatePostModal/CreatePostModal.tsx
+++ b/packages/ui/src/forum/modals/PostActionModal/CreatePostModal/CreatePostModal.tsx
@@ -7,13 +7,12 @@ import { useTransactionFee } from '@/accounts/hooks/useTransactionFee'
 import { InsufficientFundsModal } from '@/accounts/modals/InsufficientFundsModal'
 import { accountOrNamed } from '@/accounts/model/accountOrNamed'
 import { FailureModal } from '@/common/components/FailureModal'
+import { SuccessModal } from '@/common/components/SuccessModal'
 import { WaitModal } from '@/common/components/WaitModal'
 import { useApi } from '@/common/hooks/useApi'
 import { useModal } from '@/common/hooks/useModal'
+import { defaultTransactionModalMachine } from '@/common/model/machines/defaultTransactionModalMachine'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
-
-import { postActionMachine } from '../postActionMachine'
-import { PostActionSuccessModal } from '../PostActionSuccessModal'
 
 import { CreatePostModalCall } from '.'
 import { CreatePostSignModal } from './CreatePostSignModal'
@@ -29,7 +28,7 @@ export const CreatePostModal = () => {
     hideModal()
   }, [])
 
-  const [state, send] = useMachine(postActionMachine)
+  const [state, send] = useMachine(defaultTransactionModalMachine)
 
   const { active } = useMyMemberships()
   const { allAccounts } = useMyAccounts()
@@ -83,7 +82,7 @@ export const CreatePostModal = () => {
   }
 
   if (state.matches('success')) {
-    return <PostActionSuccessModal onClose={hideModalAfterSuccess} text="Your post has been submitted." />
+    return <SuccessModal onClose={hideModalAfterSuccess} text="Your post has been submitted." />
   }
 
   if (state.matches('requirementsFailed') && active && feeInfo) {

--- a/packages/ui/src/forum/modals/PostActionModal/DeletePostModal/DeletePostModal.tsx
+++ b/packages/ui/src/forum/modals/PostActionModal/DeletePostModal/DeletePostModal.tsx
@@ -6,13 +6,13 @@ import { useTransactionFee } from '@/accounts/hooks/useTransactionFee'
 import { InsufficientFundsModal } from '@/accounts/modals/InsufficientFundsModal'
 import { accountOrNamed } from '@/accounts/model/accountOrNamed'
 import { FailureModal } from '@/common/components/FailureModal'
+import { SuccessModal } from '@/common/components/SuccessModal'
 import { WaitModal } from '@/common/components/WaitModal'
 import { useModal } from '@/common/hooks/useModal'
+import { defaultTransactionModalMachine } from '@/common/model/machines/defaultTransactionModalMachine'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 
-import { postActionMachine } from '../postActionMachine'
 import { PostActionSignModal } from '../PostActionSignModal'
-import { PostActionSuccessModal } from '../PostActionSuccessModal'
 
 import { DeletePostModalCall } from '.'
 
@@ -22,7 +22,7 @@ export const DeletePostModal = () => {
     hideModal,
   } = useModal<DeletePostModalCall>()
 
-  const [state, send] = useMachine(postActionMachine)
+  const [state, send] = useMachine(defaultTransactionModalMachine)
 
   const { active } = useMyMemberships()
   const { allAccounts } = useMyAccounts()
@@ -58,7 +58,7 @@ export const DeletePostModal = () => {
   }
 
   if (state.matches('success')) {
-    return <PostActionSuccessModal onClose={hideModal} text="Your post has been deleted." />
+    return <SuccessModal onClose={hideModal} text="Your post has been deleted." />
   }
 
   if (state.matches('error')) {

--- a/packages/ui/src/forum/modals/PostActionModal/EditPostModal/EditPostModal.tsx
+++ b/packages/ui/src/forum/modals/PostActionModal/EditPostModal/EditPostModal.tsx
@@ -6,13 +6,13 @@ import { useTransactionFee } from '@/accounts/hooks/useTransactionFee'
 import { InsufficientFundsModal } from '@/accounts/modals/InsufficientFundsModal'
 import { accountOrNamed } from '@/accounts/model/accountOrNamed'
 import { FailureModal } from '@/common/components/FailureModal'
+import { SuccessModal } from '@/common/components/SuccessModal'
 import { WaitModal } from '@/common/components/WaitModal'
 import { useModal } from '@/common/hooks/useModal'
+import { defaultTransactionModalMachine } from '@/common/model/machines/defaultTransactionModalMachine'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 
-import { postActionMachine } from '../postActionMachine'
 import { PostActionSignModal } from '../PostActionSignModal'
-import { PostActionSuccessModal } from '../PostActionSuccessModal'
 
 import { EditPostModalCall } from '.'
 
@@ -22,7 +22,7 @@ export const EditPostModal = () => {
     hideModal,
   } = useModal<EditPostModalCall>()
 
-  const [state, send] = useMachine(postActionMachine)
+  const [state, send] = useMachine(defaultTransactionModalMachine)
 
   const { active } = useMyMemberships()
   const { allAccounts } = useMyAccounts()
@@ -79,7 +79,7 @@ export const EditPostModal = () => {
   }
 
   if (state.matches('success')) {
-    return <PostActionSuccessModal onClose={() => hideModalWithAction(true)} text="Your edit has been submitted." />
+    return <SuccessModal onClose={() => hideModalWithAction(true)} text="Your edit has been submitted." />
   }
 
   if (state.matches('requirementsFailed') && active && feeInfo) {

--- a/packages/ui/test/bounty/modals/WithdrawContributionModal.test.tsx
+++ b/packages/ui/test/bounty/modals/WithdrawContributionModal.test.tsx
@@ -1,0 +1,122 @@
+import { cryptoWaitReady } from '@polkadot/util-crypto'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { AccountsContext } from '@/accounts/providers/accounts/context'
+import {
+  BountyWithdrawContributionModalCall,
+  WithdrawContributionModal,
+} from '@/bounty/modals/WithdrawContributionModal'
+import { ApiContext } from '@/common/providers/api/context'
+import { ModalContext } from '@/common/providers/modal/context'
+import { ModalCallData, UseModal } from '@/common/providers/modal/types'
+import { MembershipContext } from '@/memberships/providers/membership/context'
+import { MyMemberships } from '@/memberships/providers/membership/provider'
+
+import { getButton } from '../../_helpers/getButton'
+import { alice, bob } from '../../_mocks/keyring'
+import { getMember } from '../../_mocks/members'
+import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
+import {
+  stubApi,
+  stubDefaultBalances,
+  stubTransaction,
+  stubTransactionFailure,
+  stubTransactionSuccess,
+} from '../../_mocks/transactions'
+
+jest.mock('@/common/hooks/useQueryNodeTransactionStatus', () => ({
+  useQueryNodeTransactionStatus: () => 'confirmed',
+}))
+
+describe('UI: WithdrawContributionModal', () => {
+  const modalData: ModalCallData<BountyWithdrawContributionModalCall> = {
+    bountyId: '1',
+  }
+
+  const api = stubApi()
+  const txPath = 'api.tx.bounty.withdrawFunding'
+  let tx = stubTransaction(api, txPath)
+
+  const useModal: UseModal<any> = {
+    hideModal: jest.fn(),
+    showModal: jest.fn(),
+    modal: null,
+    modalData,
+  }
+  const useMyMemberships: MyMemberships = {
+    active: getMember('alice'),
+    members: [getMember('alice'), getMember('bob')],
+    setActive: (member) => (useMyMemberships.active = member),
+    isLoading: false,
+    hasMembers: true,
+    helpers: {
+      getMemberIdByBoundAccountAddress: () => undefined,
+    },
+  }
+  const useAccounts = {
+    isLoading: false,
+    hasAccounts: true,
+    allAccounts: [alice, bob],
+  }
+
+  beforeAll(async () => {
+    await cryptoWaitReady()
+  })
+
+  beforeEach(async () => {
+    stubDefaultBalances(api)
+    tx = stubTransaction(api, txPath)
+  })
+
+  it('Requirements passed', async () => {
+    renderModal()
+
+    expect(screen.queryByText(/You intend to withdraw your contribution for this bounty/i)).not.toBeNull()
+    expect(screen.queryByText(/Sign and withdraw/i)).not.toBeNull()
+  })
+
+  it('Requirements failed', async () => {
+    tx = stubTransaction(api, txPath, 10000)
+    renderModal()
+
+    expect(await screen.findByText('Insufficient Funds')).toBeDefined()
+  })
+
+  it('Transaction failed', async () => {
+    stubTransactionFailure(tx)
+    renderModal()
+
+    await act(async () => {
+      fireEvent.click(await getButton(/Sign and withdraw/i))
+    })
+    expect(await screen.findByText('There was a problem while withdrawing your contribution.')).toBeDefined()
+  })
+
+  it('Transaction success', async () => {
+    stubTransactionSuccess(tx, 'bounty', 'BountyFundingWithdrawal')
+    renderModal()
+
+    await act(async () => {
+      fireEvent.click(await getButton(/Sign and withdraw/i))
+    })
+    expect(await screen.findByText('Your contribution has been successfully withdrawn.')).toBeDefined()
+  })
+
+  const renderModal = () =>
+    render(
+      <ModalContext.Provider value={useModal}>
+        <MockQueryNodeProviders>
+          <MockKeyringProvider>
+            <AccountsContext.Provider value={useAccounts}>
+              <MembershipContext.Provider value={useMyMemberships}>
+                <ApiContext.Provider value={api}>
+                  <WithdrawContributionModal />
+                </ApiContext.Provider>
+              </MembershipContext.Provider>
+            </AccountsContext.Provider>
+          </MockKeyringProvider>
+        </MockQueryNodeProviders>
+      </ModalContext.Provider>
+    )
+})


### PR DESCRIPTION
Closes #2021 

I believe for now ticket worth closing, and mb we should create follow-up for **Revisit withdraw contribution modal**:
- Allow actor as council (not done now, because I don't see the app behaviour for council member in the design)
- Display amount of contributed locks amount in SignModal(not done now, because initial bounty queries are still in review and it's lot of stuff to be done in mocks, best way is to postpone this)

I can create follow-up on my own, just tell me what column in ZenHub it should be in 🙈
