### PR TITLE
🐸 Announcing stage fixes

### DIFF
--- a/packages/ui/src/council/components/election/announcing/AnnouncingStage.tsx
+++ b/packages/ui/src/council/components/election/announcing/AnnouncingStage.tsx
@@ -19,11 +19,11 @@ export const AnnouncingStage = ({ election, isLoading }: AnnouncingStageProps) =
 
   const [allCandidates, myCandidates] = useMemo(() => {
     const allCandidates = election?.candidates
-      ?.map((candidate) => ({
+      .filter((candidate) => candidate.status === CandidacyStatus.Active)
+      .map((candidate) => ({
         ...candidate,
         isMyCandidate: myMemberIds.includes(candidate.member.id),
       }))
-      .filter((candidate) => candidate.status === CandidacyStatus.Active)
     const myCandidates = allCandidates?.filter(({ isMyCandidate }) => isMyCandidate)
 
     return [allCandidates, myCandidates]

--- a/packages/ui/src/council/components/election/announcing/AnnouncingStage.tsx
+++ b/packages/ui/src/council/components/election/announcing/AnnouncingStage.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react'
 
 import { CandidateCardList } from '@/council/components/election/CandidateCard/CandidateCardList'
 import { AnnouncingStageTab, CurrentElectionTabs } from '@/council/components/election/CurrentElectionTabs'
+import { CandidacyStatus } from '@/council/types'
 import { Election } from '@/council/types/Election'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 
@@ -17,10 +18,12 @@ export const AnnouncingStage = ({ election, isLoading }: AnnouncingStageProps) =
   const myMemberIds = useMemo(() => myMembers.map(({ id }) => id), [myMembers.length])
 
   const [allCandidates, myCandidates] = useMemo(() => {
-    const allCandidates = election?.candidates?.map((candidate) => ({
-      ...candidate,
-      isMyCandidate: myMemberIds.includes(candidate.member.id),
-    }))
+    const allCandidates = election?.candidates
+      ?.map((candidate) => ({
+        ...candidate,
+        isMyCandidate: myMemberIds.includes(candidate.member.id),
+      }))
+      .filter((candidate) => candidate.status === CandidacyStatus.Active)
     const myCandidates = allCandidates?.filter(({ isMyCandidate }) => isMyCandidate)
 
     return [allCandidates, myCandidates]

--- a/packages/ui/src/council/components/election/voting/VotingStage.tsx
+++ b/packages/ui/src/council/components/election/voting/VotingStage.tsx
@@ -6,6 +6,7 @@ import { CandidateCardList } from '@/council/components/election/CandidateCard/C
 import { CurrentElectionTabs, VotingStageTab } from '@/council/components/election/CurrentElectionTabs'
 import { useMyCurrentVotesCount } from '@/council/hooks/useMyCurrentVotesCount'
 import { useVerifiedVotingAttempts } from '@/council/hooks/useVerifiedVotingAttempts'
+import { CandidacyStatus } from '@/council/types'
 import { Election } from '@/council/types/Election'
 
 interface VotingStageProps {
@@ -23,10 +24,12 @@ export const VotingStage = ({ election, isLoading }: VotingStageProps) => {
   const canVote = isDefined(votesTotal) && allAccounts.length > votesTotal
 
   const [allCandidates, votedForCandidates] = useMemo(() => {
-    const allCandidates = election?.candidates?.map((candidate) => ({
-      ...candidate,
-      voted: optionIds?.has(candidate.member.id),
-    }))
+    const allCandidates = election?.candidates
+      .filter((candidate) => candidate.status === CandidacyStatus.Active)
+      .map((candidate) => ({
+        ...candidate,
+        voted: optionIds?.has(candidate.member.id),
+      }))
     const votedForCandidates = allCandidates?.filter(({ voted }) => voted)
 
     return [allCandidates, votedForCandidates]

--- a/packages/ui/src/council/modals/AnnounceCandidacy/AnnounceCandidacyModal.tsx
+++ b/packages/ui/src/council/modals/AnnounceCandidacy/AnnounceCandidacyModal.tsx
@@ -29,7 +29,7 @@ import { TitleAndBulletPointsStep } from '@/council/modals/AnnounceCandidacy/com
 import { AnnounceCandidacyTransaction } from '@/council/modals/AnnounceCandidacy/components/transactions/AnnounceCandidacyTransaction'
 import { CandidacyNoteTransaction } from '@/council/modals/AnnounceCandidacy/components/transactions/CandidacyNoteTransaction'
 import { announceCandidacyMachine, FinalAnnounceCandidacyContext } from '@/council/modals/AnnounceCandidacy/machine'
-import { ElectionCandidateWithDetails } from '@/council/types'
+import { CandidacyStatus, ElectionCandidateWithDetails } from '@/council/types'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 import { BindStakingAccountModal } from '@/memberships/modals/BindStakingAccountModal/BindStakingAccountModal'
 import { SwitchMemberModalCall } from '@/memberships/modals/SwitchMemberModal'
@@ -53,6 +53,7 @@ const getCandidateForPreview = (
   member,
   cycleId: 0,
   cycleFinished: false,
+  status: CandidacyStatus.Active,
 })
 
 const transactionSteps = [

--- a/packages/ui/src/council/queries/__generated__/council.generated.tsx
+++ b/packages/ui/src/council/queries/__generated__/council.generated.tsx
@@ -189,6 +189,7 @@ export type ElectionCandidateFieldsFragment = {
   __typename: 'Candidate'
   id: string
   stake: any
+  status: Types.CandidacyStatus
   member: {
     __typename: 'Membership'
     id: string
@@ -230,6 +231,7 @@ export type ElectionRoundFieldsFragment = {
     __typename: 'Candidate'
     id: string
     stake: any
+    status: Types.CandidacyStatus
     member: {
       __typename: 'Membership'
       id: string
@@ -287,6 +289,7 @@ export type PastElectionRoundDetailedFieldsFragment = {
     __typename: 'Candidate'
     stake: any
     id: string
+    status: Types.CandidacyStatus
     member: {
       __typename: 'Membership'
       id: string
@@ -335,6 +338,7 @@ export type ElectionCandidateDetailedFieldsFragment = {
   rewardAccountId: string
   id: string
   stake: any
+  status: Types.CandidacyStatus
   electionRound: { __typename: 'ElectionRound'; cycleId: number; isFinished: boolean }
   member: {
     __typename: 'Membership'
@@ -382,6 +386,7 @@ export type CastVoteFieldsFragment = {
         __typename: 'Candidate'
         id: string
         stake: any
+        status: Types.CandidacyStatus
         member: {
           __typename: 'Membership'
           id: string
@@ -831,6 +836,7 @@ export type GetCurrentElectionQuery = {
       __typename: 'Candidate'
       id: string
       stake: any
+      status: Types.CandidacyStatus
       member: {
         __typename: 'Membership'
         id: string
@@ -912,6 +918,7 @@ export type GetPastElectionQuery = {
           __typename: 'Candidate'
           stake: any
           id: string
+          status: Types.CandidacyStatus
           member: {
             __typename: 'Membership'
             id: string
@@ -974,6 +981,7 @@ export type GetCandidateQuery = {
         rewardAccountId: string
         id: string
         stake: any
+        status: Types.CandidacyStatus
         electionRound: { __typename: 'ElectionRound'; cycleId: number; isFinished: boolean }
         member: {
           __typename: 'Membership'
@@ -1062,6 +1070,7 @@ export type GetCouncilVotesQuery = {
           __typename: 'Candidate'
           id: string
           stake: any
+          status: Types.CandidacyStatus
           member: {
             __typename: 'Membership'
             id: string
@@ -1311,6 +1320,7 @@ export const ElectionCandidateFieldsFragmentDoc = gql`
       bannerImageUri
       description
     }
+    status
   }
   ${MemberFieldsFragmentDoc}
 `

--- a/packages/ui/src/council/queries/council.graphql
+++ b/packages/ui/src/council/queries/council.graphql
@@ -76,6 +76,7 @@ fragment ElectionCandidateFields on Candidate {
     bannerImageUri
     description
   }
+  status
 }
 
 fragment ElectionRoundFields on ElectionRound {

--- a/packages/ui/src/council/types/Candidate.ts
+++ b/packages/ui/src/council/types/Candidate.ts
@@ -1,8 +1,11 @@
 import BN from 'bn.js'
 
+import { CandidacyStatus } from '@/common/api/queries'
 import { asMember, Member } from '@/memberships/types'
 
 import { ElectionCandidateDetailedFieldsFragment, ElectionCandidateFieldsFragment } from '../queries'
+
+export { CandidacyStatus } from '@/common/api/queries'
 
 export interface ElectionCandidate {
   id: string
@@ -13,6 +16,7 @@ export interface ElectionCandidate {
     bulletPoints: string[]
     bannerUri?: string
   }
+  status: CandidacyStatus
 }
 
 export interface ElectionCandidateWithDetails extends ElectionCandidate {
@@ -32,6 +36,7 @@ export const asElectionCandidate = (fields: ElectionCandidateFieldsFragment): El
     bulletPoints: fields.noteMetadata.bulletPoints,
     bannerUri: fields.noteMetadata.bannerImageUri ?? undefined,
   },
+  status: fields.status,
 })
 
 export const asElectionCandidateWithDetails = (


### PR DESCRIPTION
See #1953 

I think displaying only active candidacies in the revealing stage does the job with both hiding withdrawn candidacies and hiding previous candidates after a missed election. The filtering takes place in the frontend and not in a query, since the current query is simple and elegant enough (and not really in need of optimization yet).

I wasn't able to find a reason why the last point would happen - from what I could gather from the [runtime code](https://github.com/Joystream/joystream/blob/db3885858a7812377a19390968bdbf65221f0270/runtime-modules/council/src/lib.rs#L1476), there is a check for an existing candidacy. Maybe the announcing period number was wrong on-chain?