### PR TITLE
🤿 Add helpers to simplify seeding bounties in tests

### DIFF
--- a/packages/ui/src/mocks/data/seedForum.ts
+++ b/packages/ui/src/mocks/data/seedForum.ts
@@ -1,5 +1,7 @@
 import { BlockFieldsMock } from '@/mocks/data/common'
 
+import { seedOverridableEntities } from '../helpers/seedEntities'
+
 import rawForumCategories from './raw/forumCategories.json'
 import rawForumPosts from './raw/forumPosts.json'
 import rawForumThreads from './raw/forumThreads.json'
@@ -72,9 +74,7 @@ export function seedForumCategory(forumCategoryData: RawForumCategoryMock, serve
   })
 }
 
-export const seedForumCategories = (server: any) => {
-  categoriesData.map((forumCategoryData) => seedForumCategory(forumCategoryData, server))
-}
+export const seedForumCategories = seedOverridableEntities<RawForumCategoryMock>(categoriesData, seedForumCategory)
 
 const seedThreadCreatedInEvent = (event: { inBlock: number }, server: any) =>
   server.schema.create('ThreadCreatedEvent', event)
@@ -103,9 +103,7 @@ export async function seedForumThread(data: RawForumThreadMock, server: any) {
   return thread.update({ status: seedThreadStatus(data.status, data.id, server) })
 }
 
-export const seedForumThreads = (server: any) => {
-  threadsData.map((data) => seedForumThread(data, server))
-}
+export const seedForumThreads = seedOverridableEntities<RawForumThreadMock>(threadsData, seedForumThread)
 
 export function seedForumPost(data: RawForumPostMock, server: any) {
   const sortedEdits = data.edits.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
@@ -125,6 +123,4 @@ export function seedForumPost(data: RawForumPostMock, server: any) {
   })
 }
 
-export const seedForumPosts = (server: any) => {
-  postsData.map((data) => seedForumPost(data, server))
-}
+export const seedForumPosts = seedOverridableEntities<RawForumPostMock>(postsData, seedForumPost)

--- a/packages/ui/test/_mocks/bounty/helpers.ts
+++ b/packages/ui/test/_mocks/bounty/helpers.ts
@@ -1,0 +1,29 @@
+import { RawBountyMock, seedBounties } from '@/mocks/data'
+import { seedForumCategories, seedForumThreads } from '@/mocks/data/seedForum'
+
+export const seedBountyThread = (server: any) => {
+  seedForumCategories(server, [{ moderatorIds: [] }])
+  seedForumThreads(server, [{ authorId: '0' }])
+}
+
+export const seedSafeBounties = (server: any, overrides: Partial<RawBountyMock>[] = [{}, {}, {}, {}]) => {
+  const baseBounty = {
+    creatorId: undefined,
+    oracleId: undefined,
+    contractType: { type: 'Open' },
+    discussionThreadId: '0',
+  }
+  const safeBounties = [
+    { ...baseBounty, creatorId: '0' },
+    { ...baseBounty, oracleId: '1' },
+    { ...baseBounty, creatorId: '1', oracleId: '0' },
+    { ...baseBounty, contractType: { type: 'Closed', whitelistIds: ['0', '1'] } },
+  ]
+
+  const bounties = overrides.map((override, index) => {
+    const safeBounty = safeBounties[index % safeBounties.length]
+    return { ...safeBounty, override }
+  })
+
+  seedBounties(server, bounties)
+}


### PR DESCRIPTION
Closes  #2071
Usage:
```ts
seedMembers(mockServer.server, 2)
seedBountyThread(mockServer.server)
seedSafeBounties(mockServer.server, [
  { stage: 'Funding' },
  { stage: 'Funding' },
  { stage: 'WorkSubmission' },
  { stage: 'Terminated' },
  { stage: 'Terminated' },
])
```
This seeds 5 bounties with different stages.

There is no need for helpers for the contributions and the entries. If needed they can already be seeded like this:
```ts
seedBountyContributions(server, [{ bountyId: '2' }, { bountyId: '3' }])
seedBountyEntries(server, [{ bountyId: '3' }, { bountyId: '3' }])
```