### PR TITLE
✏️ Update schema to allow filtering by `groupId_in`

### DIFF
--- a/packages/ui/src/common/api/queries/__generated__/baseTypes.generated.ts
+++ b/packages/ui/src/common/api/queries/__generated__/baseTypes.generated.ts
@@ -21469,6 +21469,7 @@ export type Worker = BaseGraphQlObject & {
   entry: OpeningFilledEvent
   entryId: Scalars['String']
   group: WorkingGroup
+  /** The id the group that the worker belongs to */
   groupId: Scalars['String']
   id: Scalars['ID']
   /** Whether the worker is also the working group lead */
@@ -21529,6 +21530,7 @@ export type WorkerCreateInput = {
   application: Scalars['ID']
   entry: Scalars['ID']
   group: Scalars['ID']
+  groupId: Scalars['String']
   isLead: Scalars['Boolean']
   membership: Scalars['ID']
   missingRewardAmount?: InputMaybe<Scalars['String']>
@@ -21690,6 +21692,8 @@ export enum WorkerOrderByInput {
   DeletedAtDesc = 'deletedAt_DESC',
   EntryAsc = 'entry_ASC',
   EntryDesc = 'entry_DESC',
+  GroupIdAsc = 'groupId_ASC',
+  GroupIdDesc = 'groupId_DESC',
   GroupAsc = 'group_ASC',
   GroupDesc = 'group_DESC',
   IsLeadAsc = 'isLead_ASC',
@@ -22324,6 +22328,7 @@ export type WorkerUpdateInput = {
   application?: InputMaybe<Scalars['ID']>
   entry?: InputMaybe<Scalars['ID']>
   group?: InputMaybe<Scalars['ID']>
+  groupId?: InputMaybe<Scalars['String']>
   isLead?: InputMaybe<Scalars['Boolean']>
   membership?: InputMaybe<Scalars['ID']>
   missingRewardAmount?: InputMaybe<Scalars['String']>
@@ -22373,6 +22378,11 @@ export type WorkerWhereInput = {
   deletedById_in?: InputMaybe<Array<Scalars['ID']>>
   entry?: InputMaybe<OpeningFilledEventWhereInput>
   group?: InputMaybe<WorkingGroupWhereInput>
+  groupId_contains?: InputMaybe<Scalars['String']>
+  groupId_endsWith?: InputMaybe<Scalars['String']>
+  groupId_eq?: InputMaybe<Scalars['String']>
+  groupId_in?: InputMaybe<Array<Scalars['String']>>
+  groupId_startsWith?: InputMaybe<Scalars['String']>
   id_eq?: InputMaybe<Scalars['ID']>
   id_in?: InputMaybe<Array<Scalars['ID']>>
   isLead_eq?: InputMaybe<Scalars['Boolean']>

--- a/packages/ui/src/common/api/schemas/schema.graphql
+++ b/packages/ui/src/common/api/schemas/schema.graphql
@@ -21856,6 +21856,10 @@ type Worker implements BaseGraphQLObject {
   """
   runtimeId: Int!
   group: WorkingGroup!
+
+  """
+  The id the group that the worker belongs to
+  """
   groupId: String!
   membership: Membership!
   membershipId: String!
@@ -21944,6 +21948,7 @@ type WorkerConnection {
 input WorkerCreateInput {
   runtimeId: Float!
   group: ID!
+  groupId: String!
   membership: ID!
   roleAccount: String!
   rewardAccount: String!
@@ -22117,6 +22122,8 @@ enum WorkerOrderByInput {
   runtimeId_DESC
   group_ASC
   group_DESC
+  groupId_ASC
+  groupId_DESC
   membership_ASC
   membership_DESC
   roleAccount_ASC
@@ -22805,6 +22812,7 @@ type WorkerStatusTerminated {
 input WorkerUpdateInput {
   runtimeId: Float
   group: ID
+  groupId: String
   membership: ID
   roleAccount: String
   rewardAccount: String
@@ -22850,6 +22858,11 @@ input WorkerWhereInput {
   runtimeId_lt: Int
   runtimeId_lte: Int
   runtimeId_in: [Int!]
+  groupId_eq: String
+  groupId_contains: String
+  groupId_startsWith: String
+  groupId_endsWith: String
+  groupId_in: [String!]
   roleAccount_eq: String
   roleAccount_contains: String
   roleAccount_startsWith: String


### PR DESCRIPTION
This helps solving #857 by allowing to replace:
```gql
memberships( where: { roles_some: { group: { id_in: [ ... ] } } } ) { ... } # Fails
```
by:
```gql
memberships( where: { roles_some: { groupId_in: [ ... ] } } ) { ... } # Works
```

As long as the changes from https://github.com/Joystream/joystream/pull/3043 aren't deployed to the testnet, this is only testable with local query nodes:
1. Run local query nodes following the query nodes [README.md](https://github.com/Joystream/joystream/blob/f278f8763bd7df57ffcbcb716347e8fc1e3fcf16/query-node/README.md)
2. On pioneer select: `Settings` > `Select network` > `Local`

But because the role query is already failing I think we could still merge this PR, without waiting for https://github.com/Joystream/joystream/pull/3043.