### PR TITLE
POC: Add mentions for one or more resources

### DIFF
--- a/packages/markdown-editor/src/MarkdownEditor.js
+++ b/packages/markdown-editor/src/MarkdownEditor.js
@@ -49,10 +49,24 @@ function MentionToLink(editor) {
       modelAttributeValue &&
       writer.createAttributeElement('a', {
         class: 'mention',
-        href: `#mention?member-id=${modelAttributeValue.memberId}`,
+        href: prepareLink(modelAttributeValue),
       }),
     converterPriority: 'high',
   })
+}
+
+function prepareLink({type, itemId}) {
+  switch (type) {
+    case 'member': {
+      return `#mention?member-id=${itemId}`
+    }
+    case 'proposal': {
+      return `#mention?proposal-id=${itemId}`
+    }
+    default: {
+      return ''
+    }
+  }
 }
 
 export default {

--- a/packages/ui/src/common/components/CKEditor/CKEditor.stories.tsx
+++ b/packages/ui/src/common/components/CKEditor/CKEditor.stories.tsx
@@ -1,4 +1,4 @@
-import {action} from '@storybook/addon-actions';
+import { action } from '@storybook/addon-actions'
 import { Meta, Story } from '@storybook/react'
 import React from 'react'
 

--- a/packages/ui/src/common/components/CKEditor/CKEditor.stories.tsx
+++ b/packages/ui/src/common/components/CKEditor/CKEditor.stories.tsx
@@ -1,7 +1,7 @@
+import {action} from '@storybook/addon-actions';
 import { Meta, Story } from '@storybook/react'
 import React from 'react'
 
-import { info } from '@/common/logger'
 import { MockApolloProvider } from '@/mocks/components/storybook/MockApolloProvider'
 
 import { InputComponent } from '../forms'
@@ -36,7 +36,7 @@ export const InlineEditor = Template.bind({})
 ClassicEditor.args = {
   minRows: 8,
   maxRows: 20,
-  onChange: (event, editor) => info(editor.getData()),
+  onChange: action('onChange'),
 }
 
 InlineEditor.args = {

--- a/packages/ui/src/common/components/CKEditor/CKEditor.stories.tsx
+++ b/packages/ui/src/common/components/CKEditor/CKEditor.stories.tsx
@@ -36,7 +36,7 @@ export const InlineEditor = Template.bind({})
 ClassicEditor.args = {
   minRows: 8,
   maxRows: 20,
-  onChange: action('onChange'),
+  onChange: (_, editor) => action('onChange')(editor.getData()),
 }
 
 InlineEditor.args = {

--- a/packages/ui/src/common/components/CKEditor/CKEditor.tsx
+++ b/packages/ui/src/common/components/CKEditor/CKEditor.tsx
@@ -4,6 +4,7 @@ import React, { Ref, RefObject, useCallback, useEffect, useRef } from 'react'
 
 import { debounce } from '@/common/utils'
 import { SearchMembersDocument, SearchMembersQuery, SearchMembersQueryVariables } from '@/memberships/queries'
+import { GetProposalsDocument, GetProposalsQuery, GetProposalsQueryVariables } from '@/proposals/queries'
 
 import { CKEditorStylesOverrides } from './CKEditorStylesOverrides'
 
@@ -19,6 +20,16 @@ export interface CKEditorProps {
   inline?: boolean
 }
 
+const MentionTypes = ['general', 'proposal', 'member'] as const
+type MentionType = typeof MentionTypes[number]
+
+interface MentionItem {
+  id: string
+  itemId: string
+  name: string
+  type: MentionType
+}
+
 export const CKEditor = React.forwardRef(
   (
     { maxRows = 20, minRows = 5, onChange, onBlur, onFocus, onReady, disabled, inline }: CKEditorProps,
@@ -27,6 +38,41 @@ export const CKEditor = React.forwardRef(
     const localRef = useRef<HTMLDivElement>(null)
     const elementRef: RefObject<HTMLDivElement> = (ref ?? localRef) as RefObject<HTMLDivElement>
     const editorRef = useRef<Editor | null>(null)
+
+    const fetchMembers = useCallback(async (text: string) => {
+      const { data } = await client.query<SearchMembersQuery, SearchMembersQueryVariables>({
+        query: SearchMembersDocument,
+        variables: { text, limit: 10 },
+        fetchPolicy: 'cache-first',
+      })
+      return data.memberships.map<MentionItem>(({ id, handle }) => ({
+        id: `@${handle}`,
+        itemId: id,
+        type: 'member',
+        name: handle,
+      }))
+    }, [])
+
+    const fetchProposals = useCallback(async (text: string) => {
+      const { data } = await client.query<GetProposalsQuery, GetProposalsQueryVariables>({
+        query: GetProposalsDocument,
+        variables: {
+          where: { title_contains: text },
+        },
+        fetchPolicy: 'cache-first',
+      })
+      return data.proposals.map<MentionItem>(({ id, title }) => ({
+        id: `@${title}`,
+        itemId: id,
+        type: 'proposal',
+        name: title,
+      }))
+    }, [])
+
+    const fetchAll = useCallback(async (text: string) => {
+      const data = await Promise.all([fetchMembers(text), fetchProposals(text)])
+      return data.flat().sort(sortMentions)
+    }, [])
 
     useEffect(() => {
       if (!editorRef.current) {
@@ -39,11 +85,18 @@ export const CKEditor = React.forwardRef(
     const client = useApolloClient()
     const mentionFeed = useCallback(
       debounce(async (text: string) => {
-        const { data } = await client.query<SearchMembersQuery, SearchMembersQueryVariables>({
-          query: SearchMembersDocument,
-          variables: { text, limit: 10 },
-        })
-        return data.memberships.map(({ id, handle }) => ({ id: `@${handle}`, memberId: id }))
+        const proposal = text.match(/proposal:(.+)$/)
+        if (proposal) {
+          return await fetchProposals(proposal[1])
+        }
+        const member = text.match(/member:(.+)$/)
+        if (member) {
+          return await fetchMembers(member[1])
+        }
+        if (text.length > 0) {
+          return await fetchAll(text)
+        }
+        return generalItems
       }),
       [client]
     )
@@ -71,7 +124,7 @@ export const CKEditor = React.forwardRef(
             ],
           },
           mention: {
-            feeds: [{ marker: '@', feed: mentionFeed, minimumCharacters: 1 }],
+            feeds: [{ marker: '@', feed: mentionFeed, itemRenderer: mentionItemRenderer, dropdownLimit: 10 }],
           },
           image: {
             toolbar: ['imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative'],
@@ -124,3 +177,37 @@ export const CKEditor = React.forwardRef(
     )
   }
 )
+
+const generalItems: MentionItem[] = [
+  { id: '@member:', type: 'general', itemId: 'member', name: 'member' },
+  { id: '@proposal:', type: 'general', itemId: 'proposal', name: 'proposal' },
+]
+
+const mentionItemRenderer = ({ id, itemId, type }: MentionItem) => {
+  const itemElement = document.createElement('div')
+
+  itemElement.classList.add('custom-item')
+  itemElement.id = `mention-list-item-id-${itemId}`
+  itemElement.textContent = `${id}${type === 'general' ? '<name>' : ''}`
+
+  if (type !== 'general') {
+    const typeElement = document.createElement('span')
+
+    typeElement.classList.add('custom-item-type')
+    typeElement.textContent = type
+
+    itemElement.appendChild(typeElement)
+  }
+
+  return itemElement
+}
+
+const sortMentions = (a: MentionItem, b: MentionItem) => {
+  if (a.name > b.name) {
+    return 1
+  }
+  if (b.name > a.name) {
+    return -1
+  }
+  return 0
+}

--- a/packages/ui/src/common/components/CKEditor/CKEditorStylesOverrides.tsx
+++ b/packages/ui/src/common/components/CKEditor/CKEditorStylesOverrides.tsx
@@ -62,6 +62,14 @@ export const CKEditorStylesOverrides = createGlobalStyle<{ minRows: number; maxR
     cursor: pointer;
   }
 
+  .ck.ck-list__item .ck-button .custom-item-type {
+    font-size: 8px;
+    margin-left: 8px;
+    background: ${Colors.Blue[200]};
+    border-radius: ${BorderRad.m};
+    padding: 2px 4px;
+  }
+
   .ck.ck-list__item .ck-button.ck-on {
     background: ${Colors.Blue[100]};
     color: ${Colors.Blue[500]};


### PR DESCRIPTION
Closes #2096 
Closes #2097 

**Proposed solution**
Users could filter mentions by category by using proper syntax
```
@<category>:<name>
```
For the purpose of this POC only filtering by `proposal` and `member` is supported.

- When the user types `@`, he would see the window with available categories
![Zrzut ekranu 2022-01-19 o 14 56 59](https://user-images.githubusercontent.com/7772094/150144927-72b0cde9-cdc8-42a2-ac52-d70791930c7f.png)

- When the user types a mention without a specific category eg. `@test`, he would see results from all supported resources
![Zrzut ekranu 2022-01-19 o 14 59 23](https://user-images.githubusercontent.com/7772094/150145304-f84d500a-a41d-4e9e-8228-59bd400e8d89.png)

- When the user types mention with the category eg. `@member:test`, he would see results from the desired category
![Zrzut ekranu 2022-01-19 o 15 01 57](https://user-images.githubusercontent.com/7772094/150145807-df877a81-0315-4563-a6cd-8241096340a5.png)

TODO: 
- Linking mentions to proper resources.
- Prepare dedicated queries for resources searching