### PR TITLE
Update local network settings faucet url to match playground

### DIFF
--- a/packages/ui/src/app/config/network.ts
+++ b/packages/ui/src/app/config/network.ts
@@ -6,7 +6,7 @@ const OLYMPIA_TESTNET_QUERY_NODE =
   process.env.REACT_APP_OLYMPIA_TESTNET_QUERY_NODE || 'https://olympia-dev.joystream.app/query/server/graphql'
 const OLYMPIA_TESTNET_QUERY_NODE_SOCKET =
   process.env.REACT_APP_OLYMPIA_TESTNET_QUERY_NODE_SOCKET || 'wss://olympia-dev.joystream.app/query/server/graphql'
-const MEMBERSHIP_FAUCET_URL = process.env.REACT_APP_MEMBERSHIP_FAUCET_URL || 'http://localhost:4000/register'
+const MEMBERSHIP_FAUCET_URL = process.env.REACT_APP_MEMBERSHIP_FAUCET_URL || 'http://localhost:3002/register'
 
 export const QUERY_NODE_ENDPOINT_SUBSCRIPTION: Record<NetworkType, string> = {
   local: 'ws://localhost:8081/graphql',
@@ -21,8 +21,8 @@ export const QUERY_NODE_ENDPOINT: Record<NetworkType, string> = {
 }
 
 export const MEMBERSHIP_FAUCET_ENDPOINT: Record<NetworkType, string> = {
-  local: 'http://localhost:4004/register',
-  'local-mocks': 'http://localhost:4004/register',
+  local: 'http://localhost:3002/register',
+  'local-mocks': 'http://localhost:3002/register',
   'olympia-testnet': MEMBERSHIP_FAUCET_URL,
 }
 


### PR DESCRIPTION
Proposing to update the default local-network settings for faucet url to match the playground settings in: https://github.com/Joystream/joystream/blob/eed6f9ae78d721db625cf00da8798e035a17fce5/docker-compose.yml#L259