### PR TITLE
🧑‍🔧 Fix apply for role staking account

### DIFF
--- a/packages/ui/src/common/model/JoystreamNode/metadataFromBytes.ts
+++ b/packages/ui/src/common/model/JoystreamNode/metadataFromBytes.ts
@@ -1,0 +1,12 @@
+import { AnyMessage, AnyMetadataClass, DecodedMetadataObject } from '@joystream/metadata-protobuf/types'
+import { Bytes } from '@polkadot/types/primitive'
+
+function metaToObject<T>(metaClass: AnyMetadataClass<T>, value: AnyMessage<T>) {
+  return metaClass.toObject(value, { arrays: false, longs: String }) as DecodedMetadataObject<T>
+}
+
+// From https://github.com/Joystream/joystream/blob/0977a2b5ccc08b16416f0ed8eed74cdbc9495be0/cli/src/helpers/serialization.ts
+
+export function metadataFromBytes<T>(metaClass: AnyMetadataClass<T>, bytes: Bytes): DecodedMetadataObject<T> {
+  return metaToObject(metaClass, metaClass.decode(bytes.toU8a(true)))
+}

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
@@ -150,14 +150,14 @@ export const ApplyForRoleModal = () => {
     const { stake, answers } = state.context
 
     const applyOnOpeningTransaction = api.tx[opening.groupId].applyOnOpening({
-      opening_id: opening.runtimeId,
       member_id: activeMember?.id,
+      opening_id: opening.runtimeId,
       role_account_id: activeMember?.controllerAccount,
-      reward_account_id: activeMember?.rootAccount,
+      reward_account_id: activeMember?.controllerAccount,
       description: metadataToBytes(ApplicationMetadata, { answers: Object.values(answers) }),
       stake_parameters: {
         stake: stake.amount,
-        stake_account_id: stake.account?.address,
+        staking_account_id: stake.account?.address,
       },
     })
 


### PR DESCRIPTION
Closes  #2095
This also solves the first part of #2284

Weirdly `ApplyForRoleModal` creates 2 `applyOnOpening` and sends the 2de after validating the staking account (this is why we missed this in #2239). It would be great to try to simplify this logic when working on the second part of #2284.