### PR TITLE
Add auto-conf NetworkType variant to store custom endpoints config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -185,10 +185,35 @@ To add any of the above:
 By default, only `Alice`, `Alice_Stash`, `Bob` and `Bob_Stash` accounts has any funds.
 
 ## Using custom addresses to connect with node/query node
+
+### Configure at build time
+
 To use custom addresses add the `.env` file in `packages/ui` (example: `packages/ui/.env.example`) and set
 
-1. `REACT_APP_OLYMPIA_TESTNET_NODE_SOCKET` default `wss://olympia-dev.joystream.app/rpc`
-2. `REACT_APP_OLYMPIA_TESTNET_QUERY_NODE` default `https://olympia-dev.joystream.app/query/server/graphql`
-3. `REACT_APP_OLYMPIA_TESTNET_QUERY_NODE_SOCKET` default `wss://olympia-dev.joystream.app/query/server/graphql`
+1. `REACT_APP_OLYMPIA_TESTNET_NODE_SOCKET` example `wss://olympia-dev.joystream.app/rpc`
+2. `REACT_APP_OLYMPIA_TESTNET_QUERY_NODE` example `https://olympia-dev.joystream.app/query/server/graphql`
+3. `REACT_APP_OLYMPIA_TESTNET_QUERY_NODE_SOCKET` example `wss://olympia-dev.joystream.app/query/server/graphql`
+4. `REACT_APP_OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL` example `https://olympia-dev.joystream.app/member/register`
 
 Please remember to restart the webpack process after each change.
+
+All the variables are required to be configured for the network to be used.
+
+### Auto-configure at runtime
+An auto configuration url can be used to configure pioneer. A url such as `https://playground.test/config.json` can respond with a JSON:
+
+```
+{
+  "websocket_rpc": "wss://rpc-endpoint.com:9944",
+  "graphql_server": "https://joystream.app/server/graphql",
+  "graphql_server_websocket": "wss://joystream.app/server/graphql",
+  "member_faucet": "https://joystream.app/member-faucet/register"
+}
+```
+
+By visiting pioneer with a query `network-config` as below:
+```
+https://pioneer.joystream.app/#/settings?network-config=https://playground.test/config.json
+```
+
+This will save the endpoints locally under the "Auto-conf" network.

--- a/packages/ui/.env.example
+++ b/packages/ui/.env.example
@@ -1,6 +1,4 @@
-REACT_APP_OLYMPIA_TESTNET_CONFIG_ENDPOINT=https://olympia-dev.joystream.app/config.json
-
-REACT_APP_OLYMPIA_TESTNET_NODE_SOCKET=wss://olympia-dev.joystream.app/rpc
+REACT_APP_OLYMPIA_TESTNET_NODE_SOCKET=wss://olympia-dev.joystream.app/ws-rpc
 REACT_APP_OLYMPIA_TESTNET_QUERY_NODE=https://olympia-dev.joystream.app/query/server/graphql
 REACT_APP_OLYMPIA_TESTNET_QUERY_NODE_SOCKET=wss://olympia-dev.joystream.app/query/server/graphql
-REACT_APP_MEMBERSHIP_FAUCET_URL=http://olympia-dev.joystream.app/faucet/register
+REACT_APP_OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL=http://olympia-dev.joystream.app/member-faucet/register

--- a/packages/ui/src/app/config/network.ts
+++ b/packages/ui/src/app/config/network.ts
@@ -9,9 +9,13 @@ export const configuredNetworks = () => {
   const networks: NetworkType[] = ['local', 'local-mocks', 'auto-conf']
 
   // Only include olympia-testnet if all env variables were defined
-  if(OLYMPIA_TESTNET_NODE_SOCKET && OLYMPIA_TESTNET_QUERY_NODE &&
-    OLYMPIA_TESTNET_QUERY_NODE_SOCKET && OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL) {
-      networks.push('olympia-testnet')
+  if (
+    OLYMPIA_TESTNET_NODE_SOCKET &&
+    OLYMPIA_TESTNET_QUERY_NODE &&
+    OLYMPIA_TESTNET_QUERY_NODE_SOCKET &&
+    OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL
+  ) {
+    networks.push('olympia-testnet')
   }
   return networks
 }

--- a/packages/ui/src/app/config/network.ts
+++ b/packages/ui/src/app/config/network.ts
@@ -1,33 +1,45 @@
-export type NetworkType = 'local' | 'local-mocks' | 'olympia-testnet'
-
-export const OLYMPIA_TESTNET_CONFIG_ENDPOINT =
-  process.env.REACT_APP_OLYMPIA_TESTNET_CONFIG_ENDPOINT ?? 'https://3.93.173.102.nip.io/network/config.json'
+export type NetworkType = 'local' | 'local-mocks' | 'olympia-testnet' | 'auto-conf'
 
 const OLYMPIA_TESTNET_NODE_SOCKET = process.env.REACT_APP_OLYMPIA_TESTNET_NODE_SOCKET
 const OLYMPIA_TESTNET_QUERY_NODE = process.env.REACT_APP_OLYMPIA_TESTNET_QUERY_NODE
 const OLYMPIA_TESTNET_QUERY_NODE_SOCKET = process.env.REACT_APP_OLYMPIA_TESTNET_QUERY_NODE_SOCKET
-const MEMBERSHIP_FAUCET_URL = process.env.REACT_APP_MEMBERSHIP_FAUCET_URL
+const OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL = process.env.REACT_APP_OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL
+
+export const configuredNetworks = () => {
+  const networks: NetworkType[] = ['local', 'local-mocks', 'auto-conf']
+
+  // Only include olympia-testnet if all env variables were defined
+  if(OLYMPIA_TESTNET_NODE_SOCKET && OLYMPIA_TESTNET_QUERY_NODE &&
+    OLYMPIA_TESTNET_QUERY_NODE_SOCKET && OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL) {
+      networks.push('olympia-testnet')
+  }
+  return networks
+}
 
 export const QUERY_NODE_ENDPOINT_SUBSCRIPTION: Record<NetworkType, string | undefined> = {
   local: 'ws://localhost:8081/graphql',
   'local-mocks': 'ws://localhost:8081/graphql',
   'olympia-testnet': OLYMPIA_TESTNET_QUERY_NODE_SOCKET,
+  'auto-conf': 'ws://localhost:8081/graphql',
 }
 
 export const QUERY_NODE_ENDPOINT: Record<NetworkType, string | undefined> = {
   local: 'http://localhost:8081/graphql',
   'local-mocks': 'http://localhost:8081/graphql',
   'olympia-testnet': OLYMPIA_TESTNET_QUERY_NODE,
+  'auto-conf': 'http://localhost:8081/graphql',
 }
 
 export const MEMBERSHIP_FAUCET_ENDPOINT: Record<NetworkType, string | undefined> = {
   local: 'http://localhost:3002/register',
   'local-mocks': 'http://localhost:3002/register',
-  'olympia-testnet': MEMBERSHIP_FAUCET_URL,
+  'olympia-testnet': OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL,
+  'auto-conf': 'http://localhost:3002/register',
 }
 
 export const NODE_RPC_ENDPOINT: Record<NetworkType, string | undefined> = {
   local: 'ws://127.0.0.1:9944',
   'local-mocks': 'ws://127.0.0.1:9944',
   'olympia-testnet': OLYMPIA_TESTNET_NODE_SOCKET,
+  'auto-conf': 'ws://127.0.0.1:9944',
 }

--- a/packages/ui/src/app/pages/Settings/Settings.tsx
+++ b/packages/ui/src/app/pages/Settings/Settings.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import { PageHeaderWrapper, PageLayout } from '@/app/components/PageLayout'
-import { NetworkType } from '@/app/config'
+import { NetworkType, configuredNetworks } from '@/app/config'
 import { LanguageSelect } from '@/common/components/LanguageSelect'
 import NetworkInfo from '@/common/components/NetworkInfo/NetworkInfo'
 import { MainPanel, RowGapBlock } from '@/common/components/page/PageContent'
@@ -16,7 +16,7 @@ import { useNetworkEndpoints } from '@/common/hooks/useNetworkEndpoints'
 type Tab = 'SETTINGS' | 'LANGUAGE'
 
 export const Settings = () => {
-  const options: NetworkType[] = ['local', 'local-mocks', 'olympia-testnet']
+  const options: NetworkType[] = configuredNetworks()
   const [network, setNetwork] = useNetwork()
   const { t } = useTranslation('settings')
   const [endpoints] = useNetworkEndpoints()

--- a/packages/ui/src/common/providers/network-endpoints/provider.tsx
+++ b/packages/ui/src/common/providers/network-endpoints/provider.tsx
@@ -21,7 +21,8 @@ interface Props {
 export const NetworkEndpointsProvider = ({ children }: Props) => {
   const [network, setNetwork] = useNetwork()
   const [endpoints, setEndpoints] = useState<Partial<NetworkEndpoints>>({})
-  const [storedAutoNetworkConfig, storeAutoNetworkConfig] = useLocalStorage<Partial<NetworkEndpoints>>('auto_network_config')
+  const [storedAutoNetworkConfig, storeAutoNetworkConfig] =
+    useLocalStorage<Partial<NetworkEndpoints>>('auto_network_config')
   const [isLoading, setIsLoading] = useState(false)
 
   const updateNetworkConfig = useCallback(
@@ -41,7 +42,9 @@ export const NetworkEndpointsProvider = ({ children }: Props) => {
           throw new Error('fetched config missing endpoints')
         }
 
-        const shouldUpdateConfig = !objectEquals<Partial<NetworkEndpoints>>(newNetworkConfig)(storedAutoNetworkConfig ?? {})
+        const shouldUpdateConfig = !objectEquals<Partial<NetworkEndpoints>>(newNetworkConfig)(
+          storedAutoNetworkConfig ?? {}
+        )
         const shouldUpdateNetwork = network !== 'auto-conf'
 
         if (shouldUpdateConfig) {
@@ -67,7 +70,7 @@ export const NetworkEndpointsProvider = ({ children }: Props) => {
 
   useEffect(() => {
     const endpoints = pickEndpoints(network, storedAutoNetworkConfig ?? {})
-    if(!endpointsAreDefined(endpoints) && network == 'auto-conf') {
+    if (!endpointsAreDefined(endpoints) && network == 'auto-conf') {
       setNetwork('local')
       setEndpoints(localEndpoints)
     } else {
@@ -90,7 +93,7 @@ const endpointsAreDefined = (endpoints: Partial<NetworkEndpoints>): endpoints is
   Object.values(endpoints).length === 4 && Object.values(endpoints).every(isDefined)
 
 const pickEndpoints = <R extends Partial<NetworkEndpoints>>(network: NetworkType, endpoints: R) => {
-  if(network === 'auto-conf') {
+  if (network === 'auto-conf') {
     // Use the stored config in localstorage, fallback on 'local'
     // If config endpoints are partially configured this will produce mixed results, punn intended.
     return {

--- a/packages/ui/src/common/providers/network-endpoints/provider.tsx
+++ b/packages/ui/src/common/providers/network-endpoints/provider.tsx
@@ -94,8 +94,6 @@ const endpointsAreDefined = (endpoints: Partial<NetworkEndpoints>): endpoints is
 
 const pickEndpoints = <R extends Partial<NetworkEndpoints>>(network: NetworkType, endpoints: R) => {
   if (network === 'auto-conf') {
-    // Use the stored config in localstorage, fallback on 'local'
-    // If config endpoints are partially configured this will produce mixed results, punn intended.
     return {
       queryNodeEndpointSubscription: endpoints.queryNodeEndpointSubscription,
       queryNodeEndpoint: endpoints.queryNodeEndpoint,

--- a/packages/ui/src/common/providers/network-endpoints/provider.tsx
+++ b/packages/ui/src/common/providers/network-endpoints/provider.tsx
@@ -63,7 +63,7 @@ export const NetworkEndpointsProvider = ({ children }: Props) => {
 
   useEffect(() => {
     const endpoints = pickEndpoints(network, storedAutoNetworkConfig ?? {})
-    if(!endpointsAreDefined(endpoints)) {
+    if(!endpointsAreDefined(endpoints) && network == 'auto-conf') {
       setNetwork('local')
       setEndpoints(localEndpoints)
     } else {
@@ -88,12 +88,12 @@ const endpointsAreDefined = (endpoints: Partial<NetworkEndpoints>): endpoints is
 const pickEndpoints = <R extends Partial<NetworkEndpoints>>(network: NetworkType, endpoints: R) => {
   if(network === 'auto-conf') {
     // Use the stored config in localstorage, fallback on 'local'
-    // If config endpoints are partially configured this produce mixed results, punn intended.
+    // If config endpoints are partially configured this will produce mixed results, punn intended.
     return {
-      queryNodeEndpointSubscription: endpoints.queryNodeEndpointSubscription, // ?? QUERY_NODE_ENDPOINT_SUBSCRIPTION[network],
-      queryNodeEndpoint: endpoints.queryNodeEndpoint, // ?? QUERY_NODE_ENDPOINT[network],
-      membershipFaucetEndpoint: endpoints.membershipFaucetEndpoint, // ?? MEMBERSHIP_FAUCET_ENDPOINT[network],
-      nodeRpcEndpoint: endpoints.nodeRpcEndpoint, // ?? NODE_RPC_ENDPOINT[network],
+      queryNodeEndpointSubscription: endpoints.queryNodeEndpointSubscription,
+      queryNodeEndpoint: endpoints.queryNodeEndpoint,
+      membershipFaucetEndpoint: endpoints.membershipFaucetEndpoint,
+      nodeRpcEndpoint: endpoints.nodeRpcEndpoint,
     } as R
   } else {
     return {

--- a/packages/ui/src/common/providers/network-endpoints/provider.tsx
+++ b/packages/ui/src/common/providers/network-endpoints/provider.tsx
@@ -37,6 +37,10 @@ export const NetworkEndpointsProvider = ({ children }: Props) => {
           nodeRpcEndpoint: config['websocket_rpc'],
         }
 
+        if (!endpointsAreDefined(newNetworkConfig)) {
+          throw new Error('fetched config missing endpoints')
+        }
+
         const shouldUpdateConfig = !objectEquals<Partial<NetworkEndpoints>>(newNetworkConfig)(storedAutoNetworkConfig ?? {})
         const shouldUpdateNetwork = network !== 'auto-conf'
 
@@ -55,7 +59,7 @@ export const NetworkEndpointsProvider = ({ children }: Props) => {
         const errMsg = `Failed to fetch the network configuration from ${configEndpoint}.`
 
         setEndpoints(localEndpoints)
-        throw new Error(`${errMsg} Falling back on the local endpoints.`)
+        throw new Error(`${errMsg} - Falling back on the local endpoints.`)
       }
     },
     [network]

--- a/packages/ui/src/common/providers/network-endpoints/provider.tsx
+++ b/packages/ui/src/common/providers/network-endpoints/provider.tsx
@@ -28,42 +28,42 @@ export const NetworkEndpointsProvider = ({ children }: Props) => {
   const updateNetworkConfig = useCallback(
     async (configEndpoint: string) => {
       setIsLoading(true)
+      let config
       try {
-        const config = await (await fetch(configEndpoint)).json()
-
-        const newNetworkConfig = {
-          queryNodeEndpointSubscription: config['graphql_server_websocket'],
-          queryNodeEndpoint: config['graphql_server'],
-          membershipFaucetEndpoint: config['member_faucet'],
-          nodeRpcEndpoint: config['websocket_rpc'],
-        }
-
-        if (!endpointsAreDefined(newNetworkConfig)) {
-          throw new Error('fetched config missing endpoints')
-        }
-
-        const shouldUpdateConfig = !objectEquals<Partial<NetworkEndpoints>>(newNetworkConfig)(
-          storedAutoNetworkConfig ?? {}
-        )
-        const shouldUpdateNetwork = network !== 'auto-conf'
-
-        if (shouldUpdateConfig) {
-          storeAutoNetworkConfig(newNetworkConfig)
-        }
-        if (shouldUpdateNetwork) {
-          setNetwork('auto-conf')
-        }
-        if (shouldUpdateConfig || shouldUpdateNetwork) {
-          return window.location.reload()
-        }
-        setIsLoading(false)
+        config = await (await fetch(configEndpoint)).json()
       } catch (err) {
         setIsLoading(false)
         const errMsg = `Failed to fetch the network configuration from ${configEndpoint}.`
-
-        setEndpoints(localEndpoints)
-        throw new Error(`${errMsg} - Falling back on the local endpoints.`)
+        throw new Error(`${errMsg}`)
       }
+
+      const newNetworkConfig = {
+        queryNodeEndpointSubscription: config['graphql_server_websocket'],
+        queryNodeEndpoint: config['graphql_server'],
+        membershipFaucetEndpoint: config['member_faucet'],
+        nodeRpcEndpoint: config['websocket_rpc'],
+      }
+
+      if (!endpointsAreDefined(newNetworkConfig)) {
+        setIsLoading(false)
+        throw new Error('fetched config missing endpoints')
+      }
+
+      const shouldUpdateConfig = !objectEquals<Partial<NetworkEndpoints>>(newNetworkConfig)(
+        storedAutoNetworkConfig ?? {}
+      )
+      const shouldUpdateNetwork = network !== 'auto-conf'
+
+      if (shouldUpdateConfig) {
+        storeAutoNetworkConfig(newNetworkConfig)
+      }
+      if (shouldUpdateNetwork) {
+        setNetwork('auto-conf')
+      }
+      if (shouldUpdateConfig || shouldUpdateNetwork) {
+        return window.location.reload()
+      }
+      setIsLoading(false)
     },
     [network]
   )

--- a/packages/ui/src/common/providers/network-endpoints/provider.tsx
+++ b/packages/ui/src/common/providers/network-endpoints/provider.tsx
@@ -76,7 +76,7 @@ export const NetworkEndpointsProvider = ({ children }: Props) => {
     } else {
       setEndpoints(endpoints)
     }
-  }, [network, updateNetworkConfig])
+  }, [network])
 
   if (!endpointsAreDefined(endpoints) || isLoading) {
     return <Loading text="Loading network endpoints" />


### PR DESCRIPTION
Made an attempt to improve on the custom endpoint feature.

Introduced a new network type called 'auto-conf' for which we store the custom endpoint settings. And this can only be set at runtime through the url query `network-config`. No network config url is hard-coded in code or taken from env variables, to allow changes to endpoints to be done dynamically otherwise they are persisted in local storage when first loading the site.

env variables `REACT_APP_OLYMPIA_TESTNET_xxx` only configure the the olympia-testnet. If not all values are provided the olympia-testnet option is not displayed in drop-down on settings page. Also made all var names consistent renamed `REACT_APP_MEMBERSHIP_FAUCET_URL` to `REACT_APP_OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL`.

Fallback to local network if network config is invalid or manually removed from local storage.

I tried to test it thoroughly with various failure scenarios, human error etc.

With these changes its easier to configure a single instance of pioneer configured at build time for a specific network, and to point at playgrounds (auto-conf), with option of reverting to olympia-testnet from settings page.