### PR TITLE
handle edge case where network selection from localStorage is invalid

### DIFF
--- a/packages/ui/src/common/hooks/useNetwork.ts
+++ b/packages/ui/src/common/hooks/useNetwork.ts
@@ -1,10 +1,19 @@
-import { NetworkType } from '@/app/config'
+import { NetworkType, configuredNetworks } from '@/app/config'
 
 import { useLocalStorage } from './useLocalStorage'
 
 export const useNetwork = () => {
   const [network, setNetwork] = useLocalStorage<NetworkType>('network')
-  const resolvedNetwork = network ?? 'local'
+  const networks: NetworkType[] = configuredNetworks()
 
-  return [resolvedNetwork, setNetwork] as const
+  // Ensure we have endpoints configured for selected network
+  if (networks.find((n) => n === network)) {
+    return [network!, setNetwork] as const
+  } else {
+    // Either the network was not specified,
+    // network was once available but is not recognized by pioneer anymore,
+    // or network has no endpoints configured in the current build of pioneer.
+    // Fallback to 'local'
+    return ['local', setNetwork] as const
+  }
 }


### PR DESCRIPTION
Follow up to https://github.com/Joystream/pioneer/pull/2532

Handle edge case where a network choice stored in localStorage is not valid.

1 - For example the choice was `olympia-testnet` but the build of pioneer did not define the OLYMPIA_TESTNET env vars so it is not included in the NetworkType[] of configured networks. In such case the "Loading Endpoints" page would never transition away.

2 - A future version of pioneer changes list of networks.
3 - Someone making manual / incorrect changes to localStorage values 

In these cases, we fallback to `local` network.
