### PR TITLE
Fix for recover lock wrong signer

### DIFF
--- a/packages/ui/src/accounts/modals/RecoverBalance/RecoverBalanceModal.tsx
+++ b/packages/ui/src/accounts/modals/RecoverBalance/RecoverBalanceModal.tsx
@@ -29,7 +29,13 @@ export const RecoverBalanceModal = () => {
   }, [connectionState, modalData?.memberId, modalData.lock.type])
 
   const { member } = useMember(modalData?.memberId)
-  const signer = member?.controllerAccount ?? modalData.address
+
+  const signer = useMemo(() => {
+    if (modalData.lock.type === 'Council Candidate') {
+      return member?.controllerAccount ?? modalData.address
+    }
+    return modalData.address
+  }, [modalData.lock.type, modalData.address, member])
 
   const feeInfo = useTransactionFee(signer, transaction)
 

--- a/packages/ui/src/accounts/modals/RecoverBalance/RecoverBalanceModal.tsx
+++ b/packages/ui/src/accounts/modals/RecoverBalance/RecoverBalanceModal.tsx
@@ -31,10 +31,10 @@ export const RecoverBalanceModal = () => {
   const { member } = useMember(modalData?.memberId)
 
   const signer = useMemo(() => {
-    if (modalData.lock.type === 'Council Candidate') {
-      return member?.controllerAccount ?? modalData.address
+    if (modalData.lock.type === 'Voting') {
+      return modalData.address
     }
-    return modalData.address
+    return member?.controllerAccount ?? modalData.address
   }, [modalData.lock.type, modalData.address, member])
 
   const feeInfo = useTransactionFee(signer, transaction)


### PR DESCRIPTION
This PR is implementing different logic for `Voting` lock type. It's driven by that as all locks should we recovered with controller account of the member on whose behalf staking was committed, but for voting lock there is an exception, because voting requires only account for casting a vote, so recovering of voting stake should be signer with same account which commited a vote.