### PR TITLE
🥅 Hotfix no `olympia-testnet` support

### DIFF
--- a/packages/ui/src/app/config/network.ts
+++ b/packages/ui/src/app/config/network.ts
@@ -1,49 +1,61 @@
 export type NetworkType = 'local' | 'local-mocks' | 'olympia-testnet' | 'auto-conf'
 
+export interface NetworkEndpoints {
+  queryNodeEndpointSubscription: string
+  queryNodeEndpoint: string
+  membershipFaucetEndpoint: string
+  nodeRpcEndpoint: string
+}
+
 const OLYMPIA_TESTNET_NODE_SOCKET = process.env.REACT_APP_OLYMPIA_TESTNET_NODE_SOCKET
 const OLYMPIA_TESTNET_QUERY_NODE = process.env.REACT_APP_OLYMPIA_TESTNET_QUERY_NODE
 const OLYMPIA_TESTNET_QUERY_NODE_SOCKET = process.env.REACT_APP_OLYMPIA_TESTNET_QUERY_NODE_SOCKET
 const OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL = process.env.REACT_APP_OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL
 
-export const configuredNetworks = () => {
-  const networks: NetworkType[] = ['local', 'local-mocks', 'auto-conf']
+export const IS_TESTNET_DEFINED =
+  OLYMPIA_TESTNET_NODE_SOCKET &&
+  OLYMPIA_TESTNET_QUERY_NODE &&
+  OLYMPIA_TESTNET_QUERY_NODE_SOCKET &&
+  OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL
 
-  // Only include olympia-testnet if all env variables were defined
-  if (
-    OLYMPIA_TESTNET_NODE_SOCKET &&
-    OLYMPIA_TESTNET_QUERY_NODE &&
-    OLYMPIA_TESTNET_QUERY_NODE_SOCKET &&
-    OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL
-  ) {
-    networks.push('olympia-testnet')
-  }
-  return networks
-}
+type PredefinedEndpoint = { [K in NetworkType]?: string }
 
-export const QUERY_NODE_ENDPOINT_SUBSCRIPTION: Record<NetworkType, string | undefined> = {
+const QUERY_NODE_ENDPOINT_SUBSCRIPTION: PredefinedEndpoint = {
   local: 'ws://localhost:8081/graphql',
   'local-mocks': 'ws://localhost:8081/graphql',
   'olympia-testnet': OLYMPIA_TESTNET_QUERY_NODE_SOCKET,
-  'auto-conf': 'ws://localhost:8081/graphql',
 }
 
-export const QUERY_NODE_ENDPOINT: Record<NetworkType, string | undefined> = {
+const QUERY_NODE_ENDPOINT: PredefinedEndpoint = {
   local: 'http://localhost:8081/graphql',
   'local-mocks': 'http://localhost:8081/graphql',
   'olympia-testnet': OLYMPIA_TESTNET_QUERY_NODE,
-  'auto-conf': 'http://localhost:8081/graphql',
 }
 
-export const MEMBERSHIP_FAUCET_ENDPOINT: Record<NetworkType, string | undefined> = {
+const MEMBERSHIP_FAUCET_ENDPOINT: PredefinedEndpoint = {
   local: 'http://localhost:3002/register',
   'local-mocks': 'http://localhost:3002/register',
   'olympia-testnet': OLYMPIA_TESTNET_MEMBERSHIP_FAUCET_URL,
-  'auto-conf': 'http://localhost:3002/register',
 }
 
-export const NODE_RPC_ENDPOINT: Record<NetworkType, string | undefined> = {
+const NODE_RPC_ENDPOINT: PredefinedEndpoint = {
   local: 'ws://127.0.0.1:9944',
   'local-mocks': 'ws://127.0.0.1:9944',
   'olympia-testnet': OLYMPIA_TESTNET_NODE_SOCKET,
-  'auto-conf': 'ws://127.0.0.1:9944',
+}
+
+export const pickEndpoints = (network: NetworkType): Partial<NetworkEndpoints> => ({
+  queryNodeEndpointSubscription: QUERY_NODE_ENDPOINT_SUBSCRIPTION[network],
+  queryNodeEndpoint: QUERY_NODE_ENDPOINT[network],
+  membershipFaucetEndpoint: MEMBERSHIP_FAUCET_ENDPOINT[network],
+  nodeRpcEndpoint: NODE_RPC_ENDPOINT[network],
+})
+
+export const DEFAULT_NETWORK = (
+  IS_TESTNET_DEFINED
+    ? { type: 'olympia-testnet', endpoints: pickEndpoints('olympia-testnet') }
+    : { type: 'local', endpoints: pickEndpoints('local') }
+) as {
+  type: NetworkType
+  endpoints: NetworkEndpoints
 }

--- a/packages/ui/src/app/index.ts
+++ b/packages/ui/src/app/index.ts
@@ -1,3 +1,2 @@
 export * from './App'
 export { WaitForAPI } from '@/app/components/WaitForAPI'
-export { MEMBERSHIP_FAUCET_ENDPOINT } from '@/app/config'

--- a/packages/ui/src/app/pages/Settings/Settings.tsx
+++ b/packages/ui/src/app/pages/Settings/Settings.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import { PageHeaderWrapper, PageLayout } from '@/app/components/PageLayout'
-import { NetworkType, configuredNetworks } from '@/app/config'
+import { NetworkType } from '@/app/config'
 import { LanguageSelect } from '@/common/components/LanguageSelect'
 import NetworkInfo from '@/common/components/NetworkInfo/NetworkInfo'
 import { MainPanel, RowGapBlock } from '@/common/components/page/PageContent'
@@ -16,8 +16,7 @@ import { useNetworkEndpoints } from '@/common/hooks/useNetworkEndpoints'
 type Tab = 'SETTINGS' | 'LANGUAGE'
 
 export const Settings = () => {
-  const options: NetworkType[] = configuredNetworks()
-  const [network, setNetwork] = useNetwork()
+  const { network, setNetwork, networks } = useNetwork()
   const { t } = useTranslation('settings')
   const [endpoints] = useNetworkEndpoints()
   const [currentTab, setCurrentTab] = useState<Tab>('SETTINGS')
@@ -48,7 +47,7 @@ export const Settings = () => {
                 <>
                   <SimpleSelect
                     title={t('selectNetwork')}
-                    options={options}
+                    options={networks}
                     value={network}
                     onChange={switchNetwork}
                     selectSize="l"

--- a/packages/ui/src/app/providers/QueryNodeProvider.tsx
+++ b/packages/ui/src/app/providers/QueryNodeProvider.tsx
@@ -24,7 +24,7 @@ interface Props {
 }
 
 export const QueryNodeProvider = ({ children }: Props) => {
-  const [network] = useNetwork()
+  const { network } = useNetwork()
   const [endpoints] = useNetworkEndpoints()
   const [apolloClient, setApolloClient] = useState<ApolloClient<NormalizedCacheObject>>()
 

--- a/packages/ui/src/common/hooks/useNetwork.ts
+++ b/packages/ui/src/common/hooks/useNetwork.ts
@@ -1,10 +1,23 @@
-import { NetworkType } from '@/app/config'
+import { useMemo } from 'react'
+
+import { DEFAULT_NETWORK, IS_TESTNET_DEFINED, NetworkEndpoints, NetworkType } from '@/app/config'
+import { endpointsAreDefined } from '@/common/providers/network-endpoints/provider'
 
 import { useLocalStorage } from './useLocalStorage'
 
 export const useNetwork = () => {
-  const [network, setNetwork] = useLocalStorage<NetworkType>('network')
-  const resolvedNetwork = network ?? 'olympia-testnet'
+  const [network = DEFAULT_NETWORK.type, setNetwork] = useLocalStorage<NetworkType>('network')
 
-  return [resolvedNetwork, setNetwork] as const
+  const [autoConfEndpoints] = useLocalStorage<NetworkEndpoints>('auto_network_config')
+  const networks = useMemo<NetworkType[]>(
+    () => [
+      'local',
+      'local-mocks',
+      ...(endpointsAreDefined(autoConfEndpoints) ? ['auto-conf' as const] : []),
+      ...(IS_TESTNET_DEFINED ? ['olympia-testnet' as const] : []),
+    ],
+    [autoConfEndpoints]
+  )
+
+  return { network, setNetwork, networks }
 }

--- a/packages/ui/src/common/providers/network-endpoints/context.ts
+++ b/packages/ui/src/common/providers/network-endpoints/context.ts
@@ -1,33 +1,7 @@
 import { createContext } from 'react'
 
-import {
-  MEMBERSHIP_FAUCET_ENDPOINT,
-  NODE_RPC_ENDPOINT,
-  QUERY_NODE_ENDPOINT,
-  QUERY_NODE_ENDPOINT_SUBSCRIPTION,
-} from '@/app/config'
-
-export interface NetworkEndpoints {
-  queryNodeEndpointSubscription: string
-  queryNodeEndpoint: string
-  membershipFaucetEndpoint: string
-  nodeRpcEndpoint: string
-}
-
-export const localEndpoints = {
-  queryNodeEndpointSubscription: QUERY_NODE_ENDPOINT_SUBSCRIPTION.local,
-  queryNodeEndpoint: QUERY_NODE_ENDPOINT.local,
-  membershipFaucetEndpoint: MEMBERSHIP_FAUCET_ENDPOINT.local,
-  nodeRpcEndpoint: NODE_RPC_ENDPOINT.local,
-} as NetworkEndpoints
-
-export const olympiaEndpoints = {
-  queryNodeEndpointSubscription: QUERY_NODE_ENDPOINT_SUBSCRIPTION['olympia-testnet'],
-  queryNodeEndpoint: QUERY_NODE_ENDPOINT['olympia-testnet'],
-  membershipFaucetEndpoint: MEMBERSHIP_FAUCET_ENDPOINT['olympia-testnet'],
-  nodeRpcEndpoint: NODE_RPC_ENDPOINT['olympia-testnet'],
-} as NetworkEndpoints
+import { DEFAULT_NETWORK, NetworkEndpoints } from '@/app/config'
 
 type UseNetworkEndpoints = [NetworkEndpoints, (endpoint: string) => void]
 
-export const NetworkEndpointsContext = createContext<UseNetworkEndpoints>([olympiaEndpoints, () => undefined])
+export const NetworkEndpointsContext = createContext<UseNetworkEndpoints>([DEFAULT_NETWORK.endpoints, () => undefined])

--- a/packages/ui/src/common/providers/network-endpoints/provider.tsx
+++ b/packages/ui/src/common/providers/network-endpoints/provider.tsx
@@ -1,28 +1,21 @@
 import React, { ReactNode, useCallback, useEffect, useState } from 'react'
 
-import {
-  MEMBERSHIP_FAUCET_ENDPOINT,
-  NetworkType,
-  NODE_RPC_ENDPOINT,
-  QUERY_NODE_ENDPOINT,
-  QUERY_NODE_ENDPOINT_SUBSCRIPTION,
-} from '@/app/config'
+import { DEFAULT_NETWORK, NetworkEndpoints, pickEndpoints } from '@/app/config'
 import { Loading } from '@/common/components/Loading'
 import { useLocalStorage } from '@/common/hooks/useLocalStorage'
 import { useNetwork } from '@/common/hooks/useNetwork'
 import { isDefined, objectEquals } from '@/common/utils'
 
-import { NetworkEndpoints, NetworkEndpointsContext, olympiaEndpoints } from './context'
+import { NetworkEndpointsContext } from './context'
 
 interface Props {
   children: ReactNode
 }
 
 export const NetworkEndpointsProvider = ({ children }: Props) => {
-  const [network, setNetwork] = useNetwork()
-  const [endpoints, setEndpoints] = useState<Partial<NetworkEndpoints>>({})
-  const [storedAutoNetworkConfig, storeAutoNetworkConfig] =
-    useLocalStorage<Partial<NetworkEndpoints>>('auto_network_config')
+  const { network, setNetwork } = useNetwork()
+  const [endpoints, setEndpoints] = useState<NetworkEndpoints>()
+  const [autoConfEndpoints, storeAutoConfEndpoints] = useLocalStorage<NetworkEndpoints>('auto_network_config')
   const [isLoading, setIsLoading] = useState(false)
 
   const updateNetworkConfig = useCallback(
@@ -37,25 +30,23 @@ export const NetworkEndpointsProvider = ({ children }: Props) => {
         throw new Error(`${errMsg}`)
       }
 
-      const newNetworkConfig = {
+      const newAutoConfEndpoints = {
         queryNodeEndpointSubscription: config['graphql_server_websocket'],
         queryNodeEndpoint: config['graphql_server'],
         membershipFaucetEndpoint: config['member_faucet'],
         nodeRpcEndpoint: config['websocket_rpc'],
       }
 
-      if (!endpointsAreDefined(newNetworkConfig)) {
+      if (!endpointsAreDefined(newAutoConfEndpoints)) {
         setIsLoading(false)
         throw new Error('fetched config missing endpoints')
       }
 
-      const shouldUpdateConfig = !objectEquals<Partial<NetworkEndpoints>>(newNetworkConfig)(
-        storedAutoNetworkConfig ?? {}
-      )
+      const shouldUpdateConfig = !objectEquals<Partial<NetworkEndpoints>>(newAutoConfEndpoints)(autoConfEndpoints ?? {})
       const shouldUpdateNetwork = network !== 'auto-conf'
 
       if (shouldUpdateConfig) {
-        storeAutoNetworkConfig(newNetworkConfig)
+        storeAutoConfEndpoints(newAutoConfEndpoints)
       }
       if (shouldUpdateNetwork) {
         setNetwork('auto-conf')
@@ -69,12 +60,15 @@ export const NetworkEndpointsProvider = ({ children }: Props) => {
   )
 
   useEffect(() => {
-    const endpoints = pickEndpoints(network, storedAutoNetworkConfig ?? {})
-    if (!endpointsAreDefined(endpoints)) {
-      setNetwork('olympia-testnet')
-      setEndpoints(olympiaEndpoints)
-    } else {
+    const endpoints = pickEndpoints(network)
+
+    if (endpointsAreDefined(endpoints)) {
       setEndpoints(endpoints)
+    } else if (network === 'auto-conf' && endpointsAreDefined(autoConfEndpoints)) {
+      setEndpoints(autoConfEndpoints)
+    } else {
+      setNetwork(DEFAULT_NETWORK.type)
+      setEndpoints(DEFAULT_NETWORK.endpoints)
     }
   }, [network])
 
@@ -83,29 +77,11 @@ export const NetworkEndpointsProvider = ({ children }: Props) => {
   }
 
   return (
-    <NetworkEndpointsContext.Provider value={[pickEndpoints(network, endpoints), updateNetworkConfig]}>
+    <NetworkEndpointsContext.Provider value={[endpoints, updateNetworkConfig]}>
       {children}
     </NetworkEndpointsContext.Provider>
   )
 }
 
-const endpointsAreDefined = (endpoints: Partial<NetworkEndpoints>): endpoints is NetworkEndpoints =>
+export const endpointsAreDefined = (endpoints: Partial<NetworkEndpoints> = {}): endpoints is NetworkEndpoints =>
   Object.values(endpoints).length === 4 && Object.values(endpoints).every(isDefined)
-
-const pickEndpoints = <R extends Partial<NetworkEndpoints>>(network: NetworkType, endpoints: R) => {
-  if (network === 'auto-conf') {
-    return {
-      queryNodeEndpointSubscription: endpoints.queryNodeEndpointSubscription,
-      queryNodeEndpoint: endpoints.queryNodeEndpoint,
-      membershipFaucetEndpoint: endpoints.membershipFaucetEndpoint,
-      nodeRpcEndpoint: endpoints.nodeRpcEndpoint,
-    } as R
-  } else {
-    return {
-      queryNodeEndpointSubscription: QUERY_NODE_ENDPOINT_SUBSCRIPTION[network],
-      queryNodeEndpoint: QUERY_NODE_ENDPOINT[network],
-      membershipFaucetEndpoint: MEMBERSHIP_FAUCET_ENDPOINT[network],
-      nodeRpcEndpoint: NODE_RPC_ENDPOINT[network],
-    } as R
-  }
-}

--- a/packages/ui/src/mocks/server.ts
+++ b/packages/ui/src/mocks/server.ts
@@ -2,7 +2,7 @@ import { createGraphQLHandler } from '@miragejs/graphql'
 import { createServer, Server } from 'miragejs'
 import { AnyRegistry } from 'miragejs/-types'
 
-import { localEndpoints } from '@/common/providers/network-endpoints/context'
+import { DEFAULT_NETWORK } from '@/app/config'
 import { seedForumCategories, seedForumPosts, seedForumThreads } from '@/mocks/data/seedForum'
 
 import schema from '../common/api/schemas/schema.graphql'
@@ -88,7 +88,7 @@ export const fixAssociations = (server: Server<AnyRegistry>) => {
     membershipModel.class.prototype.associations.bountycreator
 }
 
-export const makeServer = (environment = 'development', endpoints = localEndpoints) => {
+export const makeServer = (environment = 'development', endpoints = DEFAULT_NETWORK.endpoints) => {
   return createServer({
     environment,
 


### PR DESCRIPTION
This goes straight to `olympia` because the `Settings` test suite is failing there, and merging it to `dev` would create conflicts.

In addition to fixing the failing tests this PR also prevents getting a blank page when loading a Pioneer instance where `olympia-testnet` is not defined. It also simplifies the logic a bit.