### PR TITLE
Council announcement wording

### DIFF
--- a/packages/ui/src/council/components/Activities/NewCouncilElectedContent.tsx
+++ b/packages/ui/src/council/components/Activities/NewCouncilElectedContent.tsx
@@ -7,6 +7,6 @@ import { NewCouncilElectedActivity } from '@/council/types/CouncilActivities'
 
 export const NewCouncilElectedContent: ActivityContentComponent<NewCouncilElectedActivity> = ({ activity }) => (
   <ActivityRouterLink to={CouncilRoutes.council}>
-    New council have been elected with {activity.electedMembersCount} councilors.
+    {activity.electedMembersCount} councilors have been elected.
   </ActivityRouterLink>
 )

--- a/packages/ui/src/council/components/Activities/NewCouncilElectedContent.tsx
+++ b/packages/ui/src/council/components/Activities/NewCouncilElectedContent.tsx
@@ -6,7 +6,5 @@ import { CouncilRoutes } from '@/council/constants'
 import { NewCouncilElectedActivity } from '@/council/types/CouncilActivities'
 
 export const NewCouncilElectedContent: ActivityContentComponent<NewCouncilElectedActivity> = ({ activity }) => (
-  <ActivityRouterLink to={CouncilRoutes.council}>
-    New council elected.
-  </ActivityRouterLink>
+  <ActivityRouterLink to={CouncilRoutes.council}>New council elected.</ActivityRouterLink>
 )

--- a/packages/ui/src/council/components/Activities/NewCouncilElectedContent.tsx
+++ b/packages/ui/src/council/components/Activities/NewCouncilElectedContent.tsx
@@ -7,6 +7,6 @@ import { NewCouncilElectedActivity } from '@/council/types/CouncilActivities'
 
 export const NewCouncilElectedContent: ActivityContentComponent<NewCouncilElectedActivity> = ({ activity }) => (
   <ActivityRouterLink to={CouncilRoutes.council}>
-    {activity.electedMembersCount} councilors have been elected.
+    New council elected.
   </ActivityRouterLink>
 )


### PR DESCRIPTION
Technically `have been` is only correct [while](http://www.differencebetween.net/language/difference-between-were-and-have-been/) they are elected - it is likely the notification will disappear until next election finished,

If you like we could drop it altogether (`5 councilors elected to the council` or `New council elected`).

@blrhc how would a mother tongue say it?