### PR TITLE
MyStakeStat: String Concatenation in getTotalStake

### DIFF
--- a/packages/ui/src/working-groups/components/MyStakeStat.tsx
+++ b/packages/ui/src/working-groups/components/MyStakeStat.tsx
@@ -4,7 +4,7 @@ import { TokenValueStat } from '@/common/components/statistics'
 import { useMyWorkers } from '@/working-groups/hooks/useMyWorkers'
 import { Worker } from '@/working-groups/types'
 
-const getTotalStake = (workers: Worker[]) => workers.reduce((total, worker) => total + worker.stake, 0)
+const getTotalStake = (workers: Worker[]) => workers.reduce((total, worker) => total + Number(worker.stake), 0)
 
 export const MyStakeStat = () => {
   const { workers } = useMyWorkers()

--- a/packages/ui/src/working-groups/components/MyStakeStat.tsx
+++ b/packages/ui/src/working-groups/components/MyStakeStat.tsx
@@ -1,14 +1,12 @@
 import React from 'react'
 
 import { TokenValueStat } from '@/common/components/statistics'
+import { sumStakes } from '@/common/utils/bn'
 import { useMyWorkers } from '@/working-groups/hooks/useMyWorkers'
-import { Worker } from '@/working-groups/types'
-
-const getTotalStake = (workers: Worker[]) => workers.reduce((total, worker) => total + Number(worker.stake), 0)
 
 export const MyStakeStat = () => {
   const { workers } = useMyWorkers()
-  const totalStake = getTotalStake(workers)
+  const totalStake = sumStakes(workers)
 
   return <TokenValueStat title="Currently staking" value={totalStake} />
 }


### PR DESCRIPTION
When a user has more than one role, stakes are reduces to a sum, but the stake property is of string type, so it leads to wrong result: 
<img width="846" alt="image" src="https://user-images.githubusercontent.com/9252017/161392411-ddd55419-ab45-4e00-9bb8-bf368a6e79dc.png">
![image](https://user-images.githubusercontent.com/9252017/161392479-0b86bdd6-bdc3-40fe-af5b-88c266cc6917.png)

Fixes #2427 