### PR TITLE
💪 Fix on submit work validation and more

### DIFF
--- a/packages/ui/src/bounty/components/BountyActorsList/BountyActorsList.tsx
+++ b/packages/ui/src/bounty/components/BountyActorsList/BountyActorsList.tsx
@@ -40,7 +40,7 @@ const actorsMapFunction = (el: BountyActorItem) => {
       </ValueText>
     )
   }
-  return <ValueText lighter>Work withdrawn</ValueText>
+  return <ValueText lighter>Entry withdrawn</ValueText>
 }
 
 export const BountyActorsList = memo(

--- a/packages/ui/src/bounty/components/BountyPreviewHeader/BountyPreviewHeader.tsx
+++ b/packages/ui/src/bounty/components/BountyPreviewHeader/BountyPreviewHeader.tsx
@@ -60,7 +60,9 @@ const buttonValidMembersMapper: Record<ButtonTypes, keyof BountyMembershipsStati
 export const getMembershipsStatistics = (membershipsIdArray: string[], bounty?: Bounty) => {
   const extractEntryWorkerId = (entry: WorkEntry) => entry.worker.id
 
-  const membersWithEntries = bounty?.entries?.filter((entry) => membershipsIdArray.includes(entry.worker.id)) ?? []
+  const membersWithEntries =
+    bounty?.entries?.filter((entry: WorkEntry) => membershipsIdArray.includes(entry.worker.id) && !entry.withdrawn) ??
+    []
   const idsWithEntries = membersWithEntries.map(extractEntryWorkerId)
   const idsWithoutEntries = membershipsIdArray.filter((memberId) => !idsWithEntries.includes(memberId))
 
@@ -80,7 +82,6 @@ export const getMembershipsStatistics = (membershipsIdArray: string[], bounty?: 
   const idAsOracle = membershipsIdArray.filter((memberId) => bounty?.oracle?.id === memberId)
 
   return {
-    idsWithSubmissions: membersWithSubmission.map(extractEntryWorkerId),
     idsWithReward: membersWithReward.map(extractEntryWorkerId),
     idsWithLoss: membersWithLoss.map(extractEntryWorkerId),
     idsWithEntries,
@@ -102,7 +103,6 @@ const bountyHeaderButtonsFactory = (bounty: Bounty, membershipsStatistics: Bount
     idsOnWhitelist,
     idsWithLoss,
     idsWithReward,
-    idsWithSubmissions,
     idsWithEntries,
     idAsOracle,
     idsWithoutEntries,
@@ -122,7 +122,7 @@ const bountyHeaderButtonsFactory = (bounty: Bounty, membershipsStatistics: Bount
       isDefined(bounty?.entrantWhitelist) && !idsOnWhitelist.length && buttons.push('notify')
       idsWithoutEntries.length && buttons.push('announceWorkEntry')
       idsWithEntries.length && buttons.push('submitWork')
-      idsWithSubmissions.length && buttons.push('withdrawWorkEntry')
+      idsWithEntries.length && buttons.push('withdrawWorkEntry')
       break
     }
     case 'judgment': {

--- a/packages/ui/src/bounty/modals/SubmitWorkModal/SubmitWorkModal.tsx
+++ b/packages/ui/src/bounty/modals/SubmitWorkModal/SubmitWorkModal.tsx
@@ -66,7 +66,8 @@ export const SubmitWorkModal = () => {
   const { isValid, errors } = useSchema({ ...state.context }, schema)
 
   const entry = useMemo(
-    () => modalData.bounty?.entries?.find((entry) => entry.worker.id === activeMember?.id) ?? undefined,
+    () =>
+      modalData.bounty?.entries?.find((entry) => entry.worker.id === activeMember?.id && !entry.withdrawn) ?? undefined,
     [activeMember?.id]
   )
 

--- a/packages/ui/src/bounty/modals/SubmitWorkModal/SubmitWorkModal.tsx
+++ b/packages/ui/src/bounty/modals/SubmitWorkModal/SubmitWorkModal.tsx
@@ -3,11 +3,12 @@ import { createType } from '@joystream/types'
 import { BountyId, EntryId } from '@joystream/types/bounty'
 import { MemberId } from '@joystream/types/common'
 import { useMachine } from '@xstate/react'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { generatePath } from 'react-router'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
+import * as Yup from 'yup'
 
 import { useMyAccounts } from '@/accounts/hooks/useMyAccounts'
 import { accountOrNamed } from '@/accounts/model/accountOrNamed'
@@ -25,6 +26,7 @@ import { ButtonPrimary, ButtonsGroup } from '@/common/components/buttons'
 import { CKEditor } from '@/common/components/CKEditor'
 import { FailureModal } from '@/common/components/FailureModal'
 import { InputComponent, InputContainer, InputText } from '@/common/components/forms'
+import { getErrorMessage, hasError } from '@/common/components/forms/FieldError'
 import {
   Modal,
   ModalFooter,
@@ -38,9 +40,15 @@ import { TextBig } from '@/common/components/typography'
 import { WaitModal } from '@/common/components/WaitModal'
 import { useApi } from '@/common/hooks/useApi'
 import { useModal } from '@/common/hooks/useModal'
+import { useSchema } from '@/common/hooks/useSchema'
 import { metadataToBytes } from '@/common/model/JoystreamNode'
 import { SelectedMember } from '@/memberships/components/SelectMember'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
+
+const schema = Yup.object().shape({
+  workTitle: Yup.string().max(70, 'modals.submitWork.validation.maxLengthMessage').required(''),
+  workDescription: Yup.string().required(''),
+})
 
 export const SubmitWorkModal = () => {
   const { hideModal, modalData } = useModal<SubmitWorkModalCall>()
@@ -48,13 +56,14 @@ export const SubmitWorkModal = () => {
   const { t } = useTranslation('bounty')
   const [state, send, service] = useMachine(submitWorkMachine)
   const history = useHistory()
-  const [isValidNext, setValidNext] = useState(false)
   const { allAccounts } = useMyAccounts()
   const { api, isConnected } = useApi()
 
   if (!service.initialized) {
     service.start()
   }
+
+  const { isValid, errors } = useSchema({ ...state.context }, schema)
 
   const entry = useMemo(
     () => modalData.bounty?.entries?.find((entry) => entry.worker.id === activeMember?.id) ?? undefined,
@@ -76,14 +85,6 @@ export const SubmitWorkModal = () => {
     hideModal()
     history.push(generatePath(BountyRoutes.currentBounties))
   }, [])
-
-  useEffect(() => {
-    if (state.context.workTitle && state.context.workDescription !== '') {
-      setValidNext(true)
-    } else {
-      setValidNext(false)
-    }
-  })
 
   useEffect(() => {
     if (!entry && activeMember?.id) {
@@ -145,77 +146,75 @@ export const SubmitWorkModal = () => {
     return <FailureModal onClose={hideModal}>{t('common:modals.transactionCanceled')}</FailureModal>
   }
 
-  const workTitleValidation =
-    state.context.workTitle.length > 70
-      ? t('modals.submitWork.validation.maxLengthMessage')
-      : t('modals.submitWork.validation.max70')
-
   return (
-    <Modal onClose={hideModal} modalSize="l" modalHeight="xl">
+    <Modal onClose={hideModal} modalSize="l">
       <ModalHeader title={t('modals.submitWork.title')} onClick={hideModal} />
       <ScrolledModalBody>
         <ScrolledModalContainer>
-          {state.matches(SubmitWorkStates.generalParameters) && (
-            <RowGapBlock gap={24}>
-              <Row>
-                <RowGapBlock gap={8}>
-                  <h4>{t('modals.submitWork.subtitle')}</h4>
-                </RowGapBlock>
-              </Row>
-              <Container
-                disabled
-                label="Bounty ID"
-                tooltipText={t('modals.submitWork.submitWorkInput.bountyId')}
-                inputSize="l"
-              >
-                <TextBig value bold>
-                  {modalData.bounty.id}
-                </TextBig>
-              </Container>
-              <Row>
-                <RowGapBlock gap={20}>
-                  <SelectedMember
-                    disabled
-                    member={activeMember}
-                    label={t('modals.submitWork.submitWorkInput.memberId')}
-                  />
-                  <InputComponent
+          <RowGapBlock gap={24}>
+            <Row>
+              <RowGapBlock gap={8}>
+                <h4>{t('modals.submitWork.subtitle')}</h4>
+              </RowGapBlock>
+            </Row>
+            <Container
+              disabled
+              label="Bounty ID"
+              tooltipText={t('modals.submitWork.submitWorkInput.bountyId')}
+              inputSize="l"
+            >
+              <TextBig value bold>
+                {modalData.bounty.id}
+              </TextBig>
+            </Container>
+            <Row>
+              <RowGapBlock gap={20}>
+                <SelectedMember
+                  disabled
+                  member={activeMember}
+                  label={t('modals.submitWork.submitWorkInput.memberId')}
+                />
+                <InputComponent
+                  id="field-work-title"
+                  required
+                  inputSize="m"
+                  label={t('modals.submitWork.submitWorkInput.workTitle')}
+                  message={t(
+                    hasError('workTitle', errors)
+                      ? getErrorMessage('workTitle', errors) ?? ''
+                      : 'modals.submitWork.validation.max70'
+                  )}
+                  validation={hasError('workTitle', errors) ? 'invalid' : undefined}
+                >
+                  <InputText
                     id="field-work-title"
-                    required
-                    inputSize="m"
-                    label={t('modals.submitWork.submitWorkInput.workTitle')}
-                    message={workTitleValidation}
-                    validation={state.context.workTitle.length > 70 ? 'invalid' : undefined}
-                  >
-                    <InputText
-                      id="field-work-title"
-                      value={state.context.workTitle}
-                      onChange={(e) => send('SET_WORK_TITLE', { workTitle: e.target.value })}
-                      placeholder={t('modals.submitWork.submitWorkInput.workTitlePlaceholder')}
-                    />
-                  </InputComponent>
-                  <InputComponent
+                    value={state.context.workTitle}
+                    onChange={(e) => send('SET_WORK_TITLE', { workTitle: e.target.value })}
+                    placeholder={t('modals.submitWork.submitWorkInput.workTitlePlaceholder')}
+                  />
+                </InputComponent>
+                <InputComponent
+                  id="field-description"
+                  label={t('modals.submitWork.submitWorkInput.entryDescription')}
+                  inputSize="auto"
+                  required
+                >
+                  <CKEditor
                     id="field-description"
-                    label={t('modals.submitWork.submitWorkInput.entryDescription')}
-                    inputSize="auto"
-                    required
-                  >
-                    <CKEditor
-                      id="field-description"
-                      minRows={3}
-                      onChange={(event, editor) => send('SET_WORK_DESCRIPTION', { workDescription: editor.getData() })}
-                      onReady={(editor) => editor.setData(state.context.workDescription || '')}
-                    />
-                  </InputComponent>
-                </RowGapBlock>
-              </Row>
-            </RowGapBlock>
-          )}
+                    minRows={3}
+                    maxRows={5}
+                    onChange={(event, editor) => send('SET_WORK_DESCRIPTION', { workDescription: editor.getData() })}
+                    onReady={(editor) => editor.setData(state.context.workDescription || '')}
+                  />
+                </InputComponent>
+              </RowGapBlock>
+            </Row>
+          </RowGapBlock>
         </ScrolledModalContainer>
       </ScrolledModalBody>
       <ModalFooter>
         <ButtonsGroup align="right">
-          <ButtonPrimary disabled={!isValidNext} onClick={() => send('NEXT')} size="medium">
+          <ButtonPrimary disabled={!isValid} onClick={() => send('NEXT')} size="medium">
             {t('modals.submitWork.button.submitWork')}
           </ButtonPrimary>
         </ButtonsGroup>

--- a/packages/ui/src/bounty/modals/WithdrawWorkEntryModal/WithdrawWorkEntryModal.tsx
+++ b/packages/ui/src/bounty/modals/WithdrawWorkEntryModal/WithdrawWorkEntryModal.tsx
@@ -47,7 +47,7 @@ export const WithdrawWorkEntryModal = () => {
   const { allAccounts } = useMyAccounts()
 
   const entry = useMemo(
-    () => activeMember && bounty.entries?.find((entry) => entry.worker.id === activeMember.id),
+    () => activeMember && bounty.entries?.find((entry) => entry.worker.id === activeMember.id && !entry.withdrawn),
     [activeMember?.id]
   )
 
@@ -111,7 +111,7 @@ export const WithdrawWorkEntryModal = () => {
   }
 
   return (
-    <Modal onClose={hideModal} modalSize="l" modalHeight="xl">
+    <Modal onClose={hideModal} modalSize="l">
       <ModalHeader title={t('modals.withdrawWorkEntry.title')} onClick={hideModal} />
       <ScrolledModalBody>
         <ScrolledModalContainer>

--- a/packages/ui/src/common/components/forms/InputComponent.tsx
+++ b/packages/ui/src/common/components/forms/InputComponent.tsx
@@ -465,6 +465,7 @@ export const InputArea = styled.div`
   height: 100%;
   justify-content: flex-start;
   align-items: center;
+  min-width: 0;
 `
 
 const InputRightSide = styled.div<DisabledInputProps>`

--- a/packages/ui/test/bounty/modals/SubmitWorkModal.test.tsx
+++ b/packages/ui/test/bounty/modals/SubmitWorkModal.test.tsx
@@ -48,7 +48,6 @@ describe('UI: BountySubmitModal', () => {
   let useModal: UseModal<any>
   beforeAll(async () => {
     seedMembers(mockServer.server, 2)
-
     useModal = {
       hideModal: jest.fn(),
       showModal: jest.fn(),
@@ -63,6 +62,7 @@ describe('UI: BountySubmitModal', () => {
               worker: {
                 id: getMember('bob').id,
               },
+              withdrawn: false,
             },
           ],
         },
@@ -99,6 +99,14 @@ describe('UI: BountySubmitModal', () => {
   it('Renders', async () => {
     expect(screen.queryByText('modals.submitWork.title')).toBeDefined()
     expect(screen.queryByText('modals.submitWork.button.submitWork')).toBeDefined()
+  })
+
+  it('Hides modal when entry is withdrawn', () => {
+    useModal.modalData.bounty.entries[0].withdrawn = true
+    render(<RenderModal />)
+    useModal.modalData.bounty.entries[0].withdrawn = false
+
+    expect(useModal.hideModal).toBeCalledTimes(1)
   })
 
   it('Displays correct bounty', () => {


### PR DESCRIPTION
Additionally in this PR following issues should be resovled:

- Markdown editor shouldn't expand modal container on text overflow
- Correct entry will be chosen when user with try to withdraw second and subsequent work entries
- Correct entry will be chosen when user this to submit work on second and subsequent work entry
- Now we display Withdraw entry CTA for members that have entry, previously we did it for workers when submittions