### PR TITLE
🎖️ Fix on flashing validation when selecting staking account (#2852)

### DIFF
--- a/packages/ui/src/memberships/model/validation.ts
+++ b/packages/ui/src/memberships/model/validation.ts
@@ -51,14 +51,13 @@ export const StakingAccountSchema = Yup.object()
       !areLocksConflicting(validationContext.stakeLock, validationContext.balances.locks)
     )
   })
-  .test('stakingStatus', 'Account might be bound to another member', (value, context) => {
-    if (!value) {
-      return true
-    }
-
+  .test('otherStatus', 'This account is bound to another member', (value, context) => {
     const { stakingStatus } = context.options.context as IStakingAccountSchema
-
-    return stakingStatus !== 'unknown' && stakingStatus !== 'other'
+    return stakingStatus !== 'other'
+  })
+  .test('unknownStatus', '', (value, context) => {
+    const { stakingStatus } = context.options.context as IStakingAccountSchema
+    return stakingStatus !== 'unknown'
   })
 
 export const NewAddressSchema = (which: string) =>


### PR DESCRIPTION
:warning: This should be merged not squash merged

This is a cherry pick from `dev` into `staging` back into `dev` because I should have merged #2852 to `staging` directly so now I'm merging it back into `dev` again :tired_face: 
(cherry picked from commit 3e9f6871205fe090231a682142cf12e16c4f19df)