### PR TITLE
📝 Fix editable posts in proposal discussion

### DIFF
--- a/packages/ui/dev/node-mocks/commands/opening/create.ts
+++ b/packages/ui/dev/node-mocks/commands/opening/create.ts
@@ -41,6 +41,6 @@ export const createOpeningModule = {
   command: 'opening:create',
   describe: 'Create new opening',
   handler: async () => {
-    await addOpeningCommand
+    await addOpeningCommand()
   },
 }

--- a/packages/ui/src/common/components/forms/Checkbox.tsx
+++ b/packages/ui/src/common/components/forms/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { BorderRad, Colors, Fonts, Transitions } from '../../constants'
@@ -15,6 +15,10 @@ export interface CheckboxProps {
 
 export function Checkbox({ id, isRequired, children, enabled = true, isChecked = false, onChange }: CheckboxProps) {
   const [isStateChecked, setStateChecked] = useState(isChecked)
+
+  useEffect(() => {
+    setStateChecked(isChecked)
+  }, [isChecked])
 
   return (
     <CheckboxLabel

--- a/packages/ui/src/forum/components/PostList/PostEditor.tsx
+++ b/packages/ui/src/forum/components/PostList/PostEditor.tsx
@@ -42,7 +42,7 @@ export const PostEditor = ({ post, onCancel, type, onSuccessfulEdit }: Props) =>
           )
         }
         if (type === 'proposal' && proposalPostData.threadId) {
-          return api.tx.proposalsDiscussion.updatePost(post.id, proposalPostData.threadId, text)
+          return api.tx.proposalsDiscussion.updatePost(proposalPostData.threadId, post.id, text)
         }
       }
     },

--- a/packages/ui/src/proposals/components/ProposalDiscussions.tsx
+++ b/packages/ui/src/proposals/components/ProposalDiscussions.tsx
@@ -1,6 +1,6 @@
 import { ForumPostMetadata } from '@joystream/metadata-protobuf'
 import { createType } from '@joystream/types'
-import React, { RefObject, useEffect, useRef, useState } from 'react'
+import React, { RefObject, useEffect, useMemo, useRef, useState } from 'react'
 import { generatePath } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 
@@ -50,6 +50,8 @@ export const ProposalDiscussions = ({ thread, proposalId }: Props) => {
       postsRefs[initialPost].current?.scrollIntoView({ behavior: 'smooth', inline: 'start' })
     }
   }, [postsRefs, initialPost])
+
+  const discussionPosts = useMemo(() => thread.discussionPosts.filter((post) => post.status !== 'PostStatusRemoved'), [thread])
 
   const getTransaction = (postText: string, isEditable: boolean) => {
     if (api && active && thread) {
@@ -101,10 +103,10 @@ export const ProposalDiscussions = ({ thread, proposalId }: Props) => {
           </Tooltip>
         </Badge>
       </DiscussionsHeader>
-      {thread.discussionPosts.map((post, index) => {
+      {discussionPosts.map((post) => {
         return (
           <PostListItem
-            key={index}
+            key={post.id}
             insertRef={getInsertRef(post.id)}
             isSelected={post.id === initialPost}
             isThreadActive={true}

--- a/packages/ui/src/proposals/queries/__generated__/proposals.generated.tsx
+++ b/packages/ui/src/proposals/queries/__generated__/proposals.generated.tsx
@@ -503,6 +503,10 @@ export type ProposalWithDetailsFieldsFragment = {
             group: { __typename: 'WorkingGroup'; name: string }
           }>
         }
+        status:
+          | { __typename: 'ProposalDiscussionPostStatusActive' }
+          | { __typename: 'ProposalDiscussionPostStatusLocked' }
+          | { __typename: 'ProposalDiscussionPostStatusRemoved' }
       } | null
       createdInEvent: {
         __typename: 'ProposalDiscussionPostCreatedEvent'
@@ -536,6 +540,10 @@ export type ProposalWithDetailsFieldsFragment = {
           group: { __typename: 'WorkingGroup'; name: string }
         }>
       }
+      status:
+        | { __typename: 'ProposalDiscussionPostStatusActive' }
+        | { __typename: 'ProposalDiscussionPostStatusLocked' }
+        | { __typename: 'ProposalDiscussionPostStatusRemoved' }
     }>
     mode:
       | {
@@ -631,6 +639,10 @@ export type DiscussionPostFieldsFragment = {
         group: { __typename: 'WorkingGroup'; name: string }
       }>
     }
+    status:
+      | { __typename: 'ProposalDiscussionPostStatusActive' }
+      | { __typename: 'ProposalDiscussionPostStatusLocked' }
+      | { __typename: 'ProposalDiscussionPostStatusRemoved' }
   } | null
   createdInEvent: {
     __typename: 'ProposalDiscussionPostCreatedEvent'
@@ -664,6 +676,10 @@ export type DiscussionPostFieldsFragment = {
       group: { __typename: 'WorkingGroup'; name: string }
     }>
   }
+  status:
+    | { __typename: 'ProposalDiscussionPostStatusActive' }
+    | { __typename: 'ProposalDiscussionPostStatusLocked' }
+    | { __typename: 'ProposalDiscussionPostStatusRemoved' }
 }
 
 export type DiscussionPostWithoutReplyFieldsFragment = {
@@ -704,6 +720,10 @@ export type DiscussionPostWithoutReplyFieldsFragment = {
       group: { __typename: 'WorkingGroup'; name: string }
     }>
   }
+  status:
+    | { __typename: 'ProposalDiscussionPostStatusActive' }
+    | { __typename: 'ProposalDiscussionPostStatusLocked' }
+    | { __typename: 'ProposalDiscussionPostStatusRemoved' }
 }
 
 export type ProposalPostParentsFragment = { __typename: 'ProposalDiscussionPost'; discussionThreadId: string }
@@ -1210,6 +1230,10 @@ export type GetProposalQuery = {
               group: { __typename: 'WorkingGroup'; name: string }
             }>
           }
+          status:
+            | { __typename: 'ProposalDiscussionPostStatusActive' }
+            | { __typename: 'ProposalDiscussionPostStatusLocked' }
+            | { __typename: 'ProposalDiscussionPostStatusRemoved' }
         } | null
         createdInEvent: {
           __typename: 'ProposalDiscussionPostCreatedEvent'
@@ -1243,6 +1267,10 @@ export type GetProposalQuery = {
             group: { __typename: 'WorkingGroup'; name: string }
           }>
         }
+        status:
+          | { __typename: 'ProposalDiscussionPostStatusActive' }
+          | { __typename: 'ProposalDiscussionPostStatusLocked' }
+          | { __typename: 'ProposalDiscussionPostStatusRemoved' }
       }>
       mode:
         | {
@@ -1588,6 +1616,9 @@ export const DiscussionPostWithoutReplyFieldsFragmentDoc = gql`
       ...MemberFields
     }
     text
+    status {
+      __typename
+    }
   }
   ${MemberFieldsFragmentDoc}
 `

--- a/packages/ui/src/proposals/queries/proposals.graphql
+++ b/packages/ui/src/proposals/queries/proposals.graphql
@@ -219,6 +219,9 @@ fragment DiscussionPostWithoutReplyFields on ProposalDiscussionPost {
     ...MemberFields
   }
   text
+  status {
+    __typename
+  }
 }
 
 fragment ProposalPostParents on ProposalDiscussionPost {

--- a/packages/ui/src/proposals/types/ProposalWithDetails.ts
+++ b/packages/ui/src/proposals/types/ProposalWithDetails.ts
@@ -1,6 +1,6 @@
-import { ProposalVoteKind } from '@/common/api/queries'
+import { ProposalDiscussionPostStatus, ProposalVoteKind } from '@/common/api/queries'
 import { asBlock, Block } from '@/common/types'
-import { ForumPost } from '@/forum/types'
+import { ForumPost, PostStatusTypename } from '@/forum/types'
 import { asMember, Member } from '@/memberships/types'
 import { typenameToProposalStatus } from '@/proposals/model/proposalStatus'
 import {
@@ -80,6 +80,10 @@ export interface ProposalDiscussionThread {
   whitelistIds?: string[]
 }
 
+const asDiscussionPostStatus = (status: ProposalDiscussionPostStatus['__typename']) => {
+  return status.replace('ProposalDiscussion', '') as PostStatusTypename
+}
+
 const asForumComment = (fields: DiscussionPostFieldsFragment): ForumPost => ({
   id: fields.id,
   createdAt: fields.createdAt,
@@ -88,5 +92,5 @@ const asForumComment = (fields: DiscussionPostFieldsFragment): ForumPost => ({
   author: asMember(fields.author),
   text: fields.text,
   ...(fields.repliesTo ? { repliesTo: asForumComment(fields.repliesTo) } : {}),
-  status: 'PostStatusActive',
+  status: asDiscussionPostStatus(fields.status.__typename),
 })


### PR DESCRIPTION
Closes #2476 

Issue scope:
- [x] Fix editing editable posts in proposal discussion
- [x] Fix deleting replies in proposal discussion

Beyoynd issue:
- [x] Fix script for creating opening mock
- [x] Do not display deleted posts in proposal discussion
- [x] Clear checkbox after submitting: 
so far when user created editable post the checkbox stayed marked (because it didn't update properly) after transition, so if user creates another post they may think it would be editable too, but it won't. This is a change inside `Checkbox` component so it may fix other similar issues (if there are)