### PR TITLE
😵‍💫 Fix on proposal title input

### DIFF
--- a/packages/ui/src/proposals/modals/AddNewProposal/components/ProposalDetailsStep.tsx
+++ b/packages/ui/src/proposals/modals/AddNewProposal/components/ProposalDetailsStep.tsx
@@ -83,7 +83,7 @@ export const ProposalDetailsStep = ({
             >
               <InputText
                 id="field-title"
-                value={title}
+                value={fields.title ?? ''}
                 onChange={(event) => changeField('title', event.target.value)}
               />
             </InputComponent>


### PR DESCRIPTION
Main issue here was that input was changing value of `useForm` context while keeping track of value xstate machine context, which is always 1 re-render behind `useForm`, because of using `useEffect` to sync both of them. For now I switched value of input to track `useForm` value, but desirable approach is to introduce RHF.