### PR TITLE
#3025 Update medium modal padding to better fit on smaller screens.

### DIFF
--- a/packages/ui/src/common/components/Modal/Modal.tsx
+++ b/packages/ui/src/common/components/Modal/Modal.tsx
@@ -95,7 +95,7 @@ export const ModalGlass = styled.div<ModalProps>`
       case 's':
         return '0px'
       case 'm':
-        return '120px'
+        return '60px'
       case 'l':
         return '44px'
       case 'xl':


### PR DESCRIPTION
https://github.com/Joystream/pioneer/issues/3025
Lower padding-top to 60px for modal size `m`