### PR TITLE
⚖️ Fix available staking balances

### DIFF
--- a/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
@@ -4,21 +4,20 @@ import styled from 'styled-components'
 import { AccountInfo } from '@/accounts/components/AccountInfo'
 import { AccountLocks, AccountLocksWrapper } from '@/accounts/components/AccountLocks'
 import { useBalance } from '@/accounts/hooks/useBalance'
-import { isRivalrous, getStakingBalance } from '@/accounts/model/lockTypes'
-import { AccountOption, LockType } from '@/accounts/types'
+import { AccountOption } from '@/accounts/types'
 import { BalanceInfoInRow, InfoTitle, InfoValue } from '@/common/components/Modal'
 import { TokenValue } from '@/common/components/typography'
 import { Colors } from '@/common/constants'
 
 interface Props {
   option: AccountOption
-  newLockType?: LockType
+  isForStaking?: boolean
 }
 
-export const OptionAccount = ({ option, newLockType }: Props) => {
+export const OptionAccount = ({ option, isForStaking }: Props) => {
   const balances = useBalance(option.address)
-  const balance = balances && newLockType && getStakingBalance(balances, newLockType)
-  const balanceType = newLockType && isRivalrous(newLockType) ? 'Transferable' : 'Total'
+  const balance = isForStaking ? balances?.total : balances?.transferable
+  const balanceType = isForStaking ? 'Total' : 'Transferable'
   const locks = option.optionLocks
   const isLocked = !!locks?.length
 
@@ -28,7 +27,7 @@ export const OptionAccount = ({ option, newLockType }: Props) => {
       <BalanceInfoInRow>
         <InfoTitle>{balanceType} balance</InfoTitle>
         <InfoValueWithLocks>
-          <Value value={balance} locked={isLocked} />
+          <Value value={balance ?? balances?.total} locked={isLocked} />
           <AccountLocks locks={balances?.locks} />
         </InfoValueWithLocks>
       </BalanceInfoInRow>

--- a/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
@@ -27,7 +27,7 @@ export const OptionAccount = ({ option, isForStaking }: Props) => {
       <BalanceInfoInRow>
         <InfoTitle>{balanceType} balance</InfoTitle>
         <InfoValueWithLocks>
-          <Value value={balance ?? balances?.total} locked={isLocked} />
+          <Value value={balance} locked={isLocked} />
           <AccountLocks locks={balances?.locks} />
         </InfoValueWithLocks>
       </BalanceInfoInRow>

--- a/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
@@ -4,16 +4,18 @@ import styled from 'styled-components'
 import { AccountInfo } from '@/accounts/components/AccountInfo'
 import { AccountLocks, AccountLocksWrapper } from '@/accounts/components/AccountLocks'
 import { useBalance } from '@/accounts/hooks/useBalance'
-import { AccountOption } from '@/accounts/types'
+import { getAvailableBalanceForNewStaking } from '@/accounts/model/lockTypes'
+import { AccountOption, LockType } from '@/accounts/types'
 import { BalanceInfoInRow, InfoTitle, InfoValue } from '@/common/components/Modal'
 import { TokenValue } from '@/common/components/typography'
 import { Colors } from '@/common/constants'
 
 interface Props {
   option: AccountOption
+  newLockType?: LockType
 }
 
-export const OptionAccount = ({ option }: Props) => {
+export const OptionAccount = ({ option, newLockType }: Props) => {
   const balance = useBalance(option.address)
   const locks = option.optionLocks
   const isLocked = !!locks?.length
@@ -22,9 +24,14 @@ export const OptionAccount = ({ option }: Props) => {
     <>
       <AccountInfo account={option} locked={isLocked} />
       <BalanceInfoInRow>
-        <InfoTitle>Transferable balance</InfoTitle>
+        <InfoTitle>{newLockType ? 'Available balance' : 'Transferable balance'}</InfoTitle>
         <InfoValueWithLocks>
-          <Value value={balance?.transferable} locked={isLocked} />
+          <Value
+            value={
+              newLockType && balance ? getAvailableBalanceForNewStaking(balance, newLockType) : balance?.transferable
+            }
+            locked={isLocked}
+          />
           <AccountLocks locks={balance?.locks} />
         </InfoValueWithLocks>
       </BalanceInfoInRow>

--- a/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { AccountInfo } from '@/accounts/components/AccountInfo'
 import { AccountLocks, AccountLocksWrapper } from '@/accounts/components/AccountLocks'
 import { useBalance } from '@/accounts/hooks/useBalance'
-import { getAvailableBalanceForNewStaking } from '@/accounts/model/lockTypes'
+import { isRivalrous, stakingBalance } from '@/accounts/model/lockTypes'
 import { AccountOption, LockType } from '@/accounts/types'
 import { BalanceInfoInRow, InfoTitle, InfoValue } from '@/common/components/Modal'
 import { TokenValue } from '@/common/components/typography'
@@ -16,7 +16,9 @@ interface Props {
 }
 
 export const OptionAccount = ({ option, newLockType }: Props) => {
-  const balance = useBalance(option.address)
+  const balances = useBalance(option.address)
+  const balance = balances && newLockType && stakingBalance(balances, newLockType)
+  const balanceType = newLockType && isRivalrous(newLockType) ? 'Transferable' : 'Total'
   const locks = option.optionLocks
   const isLocked = !!locks?.length
 
@@ -24,15 +26,10 @@ export const OptionAccount = ({ option, newLockType }: Props) => {
     <>
       <AccountInfo account={option} locked={isLocked} />
       <BalanceInfoInRow>
-        <InfoTitle>{newLockType ? 'Available balance' : 'Transferable balance'}</InfoTitle>
+        <InfoTitle>{balanceType} balance</InfoTitle>
         <InfoValueWithLocks>
-          <Value
-            value={
-              newLockType && balance ? getAvailableBalanceForNewStaking(balance, newLockType) : balance?.transferable
-            }
-            locked={isLocked}
-          />
-          <AccountLocks locks={balance?.locks} />
+          <Value value={balance} locked={isLocked} />
+          <AccountLocks locks={balances?.locks} />
         </InfoValueWithLocks>
       </BalanceInfoInRow>
     </>

--- a/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { AccountInfo } from '@/accounts/components/AccountInfo'
 import { AccountLocks, AccountLocksWrapper } from '@/accounts/components/AccountLocks'
 import { useBalance } from '@/accounts/hooks/useBalance'
-import { isRivalrous, stakingBalance } from '@/accounts/model/lockTypes'
+import { isRivalrous, getStakingBalance } from '@/accounts/model/lockTypes'
 import { AccountOption, LockType } from '@/accounts/types'
 import { BalanceInfoInRow, InfoTitle, InfoValue } from '@/common/components/Modal'
 import { TokenValue } from '@/common/components/typography'
@@ -17,7 +17,7 @@ interface Props {
 
 export const OptionAccount = ({ option, newLockType }: Props) => {
   const balances = useBalance(option.address)
-  const balance = balances && newLockType && stakingBalance(balances, newLockType)
+  const balance = balances && newLockType && getStakingBalance(balances, newLockType)
   const balanceType = newLockType && isRivalrous(newLockType) ? 'Transferable' : 'Total'
   const locks = option.optionLocks
   const isLocked = !!locks?.length

--- a/packages/ui/src/accounts/components/SelectAccount/OptionListAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/OptionListAccount.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Option, OptionsListComponent } from '@/common/components/selects'
 
-import { AccountOption, LockType } from '../../types'
+import { AccountOption } from '../../types'
 
 import { AccountLockTooltip } from './AccountLockTooltip'
 import { OptionAccount } from './OptionAccount'
@@ -11,23 +11,23 @@ interface Props {
   options: AccountOption[]
   onChange: (option: AccountOption) => void
   className?: string
-  newLockType?: LockType
+  isForStaking?: boolean
 }
 
-export const OptionListAccount = React.memo(({ options, onChange, className, newLockType }: Props) => {
+export const OptionListAccount = React.memo(({ options, onChange, className, isForStaking }: Props) => {
   const freeAccounts = options.filter((option) => (option.optionLocks ? option.optionLocks?.length === 0 : true))
   const lockedAccounts = options.filter((option) => !!option.optionLocks?.length)
   return (
     <OptionsListComponent className={className}>
       {freeAccounts.map((option) => (
         <Option key={option.address} onClick={() => onChange && onChange(option)}>
-          <OptionAccount option={option} newLockType={newLockType} />
+          <OptionAccount option={option} isForStaking={isForStaking} />
         </Option>
       ))}
       {lockedAccounts.map((option) => (
         <AccountLockTooltip key={option.address} locks={option.optionLocks}>
           <Option key={option.address} onClick={() => onChange && onChange(option)} disabled>
-            <OptionAccount option={option} newLockType={newLockType} />
+            <OptionAccount option={option} isForStaking={isForStaking} />
           </Option>
         </AccountLockTooltip>
       ))}

--- a/packages/ui/src/accounts/components/SelectAccount/OptionListAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/OptionListAccount.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
-import { Option, OptionsListComponent } from '../../../common/components/selects'
-import { AccountOption } from '../../types'
+import { Option, OptionsListComponent } from '@/common/components/selects'
+
+import { AccountOption, LockType } from '../../types'
 
 import { AccountLockTooltip } from './AccountLockTooltip'
 import { OptionAccount } from './OptionAccount'
@@ -10,22 +11,23 @@ interface Props {
   options: AccountOption[]
   onChange: (option: AccountOption) => void
   className?: string
+  newLockType?: LockType
 }
 
-export const OptionListAccount = React.memo(({ options, onChange, className }: Props) => {
+export const OptionListAccount = React.memo(({ options, onChange, className, newLockType }: Props) => {
   const freeAccounts = options.filter((option) => (option.optionLocks ? option.optionLocks?.length === 0 : true))
   const lockedAccounts = options.filter((option) => !!option.optionLocks?.length)
   return (
     <OptionsListComponent className={className}>
       {freeAccounts.map((option) => (
         <Option key={option.address} onClick={() => onChange && onChange(option)}>
-          <OptionAccount option={option} />
+          <OptionAccount option={option} newLockType={newLockType} />
         </Option>
       ))}
       {lockedAccounts.map((option) => (
         <AccountLockTooltip key={option.address} locks={option.optionLocks}>
           <Option key={option.address} onClick={() => onChange && onChange(option)} disabled>
-            <OptionAccount option={option} />
+            <OptionAccount option={option} newLockType={newLockType} />
           </Option>
         </AccountLockTooltip>
       ))}

--- a/packages/ui/src/accounts/components/SelectAccount/SelectAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/SelectAccount.tsx
@@ -35,10 +35,11 @@ interface SelectStakingAccountProps extends SelectAccountProps {
 
 interface BaseSelectAccountProps extends SelectAccountProps {
   accounts: AccountOption[]
+  newLockType?: LockType
 }
 
 export const BaseSelectAccount = React.memo(
-  ({ id, onChange, accounts, filter, selected, disabled, onBlur }: BaseSelectAccountProps) => {
+  ({ id, onChange, accounts, filter, selected, disabled, onBlur, newLockType }: BaseSelectAccountProps) => {
     const options = accounts.filter(filter || (() => true))
 
     const [search, setSearch] = useState('')
@@ -66,20 +67,23 @@ export const BaseSelectAccount = React.memo(
         onChange={change}
         onBlur={onBlur}
         disabled={disabled}
-        renderSelected={renderSelected}
+        renderSelected={renderSelected(newLockType)}
         placeholder="Select account or paste account address"
-        renderList={(onOptionClick) => <OptionListAccount onChange={onOptionClick} options={filteredOptions} />}
+        renderList={(onOptionClick) => (
+          <OptionListAccount onChange={onOptionClick} options={filteredOptions} newLockType={newLockType} />
+        )}
         onSearch={(search) => setSearch(search)}
       />
     )
   }
 )
 
-const renderSelected = (option: AccountOption) => (
-  <SelectedOption>
-    <OptionAccount option={option} />
-  </SelectedOption>
-)
+const renderSelected = (newLockType?: LockType) => (option: AccountOption) =>
+  (
+    <SelectedOption>
+      <OptionAccount option={option} newLockType={newLockType} />
+    </SelectedOption>
+  )
 
 export const SelectAccount = ({ name, ...props }: SelectAccountProps) => {
   const { allAccounts } = useMyAccounts()
@@ -137,6 +141,7 @@ export const SelectStakingAccount = ({
           selected={field.value}
           onChange={field.onChange}
           onBlur={field.onBlur}
+          newLockType={lockType}
         />
       )}
     />

--- a/packages/ui/src/accounts/components/SelectAccount/SelectAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/SelectAccount.tsx
@@ -35,11 +35,11 @@ interface SelectStakingAccountProps extends SelectAccountProps {
 
 interface BaseSelectAccountProps extends SelectAccountProps {
   accounts: AccountOption[]
-  newLockType?: LockType
+  isForStaking?: boolean
 }
 
 export const BaseSelectAccount = React.memo(
-  ({ id, onChange, accounts, filter, selected, disabled, onBlur, newLockType }: BaseSelectAccountProps) => {
+  ({ id, onChange, accounts, filter, selected, disabled, onBlur, isForStaking }: BaseSelectAccountProps) => {
     const options = accounts.filter(filter || (() => true))
 
     const [search, setSearch] = useState('')
@@ -67,10 +67,10 @@ export const BaseSelectAccount = React.memo(
         onChange={change}
         onBlur={onBlur}
         disabled={disabled}
-        renderSelected={renderSelected(newLockType)}
+        renderSelected={renderSelected(isForStaking)}
         placeholder="Select account or paste account address"
         renderList={(onOptionClick) => (
-          <OptionListAccount onChange={onOptionClick} options={filteredOptions} newLockType={newLockType} />
+          <OptionListAccount onChange={onOptionClick} options={filteredOptions} isForStaking={isForStaking} />
         )}
         onSearch={(search) => setSearch(search)}
       />
@@ -78,10 +78,10 @@ export const BaseSelectAccount = React.memo(
   }
 )
 
-const renderSelected = (newLockType?: LockType) => (option: AccountOption) =>
+const renderSelected = (isForStaking?: boolean) => (option: AccountOption) =>
   (
     <SelectedOption>
-      <OptionAccount option={option} newLockType={newLockType} />
+      <OptionAccount option={option} isForStaking={isForStaking} />
     </SelectedOption>
   )
 
@@ -141,7 +141,7 @@ export const SelectStakingAccount = ({
           selected={field.value}
           onChange={field.onChange}
           onBlur={field.onBlur}
-          newLockType={lockType}
+          isForStaking
         />
       )}
     />

--- a/packages/ui/src/accounts/hooks/useBalance.ts
+++ b/packages/ui/src/accounts/hooks/useBalance.ts
@@ -5,14 +5,21 @@ import { Address } from '@/common/types'
 
 import { Balances } from '../types'
 
+import { useMyBalances } from './useMyBalances'
+
 export const useBalance = (address?: Address): Balances | null => {
   const { api, connectionState } = useApi()
+  const allMyBalances = useMyBalances()
+  const myBalances = address && allMyBalances[address]
 
-  const balances = useObservable(address ? api?.derive.balances.all(address) : undefined, [connectionState, address])
+  const balances = useObservable(!myBalances && address ? api?.derive.balances.all(address) : undefined, [
+    connectionState,
+    address,
+  ])
 
-  if (balances === undefined) {
-    return null
+  if (myBalances) {
+    return myBalances
   }
 
-  return toBalances(balances)
+  return balances ? toBalances(balances) : null
 }

--- a/packages/ui/src/accounts/hooks/useStakingAccountsLocks.ts
+++ b/packages/ui/src/accounts/hooks/useStakingAccountsLocks.ts
@@ -2,7 +2,7 @@ import BN from 'bn.js'
 
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 
-import { RecoveryConditions, isRecoverable, areLocksConflicting, getStakingBalance } from '../model/lockTypes'
+import { RecoveryConditions, isRecoverable, areLocksConflicting } from '../model/lockTypes'
 import { LockType, OptionLock, AccountOption } from '../types'
 
 import { useMyAccounts } from './useMyAccounts'
@@ -32,10 +32,9 @@ export const useStakingAccountsLocks = ({
     const optionLocks: OptionLock[] = []
     const accountAddress = account.address
     const accountBalances = balances[accountAddress]
-    const stakingBalance = getStakingBalance(accountBalances, lockType)
 
     const boundMembershipId = getMemberIdByBoundAccountAddress(accountAddress)
-    if (stakingBalance?.lt(requiredStake) && filterByBalance) {
+    if (accountBalances.total?.lt(requiredStake) && filterByBalance) {
       optionLocks.push('insufficientFunds')
     }
 

--- a/packages/ui/src/accounts/hooks/useStakingAccountsLocks.ts
+++ b/packages/ui/src/accounts/hooks/useStakingAccountsLocks.ts
@@ -2,7 +2,12 @@ import BN from 'bn.js'
 
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 
-import { RecoveryConditions, isRecoverable, areLocksConflicting } from '../model/lockTypes'
+import {
+  RecoveryConditions,
+  isRecoverable,
+  areLocksConflicting,
+  getAvailableBalanceForNewStaking,
+} from '../model/lockTypes'
 import { LockType, OptionLock, AccountOption } from '../types'
 
 import { useMyAccounts } from './useMyAccounts'
@@ -32,10 +37,10 @@ export const useStakingAccountsLocks = ({
     const optionLocks: OptionLock[] = []
     const accountAddress = account.address
     const balance = balances[accountAddress]
+    const availableBalance = getAvailableBalanceForNewStaking(balances[accountAddress], lockType)
 
     const boundMembershipId = getMemberIdByBoundAccountAddress(accountAddress)
-
-    if (!balance.transferable.gte(requiredStake) && filterByBalance) {
+    if (!availableBalance.gte(requiredStake) && filterByBalance) {
       optionLocks.push('insufficientFunds')
     }
 

--- a/packages/ui/src/accounts/model/lockTypes.ts
+++ b/packages/ui/src/accounts/model/lockTypes.ts
@@ -44,7 +44,7 @@ const RIVALROUS: LockType[] = [
   'Distribution Worker',
 ]
 
-const isRivalrous = (lockType: LockType) => RIVALROUS.includes(lockType)
+export const isRivalrous = (lockType: LockType) => RIVALROUS.includes(lockType)
 const asLockTypes = (locks: BalanceLock[]): LockType[] => locks.flatMap((lock) => lock.type ?? [])
 const isConflictingWith = (lockTypeA: LockType): ((lockTypeB: LockType) => boolean) => {
   if (!lockTypeA) {
@@ -95,6 +95,9 @@ export const conflictingLocks = (lockType: LockType, existingLocks: BalanceLock[
   asLockTypes(existingLocks).filter(isConflictingWith(lockType))
 
 export const lockLookup = (id: LockIdentifier): LockType => lockTypes[id.toUtf8()]
+
+export const stakingBalance = (balances: Balances, lockType: LockType) =>
+  balances[isRivalrous(lockType) ? 'transferable' : 'total']
 
 export const getAvailableBalanceForNewStaking = (balances: Balances, newLock: LockType) => {
   if (newLock === 'Voting') {

--- a/packages/ui/src/accounts/model/lockTypes.ts
+++ b/packages/ui/src/accounts/model/lockTypes.ts
@@ -1,7 +1,7 @@
 import { LockIdentifier } from '@polkadot/types/interfaces'
 
 // NOTE can't run the `node-mocks` script with the `@/...` aliases here
-import { BalanceLock, Balances, LockType, WorkerLocks, WorkerLockType } from '../types'
+import { BalanceLock, LockType, WorkerLocks, WorkerLockType } from '../types'
 
 // Mapping from:
 // - [/runtime/src/constants.rs:104](https://github.com/Joystream/joystream/blob/5a153fa18351a8fefd919a7d5230b911f180e13d/runtime/src/constants.rs#L104)
@@ -95,6 +95,3 @@ export const conflictingLocks = (lockType: LockType, existingLocks: BalanceLock[
   asLockTypes(existingLocks).filter(isConflictingWith(lockType))
 
 export const lockLookup = (id: LockIdentifier): LockType => lockTypes[id.toUtf8()]
-
-export const getStakingBalance = (balances: Balances | undefined, lockType: LockType) =>
-  balances?.[isRivalrous(lockType) ? 'transferable' : 'total']

--- a/packages/ui/src/accounts/model/lockTypes.ts
+++ b/packages/ui/src/accounts/model/lockTypes.ts
@@ -1,7 +1,7 @@
 import { LockIdentifier } from '@polkadot/types/interfaces'
 
-import { BalanceLock, Balances, LockType, WorkerLocks, WorkerLockType } from '@/accounts/types'
-import { BN_ZERO } from '@/common/constants'
+// NOTE can't run the `node-mocks` script with the `@/...` aliases here
+import { BalanceLock, Balances, LockType, WorkerLocks, WorkerLockType } from '../types'
 
 // Mapping from:
 // - [/runtime/src/constants.rs:104](https://github.com/Joystream/joystream/blob/5a153fa18351a8fefd919a7d5230b911f180e13d/runtime/src/constants.rs#L104)
@@ -96,31 +96,5 @@ export const conflictingLocks = (lockType: LockType, existingLocks: BalanceLock[
 
 export const lockLookup = (id: LockIdentifier): LockType => lockTypes[id.toUtf8()]
 
-export const stakingBalance = (balances: Balances, lockType: LockType) =>
-  balances[isRivalrous(lockType) ? 'transferable' : 'total']
-
-export const getAvailableBalanceForNewStaking = (balances: Balances, newLock: LockType) => {
-  if (newLock === 'Voting') {
-    return balances.total
-  }
-
-  let availableBalance = BN_ZERO
-  availableBalance = availableBalance.add(balances.transferable)
-
-  if (isRivalrous(newLock)) {
-    balances.locks
-      .filter((lock) => !isRivalrous(lock.type))
-      .forEach((lock: BalanceLock) => {
-        availableBalance = availableBalance.add(lock.amount)
-      })
-    return availableBalance
-  }
-
-  balances.locks.forEach((lock) => {
-    if (lock.type !== newLock) {
-      availableBalance = availableBalance.add(lock.amount)
-    }
-  })
-
-  return availableBalance
-}
+export const getStakingBalance = (balances: Balances | undefined, lockType: LockType) =>
+  balances?.[isRivalrous(lockType) ? 'transferable' : 'total']

--- a/packages/ui/src/bounty/components/BountyActorsList/BountyActorsList.tsx
+++ b/packages/ui/src/bounty/components/BountyActorsList/BountyActorsList.tsx
@@ -61,9 +61,9 @@ export const BountyActorsList = memo(({ title, elements, entrantResult, open = t
         <>
           {entrantResult && <Infobox result={entrantResult} />}
           {elements.map(
-            (el) =>
+            (el, index) =>
               el?.actor && (
-                <Wrapper key={el?.actor?.id}>
+                <Wrapper key={el?.actor?.id + '-tile-' + index}>
                   <MemberInfo member={el.actor} />
                   {actorsMapFunction(el)}
                 </Wrapper>

--- a/packages/ui/src/common/utils/validation.ts
+++ b/packages/ui/src/common/utils/validation.ts
@@ -1,6 +1,6 @@
 import { isBn } from '@polkadot/util'
 import BN from 'bn.js'
-import { at } from 'lodash'
+import { at, get } from 'lodash'
 import { useCallback } from 'react'
 import { FieldErrors, FieldValues, Resolver } from 'react-hook-form'
 import * as Yup from 'yup'
@@ -23,7 +23,8 @@ export const maxContext = (msg: string, contextPath: string): Yup.TestConfig<any
     if (!value) {
       return true
     }
-    const validationValue = new BN(this.options.context?.[contextPath])
+
+    const validationValue = new BN(get(this.options.context, contextPath))
     if (validationValue && validationValue.lt(new BN(value))) {
       return this.createError({ message: msg, params: { max: validationValue?.toNumber() ?? validationValue } })
     }
@@ -40,7 +41,7 @@ export const minContext = (msg: string, contextPath: string): Yup.TestConfig<any
       return true
     }
 
-    const validationValue = new BN(this.options.context?.[contextPath])
+    const validationValue = new BN(get(this.options.context, contextPath))
     if (validationValue && validationValue.gt(new BN(value))) {
       return this.createError({ message: msg, params: { min: validationValue?.toNumber() ?? validationValue } })
     }

--- a/packages/ui/src/council/modals/AnnounceCandidacy/AnnounceCandidacyModal.tsx
+++ b/packages/ui/src/council/modals/AnnounceCandidacy/AnnounceCandidacyModal.tsx
@@ -75,14 +75,12 @@ const transactionSteps = [
 
 interface Conditions extends IStakingAccountSchema {
   minStake: BN
-  controllerAccountBalance: BN
 }
 
 export const AnnounceCandidacyModal = () => {
   const { api, connectionState } = useApi()
   const boundingLock = api?.consts.members.candidateStake ?? BN_ZERO
   const { active: activeMember } = useMyMemberships()
-  const balances = useMyBalances()
   const { hideModal, showModal } = useModal()
   const [state, send, service] = useMachine(announceCandidacyMachine)
   const constants = useCouncilConstants()
@@ -103,7 +101,6 @@ export const AnnounceCandidacyModal = () => {
       stakeLock: 'Council Candidate',
       balances: balance,
       minStake: constants?.election.minCandidacyStake as BN,
-      controllerAccountBalance: balances[activeMember?.controllerAccount ?? '']?.transferable,
     } as Conditions,
     mode: 'onChange',
     defaultValues: getAnnounceCandidacyFormInitialState(constants?.election.minCandidacyStake ?? BN_ZERO),

--- a/packages/ui/src/council/modals/AnnounceCandidacy/helpers.ts
+++ b/packages/ui/src/council/modals/AnnounceCandidacy/helpers.ts
@@ -3,7 +3,7 @@ import { StateValueMap } from 'xstate'
 import * as Yup from 'yup'
 
 import { Account } from '@/accounts/types'
-import { BNSchema, maxContext, minContext } from '@/common/utils/validation'
+import { BNSchema, validStakingAmount } from '@/common/utils/validation'
 import { AccountSchema, StakingAccountSchema } from '@/memberships/model/validation'
 
 export interface AnnounceCandidacyFrom {
@@ -29,9 +29,7 @@ export interface AnnounceCandidacyFrom {
 export const baseSchema = Yup.object().shape({
   staking: Yup.object().shape({
     account: StakingAccountSchema.required('This field is required'),
-    amount: BNSchema.test(minContext('Minimal stake amount is ${min} tJOY', 'minStake'))
-      .test(maxContext('Insufficient funds to cover staking', 'balances.total'))
-      .required('This field is required'),
+    amount: BNSchema.test(validStakingAmount()).required('This field is required'),
   }),
   reward: Yup.object().shape({
     account: AccountSchema.required('This field is required'),

--- a/packages/ui/src/council/modals/AnnounceCandidacy/helpers.ts
+++ b/packages/ui/src/council/modals/AnnounceCandidacy/helpers.ts
@@ -29,8 +29,8 @@ export interface AnnounceCandidacyFrom {
 export const baseSchema = Yup.object().shape({
   staking: Yup.object().shape({
     account: StakingAccountSchema.required('This field is required'),
-    amount: BNSchema.test(maxContext('Insufficient funds to cover staking', 'balances.transferable'))
-      .test(minContext('Minimal stake amount is ${min} tJOY', 'minStake'))
+    amount: BNSchema.test(minContext('Minimal stake amount is ${min} tJOY', 'minStake'))
+      .test(maxContext('Insufficient funds to cover staking', 'balances.total'))
       .required('This field is required'),
   }),
   rewardAccount: Yup.object().shape({

--- a/packages/ui/src/council/modals/AnnounceCandidacy/helpers.ts
+++ b/packages/ui/src/council/modals/AnnounceCandidacy/helpers.ts
@@ -30,7 +30,7 @@ export const baseSchema = Yup.object().shape({
   staking: Yup.object().shape({
     account: StakingAccountSchema.required('This field is required'),
     amount: BNSchema.test(minContext('Minimal stake amount is ${min} tJOY', 'minStake'))
-      .test(maxContext('Insufficient funds to cover staking', 'controllerAccountBalance'))
+      .test(maxContext('Insufficient funds to cover staking', 'balances.transferable'))
       .required('This field is required'),
   }),
   rewardAccount: Yup.object().shape({

--- a/packages/ui/src/council/modals/AnnounceCandidacy/helpers.ts
+++ b/packages/ui/src/council/modals/AnnounceCandidacy/helpers.ts
@@ -29,8 +29,8 @@ export interface AnnounceCandidacyFrom {
 export const baseSchema = Yup.object().shape({
   staking: Yup.object().shape({
     account: StakingAccountSchema.required('This field is required'),
-    amount: BNSchema.test(minContext('Minimal stake amount is ${min} tJOY', 'minStake'))
-      .test(maxContext('Insufficient funds to cover staking', 'balances.transferable'))
+    amount: BNSchema.test(maxContext('Insufficient funds to cover staking', 'balances.transferable'))
+      .test(minContext('Minimal stake amount is ${min} tJOY', 'minStake'))
       .required('This field is required'),
   }),
   rewardAccount: Yup.object().shape({

--- a/packages/ui/src/council/modals/VoteForCouncil/VoteForCouncilFormModal.tsx
+++ b/packages/ui/src/council/modals/VoteForCouncil/VoteForCouncilFormModal.tsx
@@ -12,7 +12,7 @@ import { Arrow } from '@/common/components/icons'
 import { Modal, ModalFooter, ModalHeader, ScrollableModalColumn, ScrolledModalBody } from '@/common/components/Modal'
 import { useModal } from '@/common/hooks/useModal'
 import { useSchema } from '@/common/hooks/useSchema'
-import { BNSchema, minContext } from '@/common/utils/validation'
+import { BNSchema, maxContext, minContext } from '@/common/utils/validation'
 import { useCandidate } from '@/council/hooks/useCandidate'
 import { useMyCastVotes } from '@/council/hooks/useMyCastVotes'
 import { VoteForCouncilEvent, VoteForCouncilMachineState } from '@/council/modals/VoteForCouncil/machine'
@@ -29,7 +29,9 @@ export interface VoteForCouncilFormModalProps {
 
 const StakeStepFormSchema = Yup.object().shape({
   account: StakingAccountSchema.required(),
-  stake: BNSchema.test(minContext('You need at least ${min} stake', 'minStake')).required(),
+  stake: BNSchema.test(minContext('You need at least ${min} stake', 'minStake'))
+    .test(maxContext('Insufficient funds to cover staking', 'balances.total'))
+    .required(),
 })
 
 interface IFormContext extends IStakingAccountSchema {

--- a/packages/ui/src/council/modals/VoteForCouncil/VoteForCouncilFormModal.tsx
+++ b/packages/ui/src/council/modals/VoteForCouncil/VoteForCouncilFormModal.tsx
@@ -1,3 +1,4 @@
+import { BN_ZERO } from '@polkadot/util'
 import BN from 'bn.js'
 import React, { useCallback, useEffect } from 'react'
 import styled from 'styled-components'
@@ -12,7 +13,7 @@ import { Arrow } from '@/common/components/icons'
 import { Modal, ModalFooter, ModalHeader, ScrollableModalColumn, ScrolledModalBody } from '@/common/components/Modal'
 import { useModal } from '@/common/hooks/useModal'
 import { useSchema } from '@/common/hooks/useSchema'
-import { BNSchema, maxContext, minContext } from '@/common/utils/validation'
+import { BNSchema, validStakingAmount } from '@/common/utils/validation'
 import { useCandidate } from '@/council/hooks/useCandidate'
 import { useMyCastVotes } from '@/council/hooks/useMyCastVotes'
 import { VoteForCouncilEvent, VoteForCouncilMachineState } from '@/council/modals/VoteForCouncil/machine'
@@ -29,12 +30,11 @@ export interface VoteForCouncilFormModalProps {
 
 const StakeStepFormSchema = Yup.object().shape({
   account: StakingAccountSchema.required(),
-  stake: BNSchema.test(minContext('You need at least ${min} stake', 'minStake'))
-    .test(maxContext('Insufficient funds to cover staking', 'balances.total'))
-    .required(),
+  stake: BNSchema.test(validStakingAmount()).required(),
 })
 
 interface IFormContext extends IStakingAccountSchema {
+  extraFees: BN
   minStake: BN
 }
 
@@ -58,6 +58,7 @@ export const VoteForCouncilFormModal = ({ minStake, send, state }: VoteForCounci
         minStake,
         stakingStatus: 'confirmed',
         balances: stakingAccountBalance,
+        extraFees: BN_ZERO, // TODO add the transaction fees here
         stakeLock: 'Voting',
         requiredAmount: state.context.stake ?? minStake,
       })

--- a/packages/ui/src/memberships/model/validation.ts
+++ b/packages/ui/src/memberships/model/validation.ts
@@ -4,7 +4,7 @@ import { AnySchema } from 'yup'
 
 import { StakingStatus } from '@/accounts/hooks/useStakingAccountStatus'
 import { isValidAddress } from '@/accounts/model/isValidAddress'
-import { areLocksConflicting } from '@/accounts/model/lockTypes'
+import { areLocksConflicting, getAvailableBalanceForNewStaking } from '@/accounts/model/lockTypes'
 import { Balances, LockType } from '@/accounts/types'
 
 export const AccountSchema = Yup.object()
@@ -35,9 +35,12 @@ export const StakingAccountSchema = Yup.object()
     }
 
     const validationContext = context.options.context as IStakingAccountSchema
-    return (
-      !!validationContext?.balances &&
-      (validationContext.balances as Balances).transferable.gte(validationContext.requiredAmount)
+
+    if (!validationContext.balances) {
+      return false
+    }
+    return getAvailableBalanceForNewStaking(validationContext.balances, validationContext.stakeLock).gte(
+      validationContext.requiredAmount
     )
   })
   .test('locks', 'This account has conflicting locks', (value, context) => {

--- a/packages/ui/src/memberships/model/validation.ts
+++ b/packages/ui/src/memberships/model/validation.ts
@@ -4,7 +4,7 @@ import { AnySchema } from 'yup'
 
 import { StakingStatus } from '@/accounts/hooks/useStakingAccountStatus'
 import { isValidAddress } from '@/accounts/model/isValidAddress'
-import { areLocksConflicting, getAvailableBalanceForNewStaking } from '@/accounts/model/lockTypes'
+import { areLocksConflicting, getStakingBalance } from '@/accounts/model/lockTypes'
 import { Balances, LockType } from '@/accounts/types'
 
 export const AccountSchema = Yup.object()
@@ -34,14 +34,10 @@ export const StakingAccountSchema = Yup.object()
       return true
     }
 
-    const validationContext = context.options.context as IStakingAccountSchema
+    const { requiredAmount, balances, stakeLock } = context.options.context as IStakingAccountSchema
+    const stakingBalance = balances && getStakingBalance(balances, stakeLock)
 
-    if (!validationContext.balances) {
-      return false
-    }
-    return getAvailableBalanceForNewStaking(validationContext.balances, validationContext.stakeLock).gte(
-      validationContext.requiredAmount
-    )
+    return !!stakingBalance?.gte(requiredAmount)
   })
   .test('locks', 'This account has conflicting locks', (value, context) => {
     if (!value) {

--- a/packages/ui/src/memberships/model/validation.ts
+++ b/packages/ui/src/memberships/model/validation.ts
@@ -4,7 +4,7 @@ import { AnySchema } from 'yup'
 
 import { StakingStatus } from '@/accounts/hooks/useStakingAccountStatus'
 import { isValidAddress } from '@/accounts/model/isValidAddress'
-import { areLocksConflicting, getStakingBalance } from '@/accounts/model/lockTypes'
+import { areLocksConflicting } from '@/accounts/model/lockTypes'
 import { Balances, LockType } from '@/accounts/types'
 
 export const AccountSchema = Yup.object()
@@ -34,10 +34,8 @@ export const StakingAccountSchema = Yup.object()
       return true
     }
 
-    const { requiredAmount, balances, stakeLock } = context.options.context as IStakingAccountSchema
-    const stakingBalance = balances && getStakingBalance(balances, stakeLock)
-
-    return !!stakingBalance?.gte(requiredAmount)
+    const { requiredAmount, balances } = context.options.context as IStakingAccountSchema
+    return !!balances.total?.gte(requiredAmount)
   })
   .test('locks', 'This account has conflicting locks', (value, context) => {
     if (!value) {

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/ApplyForRoleModal.tsx
@@ -1,5 +1,6 @@
 import { ApplicationMetadata } from '@joystream/metadata-protobuf'
 import { SubmittableExtrinsic } from '@polkadot/api/types'
+import { BN_ZERO } from '@polkadot/util'
 import { useMachine } from '@xstate/react'
 import BN from 'bn.js'
 import React, { useEffect, useMemo, useState } from 'react'
@@ -74,12 +75,18 @@ export const ApplyForRoleModal = () => {
 
   const balance = useBalance(stakingAccountMap?.address)
   const stakingStatus = useStakingAccountStatus(stakingAccountMap?.address, activeMember?.id)
+
+  const boundingLock = api?.consts.members.candidateStake ?? BN_ZERO
+  // TODO add transaction fees here
+  const extraFees = (stakingStatus === 'free' && boundingLock) || BN_ZERO
+
   const form = useForm({
     resolver: useYupValidationResolver(schema, typeof state.value === 'string' ? state.value : undefined),
     mode: 'onChange',
     context: {
       minStake: opening.stake,
       balances: balance,
+      extraFees,
       stakeLock: groupToLockId(opening.groupId),
       requiredAmount: opening.stake,
       stakingStatus,

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/helpers.ts
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/helpers.ts
@@ -23,7 +23,7 @@ export const baseSchema = Yup.object().shape({
     rewardAccount: AccountSchema.required(),
     amount: Yup.number()
       .test(minContext('You need at least ${min} stake', 'minStake'))
-      .test(maxContext('Insufficient funds to cover staking', 'balances.transferable'))
+      .test(maxContext('Insufficient funds to cover staking', 'balances.total'))
       .required('Amount is required'),
   }),
   form: Yup.object().shape({}),

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/helpers.ts
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/helpers.ts
@@ -1,6 +1,6 @@
 import * as Yup from 'yup'
 
-import { maxContext, minContext } from '@/common/utils/validation'
+import { validStakingAmount } from '@/common/utils/validation'
 import { AccountSchema, StakingAccountSchema } from '@/memberships/model/validation'
 import { ApplicationQuestion } from '@/working-groups/types'
 
@@ -21,10 +21,7 @@ export const baseSchema = Yup.object().shape({
     account: StakingAccountSchema.required(),
     roleAccount: AccountSchema.required(),
     rewardAccount: AccountSchema.required(),
-    amount: Yup.number()
-      .test(minContext('You need at least ${min} stake', 'minStake'))
-      .test(maxContext('Insufficient funds to cover staking', 'balances.total'))
-      .required('Amount is required'),
+    amount: Yup.number().test(validStakingAmount()).required('Amount is required'),
   }),
   form: Yup.object().shape({}),
 })

--- a/packages/ui/src/working-groups/modals/ApplyForRoleModal/helpers.ts
+++ b/packages/ui/src/working-groups/modals/ApplyForRoleModal/helpers.ts
@@ -1,6 +1,6 @@
 import * as Yup from 'yup'
 
-import { minContext } from '@/common/utils/validation'
+import { maxContext, minContext } from '@/common/utils/validation'
 import { AccountSchema, StakingAccountSchema } from '@/memberships/model/validation'
 import { ApplicationQuestion } from '@/working-groups/types'
 
@@ -21,7 +21,10 @@ export const baseSchema = Yup.object().shape({
     account: StakingAccountSchema.required(),
     roleAccount: AccountSchema.required(),
     rewardAccount: AccountSchema.required(),
-    amount: Yup.number().test(minContext('You need at least ${min} stake', 'minStake')).required('Amount is required'),
+    amount: Yup.number()
+      .test(minContext('You need at least ${min} stake', 'minStake'))
+      .test(maxContext('Insufficient funds to cover staking', 'balances.transferable'))
+      .required('Amount is required'),
   }),
   form: Yup.object().shape({}),
 })

--- a/packages/ui/test/_helpers/selectFromDropdown.ts
+++ b/packages/ui/test/_helpers/selectFromDropdown.ts
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 
 export const selectFromDropdown = async (label: string, name: string) => {
   const labelElement = await screen.findByText(new RegExp(`${label}`, 'i'))
@@ -18,14 +18,20 @@ const selectFromDropdownElement = async (element: HTMLElement, name: string) => 
   }
 
   const toggle = parentElement.querySelector('.ui-toggle')
-  toggle && fireEvent.click(toggle)
+  toggle &&
+    (await act(async () => {
+      fireEvent.click(toggle)
+    }))
 
-  let found
+  let found: Element | undefined
   await waitFor(() => {
     const memberTitles = parentElement?.querySelectorAll('ul > li')
     found = memberTitles && Array.from(memberTitles).find((li) => li.textContent?.match(name))
     expect(found).toBeDefined()
   }, {})
 
-  found && fireEvent.click(found)
+  found &&
+    (await act(async () => {
+      fireEvent.click(found as Element)
+    }))
 }

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -111,8 +111,10 @@ describe('UI: ApplyForRoleModal', () => {
     useMyMemberships.setActive(getMember('alice'))
 
     stubConst(api, 'forumWorkingGroup.rewardPeriod', createType('u32', 14410))
+    stubConst(api, 'members.candidateStake', new BN(200))
+
     stubBalances(api, {
-      available: 2000,
+      available: 3000,
     })
     applyTransaction = stubTransaction(api, 'api.tx.forumWorkingGroup.applyOnOpening')
     applyOnOpeningTxMock = api.api.tx.forumWorkingGroup.applyOnOpening as unknown as jest.Mock
@@ -146,7 +148,7 @@ describe('UI: ApplyForRoleModal', () => {
     it('No active member', async () => {
       useMyMemberships.active = undefined
 
-      renderModal()
+      await renderModal()
 
       expect(useModal.showModal).toBeCalledWith({
         modal: 'SwitchMember',
@@ -168,7 +170,7 @@ describe('UI: ApplyForRoleModal', () => {
       useModal.modalData = { opening }
       batchTx = stubTransaction(api, 'api.tx.forumWorkingGroup.applyOnOpening', 10_000)
 
-      renderModal()
+      await renderModal()
 
       const moveFundsModalCall: MoveFundsModalCall = {
         modal: 'MoveFundsModal',
@@ -183,21 +185,21 @@ describe('UI: ApplyForRoleModal', () => {
   })
 
   it('Renders a modal', async () => {
-    renderModal()
+    await renderModal()
 
     expect(await screen.findByText('Applying for role')).toBeDefined()
   })
 
   describe('Stake step', () => {
     it('Empty fields', async () => {
-      renderModal()
+      await renderModal()
 
       const button = await getNextStepButton()
       expect(button).toBeDisabled()
     })
 
     it('Too low stake', async () => {
-      renderModal()
+      await renderModal()
 
       await selectFromDropdown('Select account for Staking', 'alice')
       await fillFieldByLabel(/Select amount for staking/i, '50')
@@ -207,7 +209,7 @@ describe('UI: ApplyForRoleModal', () => {
     })
 
     it('Valid fields', async () => {
-      renderModal()
+      await renderModal()
 
       await selectFromDropdown('Select account for Staking', 'alice')
       await fillFieldByLabel(/Select amount for staking/i, '2000')
@@ -460,7 +462,9 @@ describe('UI: ApplyForRoleModal', () => {
     await fillFieldByLabel(/Select amount for staking/i, '2000')
     await selectFromDropdownWithId('role-account', 'alice')
     await selectFromDropdownWithId('reward-account', 'alice')
-    fireEvent.click(await getNextStepButton())
+    await act(async () => {
+      fireEvent.click(await getNextStepButton())
+    })
     await screen.findByText('Application')
   }
 
@@ -471,34 +475,42 @@ describe('UI: ApplyForRoleModal', () => {
     await fillFieldByLabel(/Question 1/i, 'Foo bar baz')
     await fillFieldByLabel(/Question 2/i, 'Foo bar baz')
     await fillFieldByLabel(/Question 3/i, 'Foo bar baz')
-    fireEvent.click(await getNextStepButton())
+    await act(async () => {
+      fireEvent.click(await getNextStepButton())
+    })
   }
 
   async function fillFieldByLabel(label: string | RegExp, value: number | string) {
     const amountInput = await screen.findByLabelText(label)
-    fireEvent.change(amountInput, { target: { value } })
-    fireEvent.blur(amountInput)
+    await act(async () => {
+      fireEvent.change(amountInput, { target: { value } })
+    })
+    await act(async () => {
+      fireEvent.blur(amountInput)
+    })
   }
 
-  function renderModal() {
-    return render(
-      <MemoryRouter>
-        <ModalContext.Provider value={useModal}>
-          <MockQueryNodeProviders>
-            <MockKeyringProvider>
-              <ApiContext.Provider value={api}>
-                <AccountsContext.Provider value={useAccounts}>
-                  <MembershipContext.Provider value={useMyMemberships}>
-                    <BalancesContextProvider>
-                      <ApplyForRoleModal />
-                    </BalancesContextProvider>
-                  </MembershipContext.Provider>
-                </AccountsContext.Provider>
-              </ApiContext.Provider>
-            </MockKeyringProvider>
-          </MockQueryNodeProviders>
-        </ModalContext.Provider>
-      </MemoryRouter>
-    )
+  async function renderModal() {
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <ModalContext.Provider value={useModal}>
+            <MockQueryNodeProviders>
+              <MockKeyringProvider>
+                <ApiContext.Provider value={api}>
+                  <AccountsContext.Provider value={useAccounts}>
+                    <MembershipContext.Provider value={useMyMemberships}>
+                      <BalancesContextProvider>
+                        <ApplyForRoleModal />
+                      </BalancesContextProvider>
+                    </MembershipContext.Provider>
+                  </AccountsContext.Provider>
+                </ApiContext.Provider>
+              </MockKeyringProvider>
+            </MockQueryNodeProviders>
+          </ModalContext.Provider>
+        </MemoryRouter>
+      )
+    })
   }
 })


### PR DESCRIPTION
#3319

~It looks like non-rivalrous locked funds are not included in the transferable balance (`DeriveBalancesAll[DeriveBalancesAll]` in polkadotjs):~
The same fund can be staked under multiple locks at the same time:
![Screenshot from 2022-07-28 15-44-03](https://user-images.githubusercontent.com/6571453/181621126-3a560207-98f7-4920-afc1-75d46aeeae5f.png)

~Although voting is the only non-rivalrous lock where the stake needs to be set manually, I also fixed the validation on announce  candidacy, and apply for role.~

➕ improved `useBalance` a bit because it was making the API unavailable for some length of time. That said I thought that we had taken care of that already... did we revert this change before for some reason ?
