### PR TITLE
⏳ Wait for `useMyBalances` to use balances

### DIFF
--- a/packages/ui/src/accounts/hooks/useBalance.ts
+++ b/packages/ui/src/accounts/hooks/useBalance.ts
@@ -19,9 +19,9 @@ export const useBalance = (address: Address = ''): Balances | null => {
     [address, myBalances, connectionState]
   )
 
-  if (balances === undefined) {
-    return null
+  if (myBalances) {
+    return myBalances
   }
 
-  return toBalances(balances)
+  return balances ? toBalances(balances) : null
 }

--- a/packages/ui/src/accounts/hooks/useBalance.ts
+++ b/packages/ui/src/accounts/hooks/useBalance.ts
@@ -2,13 +2,22 @@ import { toBalances } from '@/accounts/model/toBalances'
 import { useApi } from '@/common/hooks/useApi'
 import { useObservable } from '@/common/hooks/useObservable'
 import { Address } from '@/common/types'
+import { isDefined } from '@/common/utils'
 
 import { Balances } from '../types'
 
-export const useBalance = (address?: Address): Balances | null => {
+import { useMyBalances } from './useMyBalances'
+
+export const useBalance = (address: Address = ''): Balances | null => {
   const { api, connectionState } = useApi()
 
-  const balances = useObservable(address ? api?.derive.balances.all(address) : undefined, [connectionState, address])
+  const allMyBalances = useMyBalances()
+  const myBalances = allMyBalances?.[address]
+
+  const balances = useObservable(
+    isDefined(allMyBalances) && address && !myBalances ? api?.derive.balances.all(address) : undefined,
+    [address, myBalances, connectionState]
+  )
 
   if (balances === undefined) {
     return null

--- a/packages/ui/src/accounts/hooks/useBalance.ts
+++ b/packages/ui/src/accounts/hooks/useBalance.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { toBalances } from '@/accounts/model/toBalances'
 import { useApi } from '@/common/hooks/useApi'
 import { useObservable } from '@/common/hooks/useObservable'
@@ -14,10 +16,11 @@ export const useBalance = (address: Address = ''): Balances | null => {
   const allMyBalances = useMyBalances()
   const myBalances = allMyBalances?.[address]
 
-  const balances = useObservable(
-    isDefined(allMyBalances) && address && !myBalances ? api?.derive.balances.all(address) : undefined,
-    [address, myBalances, connectionState]
+  const balancesObs = useMemo(
+    () => (isDefined(allMyBalances) && address && !myBalances ? api?.derive.balances.all(address) : undefined),
+    [address, myBalances]
   )
+  const balances = useObservable(balancesObs, [balancesObs, connectionState])
 
   if (myBalances) {
     return myBalances

--- a/packages/ui/src/accounts/hooks/useHasRequiredStake.ts
+++ b/packages/ui/src/accounts/hooks/useHasRequiredStake.ts
@@ -9,6 +9,14 @@ import { Comparator } from '@/common/model/Comparator'
 export const useHasRequiredStake = (stake: BN, lock: LockType) => {
   const balances = useMyBalances()
 
+  if (!balances) {
+    return {
+      hasRequiredStake: undefined,
+      accountsWithCompatibleLocks: null,
+      accountsWithTransferableBalance: null,
+    }
+  }
+
   const compatibleAccounts = Object.entries(balances).filter(
     ([, balances]) => !areLocksConflicting(lock, balances.locks)
   )

--- a/packages/ui/src/accounts/hooks/useMyTotalBalances.ts
+++ b/packages/ui/src/accounts/hooks/useMyTotalBalances.ts
@@ -4,7 +4,7 @@ import { Balances } from '../types'
 
 import { useMyBalances } from './useMyBalances'
 
-export const zeroBalance = () => ({
+export const zeroBalance = {
   recoverable: BN_ZERO,
   locked: BN_ZERO,
   transferable: BN_ZERO,
@@ -15,7 +15,7 @@ export const zeroBalance = () => ({
   vestedBalance: BN_ZERO,
   vesting: [],
   vestingLocked: BN_ZERO,
-})
+}
 
 const addBalances = (a: Balances, b: Balances) => ({
   recoverable: a.recoverable.add(b.recoverable),
@@ -33,5 +33,5 @@ const addBalances = (a: Balances, b: Balances) => ({
 export function useMyTotalBalances(): Balances {
   const balances = useMyBalances()
 
-  return [...Object.values(balances ?? [])].reduce(addBalances, zeroBalance())
+  return Object.values(balances ?? {}).reduce(addBalances, zeroBalance)
 }

--- a/packages/ui/src/accounts/hooks/useMyTotalBalances.ts
+++ b/packages/ui/src/accounts/hooks/useMyTotalBalances.ts
@@ -33,5 +33,5 @@ const addBalances = (a: Balances, b: Balances) => ({
 export function useMyTotalBalances(): Balances {
   const balances = useMyBalances()
 
-  return [...Object.values(balances)].reduce(addBalances, zeroBalance())
+  return [...Object.values(balances ?? [])].reduce(addBalances, zeroBalance())
 }

--- a/packages/ui/src/accounts/hooks/useStakingAccountsLocks.ts
+++ b/packages/ui/src/accounts/hooks/useStakingAccountsLocks.ts
@@ -31,11 +31,10 @@ export const useStakingAccountsLocks = ({
   const accountsWithLocks = allAccounts.map((account) => {
     const optionLocks: OptionLock[] = []
     const accountAddress = account.address
-    const balance = balances[accountAddress]
+    const accountBalances = balances?.[accountAddress]
 
     const boundMembershipId = getMemberIdByBoundAccountAddress(accountAddress)
-
-    if (!balance.transferable.gte(requiredStake) && filterByBalance) {
+    if (accountBalances && accountBalances.total?.lt(requiredStake) && filterByBalance) {
       optionLocks.push('insufficientFunds')
     }
 
@@ -43,7 +42,7 @@ export const useStakingAccountsLocks = ({
       optionLocks.push('boundMembership')
     }
 
-    if (areLocksConflicting(lockType, balance.locks)) {
+    if (accountBalances && areLocksConflicting(lockType, accountBalances.locks)) {
       if (isRecoverable(lockType, recoveryConditions)) {
         optionLocks.push('recoverableLock')
       } else {

--- a/packages/ui/src/accounts/modals/MoveFoundsModal/MoveFundsModal.tsx
+++ b/packages/ui/src/accounts/modals/MoveFoundsModal/MoveFundsModal.tsx
@@ -41,11 +41,11 @@ export const MoveFundsModal = () => {
   const balances = useMyBalances()
 
   const allAccounts = useStakingAccountsLocks({ requiredStake, lockType: lock, filterByBalance: false })
-  const accountsWithTransferableBalance = Object.entries(balances).filter(([, balances]) =>
+  const accountsWithTransferableBalance = Object.values(balances ?? []).filter((balances) =>
     balances.transferable.gt(BN_ZERO)
   )
   const transferableTotal = accountsWithTransferableBalance.reduce(
-    (sum, [, { transferable }]) => sum.add(transferable),
+    (sum, { transferable }) => sum.add(transferable),
     BN_ZERO
   )
   const insufficientBalances = transferableTotal.lt(requiredStake)

--- a/packages/ui/src/accounts/modals/TransferModal/TransferFormModal.tsx
+++ b/packages/ui/src/accounts/modals/TransferModal/TransferFormModal.tsx
@@ -63,11 +63,11 @@ export function TransferFormModal({ from, to, onClose, onAccept, title, maxValue
   const [sender, setSender] = useState<Account | undefined>(from)
   const balances = useMyBalances()
   const filterSender = useCallback(
-    (account: Account) => account.address !== recipient?.address && balances[account.address]?.transferable.gt(BN_ZERO),
+    ({ address }: Account) => address !== recipient?.address && !!balances?.[address]?.transferable.gt(BN_ZERO),
     [recipient, balances]
   )
   const schema = useMemo(
-    () => schemaFactory(maxValue, minValue, balances[sender?.address as string]?.transferable),
+    () => schemaFactory(maxValue, minValue, balances?.[sender?.address as string]?.transferable),
     [maxValue, minValue, balances, sender]
   )
 
@@ -78,7 +78,7 @@ export function TransferFormModal({ from, to, onClose, onAccept, title, maxValue
   } = useForm<TransferTokensFormField>({ amount: initialValue }, schema)
   const { isValid, errors } = validation
 
-  const transferableBalance = balances[sender?.address as string]?.transferable ?? BN_ZERO
+  const transferableBalance = balances?.[sender?.address as string]?.transferable ?? BN_ZERO
   const filterRecipient = useCallback(filterAccount(sender), [sender])
   const getIconType = () => (!from ? (!to ? 'transfer' : 'receive') : 'send')
 

--- a/packages/ui/src/accounts/model/filterAccounts.ts
+++ b/packages/ui/src/accounts/model/filterAccounts.ts
@@ -2,7 +2,11 @@ import BN from 'bn.js'
 
 import { Account, AddressToBalanceMap } from '../types'
 
-export const filterAccounts = (allAccounts: Account[], isDisplayAll: boolean, balances: AddressToBalanceMap) =>
-  isDisplayAll
+export const filterAccounts = (
+  allAccounts: Account[],
+  isDisplayAll: boolean,
+  balances: AddressToBalanceMap | undefined
+) =>
+  isDisplayAll || !balances
     ? allAccounts
-    : allAccounts.filter(({ address }) => balances[address] && balances[address].transferable.gt(new BN(0)))
+    : allAccounts.filter(({ address }) => balances[address]?.transferable.gt(new BN(0)))

--- a/packages/ui/src/accounts/model/sortAccounts.ts
+++ b/packages/ui/src/accounts/model/sortAccounts.ts
@@ -6,10 +6,17 @@ import { BalanceComparator } from './BalanceComparator'
 
 export type SortKey = keyof Omit<Balances, 'locks' | 'vesting'> | 'name'
 
-export function sortAccounts(accounts: Account[], balanceMap: AddressToBalanceMap, key: SortKey, isDescending = false) {
+export function sortAccounts(
+  accounts: Account[],
+  balanceMap: AddressToBalanceMap | undefined,
+  key: SortKey,
+  isDescending = false
+) {
   return key === 'name'
     ? [...accounts].sort(Comparator<Account>(isDescending, key).string)
-    : [...accounts].sort(BalanceComparator(balanceMap, key, isDescending))
+    : balanceMap
+    ? [...accounts].sort(BalanceComparator(balanceMap, key, isDescending))
+    : accounts
 }
 
 export function setOrder(

--- a/packages/ui/src/accounts/providers/balances/context.tsx
+++ b/packages/ui/src/accounts/providers/balances/context.tsx
@@ -2,4 +2,4 @@ import { createContext } from 'react'
 
 import { AddressToBalanceMap } from '@/accounts/types'
 
-export const BalancesContext = createContext<AddressToBalanceMap>({})
+export const BalancesContext = createContext<AddressToBalanceMap | undefined>(undefined)

--- a/packages/ui/src/accounts/providers/balances/provider.tsx
+++ b/packages/ui/src/accounts/providers/balances/provider.tsx
@@ -15,7 +15,7 @@ interface Props {
   children: ReactNode
 }
 export const BalancesContextProvider = (props: Props) => {
-  const { allAccounts } = useMyAccounts()
+  const { allAccounts, isLoading } = useMyAccounts()
   const { isConnected, api } = useApi()
 
   const addresses = allAccounts.map((account) => account.address)
@@ -23,16 +23,15 @@ export const BalancesContextProvider = (props: Props) => {
 
   const result = useObservable(combineLatest(balancesObs), [isConnected, JSON.stringify(addresses)])
 
-  const balances = useMemo(
-    () =>
-      (result ?? []).reduce((acc, balance, index) => {
+  const balances = useMemo(() => {
+    if (!isLoading && result)
+      return result.reduce((acc, balance, index) => {
         return {
           ...{ [addresses[index]]: balance },
           ...acc,
         }
-      }, {} as AddressToBalanceMap),
-    [result]
-  )
+      }, {} as AddressToBalanceMap)
+  }, [result])
 
   return <BalancesContext.Provider value={balances}>{props.children}</BalancesContext.Provider>
 }

--- a/packages/ui/src/accounts/providers/balances/provider.tsx
+++ b/packages/ui/src/accounts/providers/balances/provider.tsx
@@ -22,7 +22,7 @@ export const BalancesContextProvider = (props: Props) => {
 
   const balancesObs = useMemo(
     () => (api ? addresses.map((address) => api.derive.balances.all(address).pipe(map(toBalances))) : []),
-    [api, JSON.stringify(addresses)]
+    [!api, JSON.stringify(addresses)]
   )
   const result = useObservable(combineLatest(balancesObs), [balancesObs])
 

--- a/packages/ui/src/accounts/providers/balances/provider.tsx
+++ b/packages/ui/src/accounts/providers/balances/provider.tsx
@@ -16,12 +16,15 @@ interface Props {
 }
 export const BalancesContextProvider = (props: Props) => {
   const { allAccounts, isLoading } = useMyAccounts()
-  const { isConnected, api } = useApi()
+  const { api } = useApi()
 
   const addresses = allAccounts.map((account) => account.address)
-  const balancesObs = api ? addresses.map((address) => api.derive.balances.all(address).pipe(map(toBalances))) : []
 
-  const result = useObservable(combineLatest(balancesObs), [isConnected, JSON.stringify(addresses)])
+  const balancesObs = useMemo(
+    () => (api ? addresses.map((address) => api.derive.balances.all(address).pipe(map(toBalances))) : []),
+    [api, JSON.stringify(addresses)]
+  )
+  const result = useObservable(combineLatest(balancesObs), [balancesObs])
 
   const balances = useMemo(() => {
     if (!isLoading && result)

--- a/packages/ui/src/bounty/modals/AuthorizeTransactionModal/AuthorizeTransactionModal.tsx
+++ b/packages/ui/src/bounty/modals/AuthorizeTransactionModal/AuthorizeTransactionModal.tsx
@@ -52,9 +52,9 @@ export const AuthorizeTransactionModal = ({
 
   useEffect(() => {
     if (controllerAccount && paymentInfo?.partialFee) {
-      setHasFunds(balances[controllerAccount.address]?.transferable.gte(paymentInfo.partialFee))
+      setHasFunds(!!balances?.[controllerAccount.address]?.transferable.gte(paymentInfo.partialFee))
     }
-  }, [controllerAccount, paymentInfo?.partialFee])
+  }, [balances, controllerAccount, paymentInfo?.partialFee])
 
   return (
     <TransactionModal onClose={onClose} service={service} useMultiTransaction={useMultiTransaction}>

--- a/packages/ui/src/bounty/modals/CancelBountyModal/components/AuthorizationModal.tsx
+++ b/packages/ui/src/bounty/modals/CancelBountyModal/components/AuthorizationModal.tsx
@@ -44,24 +44,22 @@ export const AuthorizationModal = ({ onClose, creator, bountyId, service }: Prop
 
   const accountsWithValidAmount = useMemo(
     () =>
-      Object.entries(balances).map(([address, balance]) => {
-        if (balance.transferable.gte(paymentInfo?.partialFee || BN_ZERO)) {
-          return address
-        }
-      }),
+      Object.entries(balances ?? []).flatMap(([address, balance]) =>
+        balance.transferable.gte(paymentInfo?.partialFee || BN_ZERO) ? address : []
+      ),
     [balances, paymentInfo?.partialFee]
   )
 
   const accountsFilter = useCallback(
-    (acc: Account) => accountsWithValidAmount.includes(acc.address),
+    ({ address }: Account) => accountsWithValidAmount.includes(address),
     [accountsWithValidAmount.length]
   )
 
   useEffect(() => {
     if (selectedAccount && paymentInfo?.partialFee) {
-      setHasFunds(balances[selectedAccount.address].transferable.gte(paymentInfo.partialFee))
+      setHasFunds(!!balances?.[selectedAccount.address]?.transferable.gte(paymentInfo.partialFee))
     }
-  }, [selectedAccount, paymentInfo?.partialFee])
+  }, [balances, selectedAccount, paymentInfo?.partialFee])
 
   return (
     <Modal onClose={onClose} modalSize="l">

--- a/packages/ui/src/common/modals/OnBoardingModal/components/SelectAccountStep.tsx
+++ b/packages/ui/src/common/modals/OnBoardingModal/components/SelectAccountStep.tsx
@@ -1,3 +1,4 @@
+import { BN_ZERO } from '@polkadot/util'
 import { getWalletBySource } from 'injectweb3-connect'
 import React, { useState } from 'react'
 import styled from 'styled-components'
@@ -50,7 +51,7 @@ export const SelectAccountStep = ({ onAccountSelect }: Props) => {
               <ListItem onClick={() => setSelectedAccountAddress(account.address)} key={account.address} borderless>
                 <ConnectAccountItem
                   account={account}
-                  totalBalance={balances[account.address]?.total}
+                  totalBalance={balances?.[account.address]?.total ?? BN_ZERO}
                   selected={account.address === selectedAccountAddress}
                 />
               </ListItem>

--- a/packages/ui/src/council/modals/AnnounceCandidacy/AnnounceCandidacyModal.tsx
+++ b/packages/ui/src/council/modals/AnnounceCandidacy/AnnounceCandidacyModal.tsx
@@ -20,6 +20,7 @@ import { useModal } from '@/common/hooks/useModal'
 import { isLastStepActive } from '@/common/modals/utils'
 import { metadataToBytes } from '@/common/model/JoystreamNode'
 import { getSteps } from '@/common/model/machines/getSteps'
+import { isDefined } from '@/common/utils'
 import { enhancedGetErrorMessage, enhancedHasError, useYupValidationResolver } from '@/common/utils/validation'
 import { useCouncilConstants } from '@/council/hooks/useCouncilConstants'
 import { AnnounceCandidacyConstantsWrapper } from '@/council/modals/AnnounceCandidacy/components/AnnounceCandidacyConstantsWrapper'
@@ -99,7 +100,7 @@ export const AnnounceCandidacyModal = () => {
       stakeLock: 'Council Candidate',
       balances: balance,
       minStake: constants?.election.minCandidacyStake as BN,
-      controllerAccountBalance: balances[activeMember?.controllerAccount ?? '']?.transferable,
+      controllerAccountBalance: balances?.[activeMember?.controllerAccount ?? '']?.transferable ?? BN_ZERO,
     } as Conditions,
     mode: 'onChange',
     defaultValues: getAnnounceCandidacyFormInitialState(constants?.election.minCandidacyStake ?? BN_ZERO),
@@ -191,7 +192,7 @@ export const AnnounceCandidacyModal = () => {
         })
       }
 
-      if (feeInfo && Object.keys(balances).length) {
+      if (feeInfo && isDefined(hasRequiredStake)) {
         const areFundsSufficient = feeInfo.canAfford && hasRequiredStake
         send(areFundsSufficient ? 'NEXT' : 'FAIL')
       }
@@ -217,7 +218,7 @@ export const AnnounceCandidacyModal = () => {
       // wrong account
       return feeInfo?.canAfford ? send(stakingStatus === 'free' ? 'REQUIRES_STAKING_CANDIDATE' : 'BOUND') : send('FAIL')
     }
-  }, [state, activeMember?.id, JSON.stringify(feeInfo), hasRequiredStake, stakingStatus, Object.keys(balances).length])
+  }, [state, activeMember?.id, JSON.stringify(feeInfo), hasRequiredStake, stakingStatus])
 
   if (!api || !activeMember || !transaction || !feeInfo) {
     return null

--- a/packages/ui/src/council/modals/AnnounceCandidacy/components/StakeStep.tsx
+++ b/packages/ui/src/council/modals/AnnounceCandidacy/components/StakeStep.tsx
@@ -24,9 +24,10 @@ export const StakeStep = ({ candidacyMember, minStake, errorChecker, errorMessag
   const [stake] = form.watch(['staking.account', 'staking.amount'])
   const balances = useMyBalances()
 
-  const isSomeBalanceGteStake = useMemo(() => {
-    return Object.entries(balances).some(([, balance]) => balance.transferable.gte(stake ?? minStake))
-  }, [stake?.toString(), JSON.stringify(balances)])
+  const isSomeBalanceGteStake = useMemo(
+    () => Object.values(balances ?? []).some(({ transferable }) => transferable.gte(stake ?? minStake)),
+    [stake?.toString(), JSON.stringify(balances)]
+  )
 
   return (
     <RowGapBlock gap={24}>

--- a/packages/ui/src/council/modals/VoteForCouncil/VoteForCouncilModal.tsx
+++ b/packages/ui/src/council/modals/VoteForCouncil/VoteForCouncilModal.tsx
@@ -2,13 +2,13 @@ import { useMachine } from '@xstate/react'
 import React, { useEffect } from 'react'
 
 import { useHasRequiredStake } from '@/accounts/hooks/useHasRequiredStake'
-import { useMyBalances } from '@/accounts/hooks/useMyBalances'
 import { useTransactionFee } from '@/accounts/hooks/useTransactionFee'
 import { MoveFundsModalCall } from '@/accounts/modals/MoveFoundsModal'
 import { FailureModal } from '@/common/components/FailureModal'
 import { BN_ZERO } from '@/common/constants'
 import { useApi } from '@/common/hooks/useApi'
 import { useModal } from '@/common/hooks/useModal'
+import { isDefined } from '@/common/utils'
 import { useCouncilConstants } from '@/council/hooks/useCouncilConstants'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 import { SwitchMemberModalCall } from '@/memberships/modals/SwitchMemberModal'
@@ -26,7 +26,6 @@ export const VoteForCouncilModal = () => {
   const { api } = useApi()
 
   const { active: activeMember } = useMyMemberships()
-  const balances = useMyBalances()
 
   const constants = useCouncilConstants()
   const minStake = constants?.election.minVoteStake
@@ -51,12 +50,12 @@ export const VoteForCouncilModal = () => {
           },
         })
       }
-      if (feeInfo && Object.keys(balances).length) {
+      if (feeInfo && isDefined(hasRequiredStake)) {
         const areFundsSufficient = feeInfo.canAfford && hasRequiredStake
         send(areFundsSufficient ? 'PASS' : 'FAIL')
       }
     }
-  }, [state.value, activeMember?.id, hasRequiredStake, feeInfo?.canAfford, Object.keys(balances).length])
+  }, [state.value, activeMember?.id, hasRequiredStake, feeInfo?.canAfford])
 
   if (state.matches('success')) {
     return <VoteForCouncilSuccessModal onClose={hideModal} candidateId={modalData.id} />

--- a/packages/ui/src/memberships/modals/BuyMembershipModal/BuyMembershipSignModal.tsx
+++ b/packages/ui/src/memberships/modals/BuyMembershipModal/BuyMembershipSignModal.tsx
@@ -1,7 +1,7 @@
 import { SubmittableExtrinsic } from '@polkadot/api/types'
 import { BalanceOf } from '@polkadot/types/interfaces/runtime'
 import { ISubmittableResult } from '@polkadot/types/types'
-import React, { useEffect, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { ActorRef } from 'xstate'
 
 import { SelectAccount, SelectedAccount } from '@/accounts/components/SelectAccount'
@@ -47,17 +47,15 @@ export const BuyMembershipSignModal = ({
     signer: fromAddress,
     service,
   })
-  const [hasFunds, setHasFunds] = useState(true)
   const balance = useBalance(fromAddress)
   const validationInfo = balance?.transferable && paymentInfo?.partialFee && membershipPrice
 
-  useEffect(() => {
+  const hasFunds = useMemo(() => {
     if (validationInfo) {
       const requiredBalance = paymentInfo.partialFee.add(membershipPrice)
-      const hasFunds = balance.transferable.gte(requiredBalance)
-      setHasFunds(hasFunds)
+      return balance.transferable.gte(requiredBalance)
     }
-  }, [fromAddress, balance])
+  }, [fromAddress, !balance, !validationInfo])
 
   const signDisabled = !isReady || !hasFunds || !validationInfo
 

--- a/packages/ui/test/_mocks/transactions.ts
+++ b/packages/ui/test/_mocks/transactions.ts
@@ -297,4 +297,9 @@ export const stubAccounts = (allAccounts: Account[], myAccounts: Partial<UseAcco
     hasAccounts,
     ...myAccounts,
   })
+
+  const balance = mockedBalances()
+  if (balance) {
+    mockedMyBalances.mockReturnValue(Object.fromEntries(allAccounts.map(({ address }) => [address, balance])))
+  }
 }

--- a/packages/ui/test/_mocks/transactions.ts
+++ b/packages/ui/test/_mocks/transactions.ts
@@ -180,11 +180,8 @@ export const stubApi = () => {
   return api
 }
 
-export const stubDefaultBalances = (api?: UseApi) => {
-  stubBalances(api, {
-    available: 1000,
-    locked: 0,
-  })
+export const stubDefaultBalances = () => {
+  stubBalances({ available: 1000, locked: 0 })
 }
 
 export const stubCouncilConstants = (api: UseApi, constants?: { minStake: number }) => {
@@ -256,7 +253,7 @@ export const stubCouncilAndReferendum = (
 
 type Balances = { available?: number; locked?: number; lockId?: LockType }
 
-export const stubBalances = (api: UseApi | undefined, { available, lockId, locked }: Balances) => {
+export const stubBalances = ({ available, lockId, locked }: Balances) => {
   const availableBalance = new BN(available ?? 0)
   const lockedBalance = new BN(locked ?? 0)
 

--- a/packages/ui/test/_mocks/transactions.ts
+++ b/packages/ui/test/_mocks/transactions.ts
@@ -12,7 +12,9 @@ import { ExtractTuple } from '@/common/model/JoystreamNode'
 import { UseApi } from '@/common/providers/api/provider'
 import { proposalDetails } from '@/proposals/model/proposalDetails'
 
-import { createBalanceLock, createRuntimeDispatchInfo } from './chainTypes'
+import { mockedMyBalances } from '../setup'
+
+import { createRuntimeDispatchInfo } from './chainTypes'
 
 const createSuccessEvents = (data: any[], section: string, method: string) => [
   {
@@ -256,30 +258,16 @@ export const stubBalances = (api: UseApi, { available, lockId, locked }: Balance
   const availableBalance = new BN(available ?? 0)
   const lockedBalance = new BN(locked ?? 0)
 
-  set(api, 'api.derive.balances.all', () =>
-    from([
-      {
-        availableBalance: createType('Balance', availableBalance),
-        lockedBalance: createType('Balance', lockedBalance),
-        accountId: createType('AccountId', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'),
-        accountNonce: createType('Index', 1),
-        freeBalance: createType('Balance', availableBalance.add(lockedBalance)),
-        frozenFee: new BN(0),
-        frozenMisc: new BN(0),
-        isVesting: false,
-        lockedBreakdown: lockedBalance.eq(BN_ZERO)
-          ? []
-          : [createBalanceLock(locked!, lockId ?? 'Bound Staking Account')],
-        reservedBalance: new BN(0),
-        vestedBalance: new BN(0),
-        vestedClaimable: new BN(0),
-        vestingEndBlock: createType('BlockNumber', 1234),
-        vestingLocked: new BN(0),
-        vestingPerBlock: new BN(0),
-        vestingTotal: new BN(0),
-        votingBalance: new BN(0),
-        vesting: [],
-      },
-    ])
-  )
+  mockedMyBalances.mockReturnValue({
+    total: availableBalance.add(lockedBalance),
+    locked: lockedBalance,
+    recoverable: BN_ZERO,
+    transferable: availableBalance,
+    locks: lockedBalance.isZero() ? [] : [{ amount: lockedBalance, type: lockId ?? 'Bound Staking Account' }],
+    vestedBalance: BN_ZERO,
+    vestedClaimable: BN_ZERO,
+    vestingLocked: BN_ZERO,
+    vestingTotal: BN_ZERO,
+    vesting: [],
+  })
 }

--- a/packages/ui/test/_mocks/transactions.ts
+++ b/packages/ui/test/_mocks/transactions.ts
@@ -6,6 +6,7 @@ import { set } from 'lodash'
 import { from, of, asyncScheduler, scheduled, Observable } from 'rxjs'
 
 import { toBalances } from '@/accounts/model/toBalances'
+import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { Account, LockType } from '@/accounts/types'
 import { Api } from '@/api/types'
 import { BN_ZERO } from '@/common/constants'
@@ -288,7 +289,12 @@ export const stubBalances = (api: UseApi | undefined, { available, lockId, locke
   )
 }
 
-export const stubAccounts = (allAccounts: Account[], isLoading = false) => {
+export const stubAccounts = (allAccounts: Account[], myAccounts: Partial<UseAccounts> = {}) => {
   const hasAccounts = allAccounts.length > 0
-  mockedUseMyAccounts.mockReturnValue({ allAccounts, hasAccounts, isLoading })
+  mockedUseMyAccounts.mockReturnValue({
+    isLoading: false,
+    allAccounts,
+    hasAccounts,
+    ...myAccounts,
+  })
 }

--- a/packages/ui/test/accounts/components/MyAccounts.test.tsx
+++ b/packages/ui/test/accounts/components/MyAccounts.test.tsx
@@ -35,7 +35,7 @@ describe('UI: Accounts list', () => {
 
   describe('with empty keyring', () => {
     it('Shows loading screen', async () => {
-      stubAccounts([], true)
+      stubAccounts([], { isLoading: true })
       const profile = render(
         <KeyringContext.Provider value={new Keyring()}>
           <Accounts />

--- a/packages/ui/test/accounts/components/SelectAccount.test.tsx
+++ b/packages/ui/test/accounts/components/SelectAccount.test.tsx
@@ -9,27 +9,23 @@ import { KeyringContext } from '@/common/providers/keyring/context'
 import { mockKeyring } from '../../_mocks/keyring'
 import { MockApiProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
-
-jest.mock('../../../src/accounts/hooks/useMyAccounts', () => {
-  return {
-    useMyAccounts: () => ({
-      hasAccounts: false,
-      allAccounts: [
-        { name: 'Alice', address: '1' },
-        { name: 'Bob', address: '5222' },
-        { name: 'Dave', address: '3' },
-        { name: 'Eve', address: '4' },
-      ],
-    }),
-  }
-})
+import { stubAccounts } from '../../_mocks/transactions'
 
 describe('UI: SelectAccount component', () => {
   setupMockServer()
 
   jest.useFakeTimers()
 
-  beforeAll(cryptoWaitReady)
+  beforeAll(() => {
+    stubAccounts([
+      { name: 'Alice', address: '1' },
+      { name: 'Bob', address: '5222' },
+      { name: 'Dave', address: '3' },
+      { name: 'Eve', address: '4' },
+    ])
+
+    cryptoWaitReady()
+  })
 
   it('Displays component', () => {
     const { getByRole } = renderComponent()
@@ -113,7 +109,6 @@ describe('UI: SelectAccount component', () => {
       act(() => {
         fireEvent.change(textBox, { target: { value: '5CStixio6DdmhMJGtTpUVWtR2PvR7Kydc7RnECRYefFr5mKy' } })
         fireEvent.keyDown(textBox, { key: 'Enter', code: 'Enter' })
-        jest.runOnlyPendingTimers()
       })
       expect(screen.getByText('Unsaved account')).toBeDefined()
     })

--- a/packages/ui/test/accounts/components/UnknownAccountInfo.test.tsx
+++ b/packages/ui/test/accounts/components/UnknownAccountInfo.test.tsx
@@ -1,12 +1,12 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto'
 import { render, screen } from '@testing-library/react'
 import React from 'react'
-import { stubAccounts } from 'test/_mocks/transactions'
 
 import { UnknownAccountInfo } from '../../../src/accounts/components/UnknownAccountInfo'
 import { alice, bob } from '../../_mocks/keyring'
 import { MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
+import { stubAccounts } from '../../_mocks/transactions'
 
 describe('UI: UnknownAccountInfo component', () => {
   setupMockServer()

--- a/packages/ui/test/accounts/components/UnknownAccountInfo.test.tsx
+++ b/packages/ui/test/accounts/components/UnknownAccountInfo.test.tsx
@@ -1,25 +1,22 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto'
 import { render, screen } from '@testing-library/react'
 import React from 'react'
+import { stubAccounts } from 'test/_mocks/transactions'
 
 import { UnknownAccountInfo } from '../../../src/accounts/components/UnknownAccountInfo'
-import { AccountsContext } from '../../../src/accounts/providers/accounts/context'
 import { alice, bob } from '../../_mocks/keyring'
 import { MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 
 describe('UI: UnknownAccountInfo component', () => {
-  const useAccounts = {
-    isLoading: false,
-    hasAccounts: false,
-    allAccounts: [alice, bob],
-  }
-
   setupMockServer()
 
   jest.useFakeTimers()
 
-  beforeAll(cryptoWaitReady)
+  beforeAll(async () => {
+    stubAccounts([alice, bob])
+    await cryptoWaitReady()
+  })
 
   it('User account', () => {
     renderComponent(alice.address)
@@ -36,9 +33,7 @@ describe('UI: UnknownAccountInfo component', () => {
   function renderComponent(address: string) {
     return render(
       <MockQueryNodeProviders>
-        <AccountsContext.Provider value={useAccounts}>
-          <UnknownAccountInfo address={address} placeholderName="Root account" />
-        </AccountsContext.Provider>
+        <UnknownAccountInfo address={address} placeholderName="Root account" />
       </MockQueryNodeProviders>
     )
   }

--- a/packages/ui/test/accounts/hooks/useMyTotalBalances.test.tsx
+++ b/packages/ui/test/accounts/hooks/useMyTotalBalances.test.tsx
@@ -5,50 +5,34 @@ import BN from 'bn.js'
 import React, { ReactNode } from 'react'
 
 import { useMyTotalBalances } from '@/accounts/hooks/useMyTotalBalances'
-import { AccountsContext } from '@/accounts/providers/accounts/context'
 import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
-import { ApiContext } from '@/common/providers/api/context'
-import { UseApi } from '@/common/providers/api/provider'
 
 import { createBalance } from '../../_mocks/chainTypes'
 import { alice, aliceStash } from '../../_mocks/keyring'
 import { MockKeyringProvider } from '../../_mocks/providers'
-import { stubApi, stubBalances } from '../../_mocks/transactions'
-import { mockDefaultBalance } from '../../setup'
+import { stubAccounts, stubBalances } from '../../_mocks/transactions'
+import { mockedMyBalances, zeroBalance } from '../../setup'
 
 describe('useMyTotalBalances', () => {
-  let useApi: UseApi = stubApi()
-
   jest.useFakeTimers()
 
   beforeAll(async () => {
+    stubAccounts([alice, aliceStash])
     await cryptoWaitReady()
   })
 
-  beforeEach(() => {
-    stubBalances(useApi, { available: 100, locked: 10, lockId: 'Bound Staking Account' })
-  })
-
   it('Returns zero balances when API not ready', () => {
-    useApi = {
-      connectionState: 'connecting',
-      isConnected: false,
-      api: undefined,
-    }
+    mockedMyBalances.mockReturnValue(undefined)
+
     const { result } = renderUseTotalBalances()
 
     expect(result.current).toEqual({
-      ...mockDefaultBalance,
-      total: new BN(0),
-      transferable: new BN(0),
-      locked: new BN(0),
-      recoverable: new BN(0),
-      locks: [],
+      ...zeroBalance,
     })
   })
 
   it('Returns total balances', () => {
-    useApi.isConnected = true
+    stubBalances(undefined, { available: 100, locked: 10, lockId: 'Bound Staking Account' })
 
     const { result } = renderUseTotalBalances()
 
@@ -57,7 +41,7 @@ describe('useMyTotalBalances', () => {
     })
 
     expect(result.current).toEqual({
-      ...mockDefaultBalance,
+      ...zeroBalance,
       locked: new BN(20),
       locks: new Array(2).fill({
         amount: createBalance(10),
@@ -72,26 +56,7 @@ describe('useMyTotalBalances', () => {
   function renderUseTotalBalances() {
     const wrapper = ({ children }: { children: ReactNode }) => (
       <MockKeyringProvider>
-        <AccountsContext.Provider
-          value={{
-            isLoading: false,
-            allAccounts: [
-              {
-                address: alice.address,
-                name: 'Alice',
-              },
-              {
-                address: aliceStash.address,
-                name: 'AliceStash',
-              },
-            ],
-            hasAccounts: true,
-          }}
-        >
-          <ApiContext.Provider value={useApi}>
-            <BalancesContextProvider>{children}</BalancesContextProvider>
-          </ApiContext.Provider>
-        </AccountsContext.Provider>
+        <BalancesContextProvider>{children}</BalancesContextProvider>
       </MockKeyringProvider>
     )
     return renderHook(() => useMyTotalBalances(), { wrapper })

--- a/packages/ui/test/accounts/hooks/useMyTotalBalances.test.tsx
+++ b/packages/ui/test/accounts/hooks/useMyTotalBalances.test.tsx
@@ -31,7 +31,7 @@ describe('useMyTotalBalances', () => {
   })
 
   it('Returns total balances', () => {
-    stubBalances(undefined, { available: 100, locked: 10, lockId: 'Bound Staking Account' })
+    stubBalances({ available: 100, locked: 10, lockId: 'Bound Staking Account' })
 
     const { result } = renderUseTotalBalances()
 

--- a/packages/ui/test/accounts/hooks/useMyTotalBalances.test.tsx
+++ b/packages/ui/test/accounts/hooks/useMyTotalBalances.test.tsx
@@ -5,7 +5,6 @@ import BN from 'bn.js'
 import React, { ReactNode } from 'react'
 
 import { useMyTotalBalances } from '@/accounts/hooks/useMyTotalBalances'
-import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 
 import { createBalance } from '../../_mocks/chainTypes'
 import { alice, aliceStash } from '../../_mocks/keyring'
@@ -54,11 +53,7 @@ describe('useMyTotalBalances', () => {
   })
 
   function renderUseTotalBalances() {
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <MockKeyringProvider>
-        <BalancesContextProvider>{children}</BalancesContextProvider>
-      </MockKeyringProvider>
-    )
+    const wrapper = ({ children }: { children: ReactNode }) => <MockKeyringProvider>{children}</MockKeyringProvider>
     return renderHook(() => useMyTotalBalances(), { wrapper })
   }
 })

--- a/packages/ui/test/accounts/modal/RecoverBalanceModal.test.tsx
+++ b/packages/ui/test/accounts/modal/RecoverBalanceModal.test.tsx
@@ -5,8 +5,6 @@ import { set } from 'lodash'
 import React from 'react'
 
 import { RecoverBalanceModal, RecoverBalanceModalCall } from '@/accounts/modals/RecoverBalance'
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { createType } from '@/common/model/createType'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
@@ -20,6 +18,7 @@ import { getMember } from '../../_mocks/members'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import {
+  stubAccounts,
   stubApi,
   stubDefaultBalances,
   stubTransaction,
@@ -29,7 +28,6 @@ import {
 import { mockedTransactionFee } from '../../setup'
 
 describe('UI: RecoverBalanceModal', () => {
-  let useAccounts: UseAccounts
   const api = stubApi()
   const server = setupMockServer({ noCleanupAfterEach: true })
   let tx: any
@@ -53,16 +51,12 @@ describe('UI: RecoverBalanceModal', () => {
   }
 
   beforeEach(async () => {
+    stubAccounts([alice, bob])
     stubDefaultBalances(api)
     useMyMemberships.setActive(getMember('alice'))
     tx = stubTransaction(api, 'api.tx.council.releaseCandidacyStake')
     mockedTransactionFee.feeInfo = { transactionFee: new BN(100), canAfford: true }
     mockedTransactionFee.transaction = tx as any
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
     useModal = {
       hideModal: jest.fn(),
       showModal: jest.fn(),
@@ -148,11 +142,9 @@ describe('UI: RecoverBalanceModal', () => {
         <MockQueryNodeProviders>
           <MembershipContext.Provider value={useMyMemberships}>
             <ApiContext.Provider value={api}>
-              <AccountsContext.Provider value={useAccounts}>
-                <ModalContext.Provider value={useModal}>
-                  <RecoverBalanceModal />
-                </ModalContext.Provider>
-              </AccountsContext.Provider>
+              <ModalContext.Provider value={useModal}>
+                <RecoverBalanceModal />
+              </ModalContext.Provider>
             </ApiContext.Provider>
           </MembershipContext.Provider>
         </MockQueryNodeProviders>

--- a/packages/ui/test/accounts/modal/RecoverBalanceModal.test.tsx
+++ b/packages/ui/test/accounts/modal/RecoverBalanceModal.test.tsx
@@ -52,7 +52,7 @@ describe('UI: RecoverBalanceModal', () => {
 
   beforeEach(async () => {
     stubAccounts([alice, bob])
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     useMyMemberships.setActive(getMember('alice'))
     tx = stubTransaction(api, 'api.tx.council.releaseCandidacyStake')
     mockedTransactionFee.feeInfo = { transactionFee: new BN(100), canAfford: true }

--- a/packages/ui/test/accounts/modal/TransferModal.test.tsx
+++ b/packages/ui/test/accounts/modal/TransferModal.test.tsx
@@ -58,7 +58,7 @@ describe('UI: TransferModal', () => {
   })
 
   beforeEach(async () => {
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     transfer = stubTransaction(api, 'api.tx.balances.transfer')
   })
 

--- a/packages/ui/test/accounts/modal/TransferModal.test.tsx
+++ b/packages/ui/test/accounts/modal/TransferModal.test.tsx
@@ -6,8 +6,7 @@ import BN from 'bn.js'
 import React from 'react'
 
 import { TransferModal } from '@/accounts/modals/TransferModal'
-import { Account, Balances } from '@/accounts/types'
-import { BN_ZERO } from '@/common/constants'
+import { Account } from '@/accounts/types'
 import { createType } from '@/common/model/createType'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
@@ -18,30 +17,13 @@ import { alice, bob } from '../../_mocks/keyring'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import {
+  stubAccounts,
   stubApi,
   stubDefaultBalances,
   stubTransaction,
   stubTransactionFailure,
   stubTransactionSuccess,
 } from '../../_mocks/transactions'
-import { mockDefaultBalance } from '../../setup'
-
-const useMyAccounts: { hasAccounts: boolean; allAccounts: Account[] } = {
-  hasAccounts: true,
-  allAccounts: [],
-}
-
-const useMyBalances: { [k: string]: Balances } = {}
-
-jest.mock('@/accounts/hooks/useMyAccounts', () => {
-  return {
-    useMyAccounts: () => useMyAccounts,
-  }
-})
-
-jest.mock('@/accounts/hooks/useMyBalances', () => ({
-  useMyBalances: () => useMyBalances,
-}))
 
 interface ModalData {
   from?: Account
@@ -52,27 +34,11 @@ interface ModalData {
   transactionFactory?: (amount: BN) => SubmittableExtrinsic<'rxjs', ISubmittableResult>
 }
 
-const BN_BALANCE = new BN(1000)
-
 describe('UI: TransferModal', () => {
   beforeAll(async () => {
     await cryptoWaitReady()
     jest.spyOn(console, 'log').mockImplementation()
-    useMyAccounts.allAccounts.push(alice, bob)
-    useMyBalances[alice.address] = {
-      ...mockDefaultBalance,
-      total: BN_BALANCE,
-      locked: BN_ZERO,
-      recoverable: BN_BALANCE,
-      transferable: BN_BALANCE,
-    }
-    useMyBalances[bob.address] = {
-      ...mockDefaultBalance,
-      total: BN_BALANCE,
-      locked: BN_ZERO,
-      recoverable: BN_BALANCE,
-      transferable: BN_BALANCE,
-    }
+    stubAccounts([alice, bob])
   })
 
   afterAll(() => {

--- a/packages/ui/test/accounts/model/toBalances.test.ts
+++ b/packages/ui/test/accounts/model/toBalances.test.ts
@@ -5,12 +5,12 @@ import { toBalances } from '@/accounts/model/toBalances'
 import { Balances } from '@/accounts/types'
 
 import { createBalance, createBalanceLock, EMPTY_BALANCES } from '../../_mocks/chainTypes'
-import { mockDefaultBalance } from '../../setup'
+import { zeroBalance } from '../../setup'
 
 describe('toBalances', () => {
   it('Empty', () => {
     testBalances(EMPTY_BALANCES, {
-      ...mockDefaultBalance,
+      ...zeroBalance,
     })
   })
 
@@ -23,7 +23,7 @@ describe('toBalances', () => {
         votingBalance: createBalance(1234),
       },
       {
-        ...mockDefaultBalance,
+        ...zeroBalance,
         total: new BN(1234),
         transferable: createBalance(1234).toBn(),
       }
@@ -43,7 +43,7 @@ describe('toBalances', () => {
         votingBalance: createBalance(387),
       },
       {
-        ...mockDefaultBalance,
+        ...zeroBalance,
         locked: createBalance(200).toBn(),
         locks: [
           {
@@ -70,7 +70,7 @@ describe('toBalances', () => {
         votingBalance: createBalance(200),
       },
       {
-        ...mockDefaultBalance,
+        ...zeroBalance,
         locked: createBalance(200).toBn(),
         locks: [
           {
@@ -96,7 +96,7 @@ describe('toBalances', () => {
         votingBalance: createBalance(10_500),
       },
       {
-        ...mockDefaultBalance,
+        ...zeroBalance,
         locked: createBalance(10_000).toBn(),
         locks: [
           {

--- a/packages/ui/test/app/OnBoardingOverlay.test.tsx
+++ b/packages/ui/test/app/OnBoardingOverlay.test.tsx
@@ -1,8 +1,11 @@
 import { cleanup, render, screen } from '@testing-library/react'
+import { Wallet } from 'injectweb3-connect'
 import React from 'react'
 
 import { OnBoardingOverlay, onBoardingSteps } from '@/app/components/OnboardingOverlay/OnBoardingOverlay'
 import { UseOnBoarding } from '@/common/providers/onboarding/types'
+
+import { mockedUseMyAccounts } from '../setup'
 
 const mockOnBoarding: UseOnBoarding = {
   status: 'installPlugin',
@@ -12,14 +15,6 @@ const mockOnBoarding: UseOnBoarding = {
 
 jest.mock('@/common/hooks/useOnBoarding', () => ({
   useOnBoarding: () => mockOnBoarding,
-}))
-
-const mockMyAccounts: Record<string, unknown> = {
-  wallet: undefined,
-}
-
-jest.mock('@/accounts/hooks/useMyAccounts', () => ({
-  useMyAccounts: () => mockMyAccounts,
 }))
 
 describe('OnBoardingOverlay', () => {
@@ -45,7 +40,12 @@ describe('OnBoardingOverlay', () => {
     })
 
     it('After wallet is selected', () => {
-      mockMyAccounts.wallet = {}
+      mockedUseMyAccounts.mockReturnValue({
+        allAccounts: [],
+        hasAccounts: false,
+        isLoading: true,
+        wallet: {} as Wallet,
+      })
       renderComponent()
 
       expect(screen.queryByText('Connect Wallet')).not.toBeInTheDocument()

--- a/packages/ui/test/app/pages/MyProfile/MyAccounts.test.tsx
+++ b/packages/ui/test/app/pages/MyProfile/MyAccounts.test.tsx
@@ -5,8 +5,6 @@ import React from 'react'
 import { Route, Router, Switch } from 'react-router-dom'
 
 import { RecoverBalanceModalCall } from '@/accounts/modals/RecoverBalance'
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { GlobalModals } from '@/app/GlobalModals'
 import { MyAccounts } from '@/app/pages/Profile/MyAccounts'
@@ -23,7 +21,7 @@ import { alice, bob } from '../../../_mocks/keyring'
 import { MockQueryNodeProviders } from '../../../_mocks/providers'
 import { setupMockServer } from '../../../_mocks/server'
 import { MEMBER_ALICE_DATA } from '../../../_mocks/server/seeds'
-import { stubApi, stubBalances, stubDefaultBalances } from '../../../_mocks/transactions'
+import { stubAccounts, stubApi, stubBalances, stubDefaultBalances } from '../../../_mocks/transactions'
 
 const testStatisticItem = (header: HTMLElement, labelMatcher: RegExp, expected: RegExp) => {
   const label = within(header).getByText(labelMatcher)
@@ -32,7 +30,6 @@ const testStatisticItem = (header: HTMLElement, labelMatcher: RegExp, expected: 
 }
 
 describe('Page: MyAccounts', () => {
-  let useAccounts: UseAccounts
   const server = setupMockServer({ noCleanupAfterEach: true })
   const api = stubApi()
   const useMyMemberships: MyMemberships = {
@@ -54,11 +51,6 @@ describe('Page: MyAccounts', () => {
   })
 
   beforeEach(() => {
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
     useModal = {
       hideModal: jest.fn(),
       modal: null,
@@ -67,6 +59,7 @@ describe('Page: MyAccounts', () => {
     }
     useMyMemberships.members = []
 
+    stubAccounts([alice, bob])
     stubDefaultBalances(api)
   })
 
@@ -166,22 +159,20 @@ describe('Page: MyAccounts', () => {
 
     render(
       <Router history={history}>
-        <AccountsContext.Provider value={useAccounts}>
-          <ApiContext.Provider value={api}>
-            <BalancesContextProvider>
-              <ModalContext.Provider value={useModal}>
-                <MockQueryNodeProviders>
-                  <MembershipContext.Provider value={useMyMemberships}>
-                    <Switch>
-                      <Route path="/profile" component={MyAccounts} />
-                    </Switch>
-                    <GlobalModals />
-                  </MembershipContext.Provider>
-                </MockQueryNodeProviders>
-              </ModalContext.Provider>
-            </BalancesContextProvider>
-          </ApiContext.Provider>
-        </AccountsContext.Provider>
+        <ApiContext.Provider value={api}>
+          <BalancesContextProvider>
+            <ModalContext.Provider value={useModal}>
+              <MockQueryNodeProviders>
+                <MembershipContext.Provider value={useMyMemberships}>
+                  <Switch>
+                    <Route path="/profile" component={MyAccounts} />
+                  </Switch>
+                  <GlobalModals />
+                </MembershipContext.Provider>
+              </MockQueryNodeProviders>
+            </ModalContext.Provider>
+          </BalancesContextProvider>
+        </ApiContext.Provider>
       </Router>
     )
   }

--- a/packages/ui/test/app/pages/MyProfile/MyAccounts.test.tsx
+++ b/packages/ui/test/app/pages/MyProfile/MyAccounts.test.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 import { Route, Router, Switch } from 'react-router-dom'
 
 import { RecoverBalanceModalCall } from '@/accounts/modals/RecoverBalance'
-import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { GlobalModals } from '@/app/GlobalModals'
 import { MyAccounts } from '@/app/pages/Profile/MyAccounts'
 import { ApiContext } from '@/common/providers/api/context'
@@ -160,18 +159,16 @@ describe('Page: MyAccounts', () => {
     render(
       <Router history={history}>
         <ApiContext.Provider value={api}>
-          <BalancesContextProvider>
-            <ModalContext.Provider value={useModal}>
-              <MockQueryNodeProviders>
-                <MembershipContext.Provider value={useMyMemberships}>
-                  <Switch>
-                    <Route path="/profile" component={MyAccounts} />
-                  </Switch>
-                  <GlobalModals />
-                </MembershipContext.Provider>
-              </MockQueryNodeProviders>
-            </ModalContext.Provider>
-          </BalancesContextProvider>
+          <ModalContext.Provider value={useModal}>
+            <MockQueryNodeProviders>
+              <MembershipContext.Provider value={useMyMemberships}>
+                <Switch>
+                  <Route path="/profile" component={MyAccounts} />
+                </Switch>
+                <GlobalModals />
+              </MembershipContext.Provider>
+            </MockQueryNodeProviders>
+          </ModalContext.Provider>
         </ApiContext.Provider>
       </Router>
     )

--- a/packages/ui/test/app/pages/MyProfile/MyAccounts.test.tsx
+++ b/packages/ui/test/app/pages/MyProfile/MyAccounts.test.tsx
@@ -59,7 +59,7 @@ describe('Page: MyAccounts', () => {
     useMyMemberships.members = []
 
     stubAccounts([alice, bob])
-    stubDefaultBalances(api)
+    stubDefaultBalances()
   })
 
   it('Accounts List', async () => {
@@ -80,7 +80,7 @@ describe('Page: MyAccounts', () => {
   })
 
   it('Locked balance', () => {
-    stubBalances(api, { locked: 250, available: 10_000 })
+    stubBalances({ locked: 250, available: 10_000 })
 
     renderPage()
 
@@ -92,7 +92,7 @@ describe('Page: MyAccounts', () => {
   })
 
   it('Recoverable locked balance', () => {
-    stubBalances(api, { locked: 250, available: 10_000, lockId: 'Council Candidate' })
+    stubBalances({ locked: 250, available: 10_000, lockId: 'Council Candidate' })
 
     renderPage()
 
@@ -106,7 +106,7 @@ describe('Page: MyAccounts', () => {
 
   describe('Recover balance button', () => {
     it('Recoverable', async () => {
-      stubBalances(api, { locked: 250, available: 10_000, lockId: 'Council Candidate' })
+      stubBalances({ locked: 250, available: 10_000, lockId: 'Council Candidate' })
 
       renderPage()
 
@@ -117,7 +117,7 @@ describe('Page: MyAccounts', () => {
     })
 
     it('Opens modal', async () => {
-      stubBalances(api, { locked: 250, available: 10_000, lockId: 'Council Candidate' })
+      stubBalances({ locked: 250, available: 10_000, lockId: 'Council Candidate' })
 
       renderPage()
 
@@ -141,7 +141,7 @@ describe('Page: MyAccounts', () => {
     })
 
     it('Nonrecoverable', async () => {
-      stubBalances(api, { locked: 250, available: 10_000, lockId: 'Bound Staking Account' })
+      stubBalances({ locked: 250, available: 10_000, lockId: 'Bound Staking Account' })
 
       renderPage()
 

--- a/packages/ui/test/bounty/modals/AddBountyModal.test.tsx
+++ b/packages/ui/test/bounty/modals/AddBountyModal.test.tsx
@@ -4,9 +4,6 @@ import React from 'react'
 import { MemoryRouter } from 'react-router'
 import { interpret } from 'xstate'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
-import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { AddBountyModal } from '@/bounty/modals/AddBountyModal'
 import { addBountyMachine } from '@/bounty/modals/AddBountyModal/machine'
 import { CKEditorProps } from '@/common/components/CKEditor'
@@ -28,6 +25,7 @@ import { getMember } from '../../_mocks/members'
 import { MockApolloProvider, MockKeyringProvider } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import {
+  stubAccounts,
   stubApi,
   stubBountyConstants,
   stubDefaultBalances,
@@ -69,7 +67,6 @@ describe('UI: AddNewBountyModal', () => {
     },
   }
 
-  let useAccounts: UseAccounts
   let createTransaction: any
   let forumThreadTransaction: any
 
@@ -82,12 +79,7 @@ describe('UI: AddNewBountyModal', () => {
     seedForumCategories(server.server, [
       { parentId: null, status: { __typename: 'CategoryStatusActive' }, moderatorIds: [] },
     ])
-
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
+    stubAccounts([alice, bob])
   })
 
   beforeEach(async () => {
@@ -444,17 +436,13 @@ describe('UI: AddNewBountyModal', () => {
       <MemoryRouter>
         <ModalContext.Provider value={useModal}>
           <MockKeyringProvider>
-            <AccountsContext.Provider value={useAccounts}>
-              <ApiContext.Provider value={api}>
-                <BalancesContextProvider>
-                  <MembershipContext.Provider value={useMyMemberships}>
-                    <MockApolloProvider>
-                      <AddBountyModal />
-                    </MockApolloProvider>
-                  </MembershipContext.Provider>
-                </BalancesContextProvider>
-              </ApiContext.Provider>
-            </AccountsContext.Provider>
+            <ApiContext.Provider value={api}>
+              <MembershipContext.Provider value={useMyMemberships}>
+                <MockApolloProvider>
+                  <AddBountyModal />
+                </MockApolloProvider>
+              </MembershipContext.Provider>
+            </ApiContext.Provider>
           </MockKeyringProvider>
         </ModalContext.Provider>
       </MemoryRouter>

--- a/packages/ui/test/bounty/modals/AddBountyModal.test.tsx
+++ b/packages/ui/test/bounty/modals/AddBountyModal.test.tsx
@@ -94,7 +94,7 @@ describe('UI: AddNewBountyModal', () => {
     useMyMemberships.members = [getMember('alice'), getMember('bob')]
     useMyMemberships.setActive(getMember('alice'))
 
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     stubBountyConstants(api)
     createTransaction = stubTransaction(api, 'api.tx.bounty.createBounty', 100)
     forumThreadTransaction = stubTransaction(api, 'api.tx.forum.createThread', 100)

--- a/packages/ui/test/bounty/modals/AnnounceWorkEntryModal.test.tsx
+++ b/packages/ui/test/bounty/modals/AnnounceWorkEntryModal.test.tsx
@@ -3,8 +3,6 @@ import BN from 'bn.js'
 import React from 'react'
 
 import { MoveFundsModalCall } from '@/accounts/modals/MoveFoundsModal'
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { BalancesContext } from '@/accounts/providers/balances/context'
 import { AnnounceWorkEntryModal } from '@/bounty/modals/AnnounceWorkEntryModal'
 import { formatTokenValue } from '@/common/model/formatters'
 import { ApiContext } from '@/common/providers/api/context'
@@ -19,23 +17,18 @@ import { getButton } from '../../_helpers/getButton'
 import { alice, bob } from '../../_mocks/keyring'
 import { MockApolloProvider, MockKeyringProvider } from '../../_mocks/providers'
 import {
+  stubAccounts,
   stubApi,
+  stubBalances,
   stubBountyConstants,
   stubTransaction,
   stubTransactionFailure,
   stubTransactionSuccess,
 } from '../../_mocks/transactions'
-import { mockDefaultBalance, mockedTransactionFee } from '../../setup'
+import { mockedTransactionFee } from '../../setup'
 
 const [bountyMock] = bounties
 const bounty = { ...bountyMock, entrantStake: new BN(bountyMock.entrantStake) }
-const sufficientBalance = bounty.entrantStake.addn(1000)
-
-const defaultBalance = {
-  ...mockDefaultBalance,
-  total: sufficientBalance,
-  transferable: sufficientBalance,
-}
 
 describe('UI: AnnounceWorkEntryModal', () => {
   let renderResult: RenderResult
@@ -61,11 +54,6 @@ describe('UI: AnnounceWorkEntryModal', () => {
     },
   }
 
-  const useBalances = {
-    [getMember('bob').controllerAccount]: { ...defaultBalance },
-    [getMember('alice').controllerAccount]: defaultBalance,
-  }
-
   const useMembership = {
     isLoading: false,
     active: getMember('alice'),
@@ -77,11 +65,10 @@ describe('UI: AnnounceWorkEntryModal', () => {
     },
   }
 
-  const useAccounts = {
-    isLoading: false,
-    hasAccounts: true,
-    allAccounts: [bob, alice],
-  }
+  beforeAll(() => {
+    stubBalances({ available: +bountyMock.entrantStake + 1000 })
+    stubAccounts([alice, bob])
+  })
 
   beforeEach(() => {
     stubTransaction(api, 'api.tx.utility.batch', fee)
@@ -177,11 +164,7 @@ describe('UI: AnnounceWorkEntryModal', () => {
         <MockKeyringProvider>
           <ApiContext.Provider value={api}>
             <MembershipContext.Provider value={useMembership}>
-              <AccountsContext.Provider value={useAccounts}>
-                <BalancesContext.Provider value={useBalances}>
-                  <AnnounceWorkEntryModal />
-                </BalancesContext.Provider>
-              </AccountsContext.Provider>
+              <AnnounceWorkEntryModal />
             </MembershipContext.Provider>
           </ApiContext.Provider>
         </MockKeyringProvider>

--- a/packages/ui/test/bounty/modals/AuthorizeTransactionModal.test.tsx
+++ b/packages/ui/test/bounty/modals/AuthorizeTransactionModal.test.tsx
@@ -60,7 +60,7 @@ describe('UI: AuthorizeTransactionModal', () => {
   }
 
   beforeEach(() => {
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     renderModal()
   })
 

--- a/packages/ui/test/bounty/modals/BountyCancelModal.test.tsx
+++ b/packages/ui/test/bounty/modals/BountyCancelModal.test.tsx
@@ -1,10 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import BN from 'bn.js'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
-import { BalancesContext } from '@/accounts/providers/balances/context'
 import { BountyCancelModal } from '@/bounty/modals/CancelBountyModal'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
@@ -15,16 +11,16 @@ import { getMember } from '@/mocks/helpers'
 import { getButton } from '../../_helpers/getButton'
 import { alice, bob } from '../../_mocks/keyring'
 import { MockApolloProvider, MockKeyringProvider } from '../../_mocks/providers'
-import { stubApi, stubTransaction, stubTransactionFailure, stubTransactionSuccess } from '../../_mocks/transactions'
-import { mockDefaultBalance } from '../../setup'
+import {
+  stubAccounts,
+  stubApi,
+  stubTransaction,
+  stubTransactionFailure,
+  stubTransactionSuccess,
+} from '../../_mocks/transactions'
 
 const bounty = bounties[0]
 const creator = getMember('alice')
-
-const defaultBalance = {
-  ...mockDefaultBalance,
-  transferable: new BN(1000),
-}
 
 describe('UI: BountyCancelModal', () => {
   const api = stubApi()
@@ -39,22 +35,11 @@ describe('UI: BountyCancelModal', () => {
     },
   }
 
-  const useBalances = {
-    [getMember('bob').controllerAccount]: { ...defaultBalance },
-    [getMember('alice').controllerAccount]: defaultBalance,
-  }
-
   let transaction: any
-  let useAccounts: UseAccounts
 
   beforeAll(() => {
     transaction = stubTransaction(api, 'api.tx.bounty.cancelBounty', 100)
-
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [bob, alice],
-    }
+    stubAccounts([alice, bob])
   })
 
   it('Renders', async () => {
@@ -147,11 +132,7 @@ describe('UI: BountyCancelModal', () => {
         <ModalContext.Provider value={useModal}>
           <MockKeyringProvider>
             <ApiContext.Provider value={api}>
-              <AccountsContext.Provider value={useAccounts}>
-                <BalancesContext.Provider value={useBalances}>
-                  <BountyCancelModal />
-                </BalancesContext.Provider>
-              </AccountsContext.Provider>
+              <BountyCancelModal />
             </ApiContext.Provider>
           </MockKeyringProvider>
         </ModalContext.Provider>

--- a/packages/ui/test/bounty/modals/ClaimReward.test.tsx
+++ b/packages/ui/test/bounty/modals/ClaimReward.test.tsx
@@ -69,7 +69,7 @@ describe('UI: ClaimRewardModal', () => {
 
   beforeEach(async () => {
     useMyMemberships.setActive(getMember('alice'))
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     tx = stubTransaction(api, txPath)
     mockedTransactionFee.transaction = tx as any
     mockedTransactionFee.feeInfo = { transactionFee: new BN(10), canAfford: true }

--- a/packages/ui/test/bounty/modals/ContributeFundsModal.test.tsx
+++ b/packages/ui/test/bounty/modals/ContributeFundsModal.test.tsx
@@ -2,8 +2,6 @@ import { fireEvent, render, RenderResult, screen } from '@testing-library/react'
 import BN from 'bn.js'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { BalancesContext } from '@/accounts/providers/balances/context'
 import { ContributeFundsModal } from '@/bounty/modals/ContributeFundsModal'
 import { FundingLimited } from '@/bounty/types/Bounty'
 import { ApiContext } from '@/common/providers/api/context'
@@ -17,13 +15,15 @@ import { getButton } from '../../_helpers/getButton'
 import { alice, bob } from '../../_mocks/keyring'
 import { MockApolloProvider, MockKeyringProvider } from '../../_mocks/providers'
 import {
+  stubAccounts,
   stubApi,
   stubBountyConstants,
+  stubDefaultBalances,
   stubTransaction,
   stubTransactionFailure,
   stubTransactionSuccess,
 } from '../../_mocks/transactions'
-import { mockDefaultBalance, mockedTransactionFee } from '../../setup'
+import { mockedTransactionFee } from '../../setup'
 
 const [baseBounty] = bounties
 const bounty = {
@@ -34,11 +34,6 @@ const bounty = {
     maxAmount: new BN((baseBounty.fundingType as unknown as FundingLimited).maxAmount ?? 0),
     minAmount: new BN((baseBounty.fundingType as unknown as FundingLimited).minAmount ?? 0),
   },
-}
-
-const defaultBalance = {
-  ...mockDefaultBalance,
-  transferable: new BN(1000),
 }
 
 describe('UI: ContributeFundsModal', () => {
@@ -57,11 +52,6 @@ describe('UI: ContributeFundsModal', () => {
     },
   }
 
-  const useBalances = {
-    [getMember('bob').controllerAccount]: { ...defaultBalance },
-    [getMember('alice').controllerAccount]: defaultBalance,
-  }
-
   const useMembership = {
     isLoading: false,
     active: getMember('alice'),
@@ -73,11 +63,10 @@ describe('UI: ContributeFundsModal', () => {
     },
   }
 
-  const useAccounts = {
-    isLoading: false,
-    hasAccounts: true,
-    allAccounts: [bob, alice],
-  }
+  beforeAll(() => {
+    stubDefaultBalances()
+    stubAccounts([bob, alice])
+  })
 
   beforeEach(() => {
     transaction = stubTransaction(api, 'api.tx.bounty.fundBounty', fee)
@@ -158,11 +147,7 @@ describe('UI: ContributeFundsModal', () => {
         <MockKeyringProvider>
           <ApiContext.Provider value={api}>
             <MembershipContext.Provider value={useMembership}>
-              <AccountsContext.Provider value={useAccounts}>
-                <BalancesContext.Provider value={useBalances}>
-                  <ContributeFundsModal />
-                </BalancesContext.Provider>
-              </AccountsContext.Provider>
+              <ContributeFundsModal />
             </MembershipContext.Provider>
           </ApiContext.Provider>
         </MockKeyringProvider>

--- a/packages/ui/test/bounty/modals/SubmitJudgementModal.test.tsx
+++ b/packages/ui/test/bounty/modals/SubmitJudgementModal.test.tsx
@@ -109,7 +109,7 @@ describe('UI: SubmitJudgementModal', () => {
   })
 
   beforeEach(async () => {
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     stubBountyConstants(api)
     transaction = stubTransaction(api, 'api.tx.bounty.submitOracleJudgment', 100)
     txMock = api.api.tx.bounty.submitOracleJudgment as unknown as jest.Mock

--- a/packages/ui/test/bounty/modals/SubmitJudgementModal.test.tsx
+++ b/packages/ui/test/bounty/modals/SubmitJudgementModal.test.tsx
@@ -3,11 +3,6 @@ import { configure, fireEvent, render, screen, waitFor } from '@testing-library/
 import BN from 'bn.js'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
-import { BalancesContext } from '@/accounts/providers/balances/context'
-import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
-import { AddressToBalanceMap } from '@/accounts/types'
 import { SubmitJudgementModal } from '@/bounty/modals/SubmitJudgementModal'
 import { CKEditorProps } from '@/common/components/CKEditor'
 import { ApiContext } from '@/common/providers/api/context'
@@ -27,6 +22,7 @@ import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/provid
 import { setupMockServer } from '../../_mocks/server'
 import {
   currentStubErrorMessage,
+  stubAccounts,
   stubApi,
   stubBountyConstants,
   stubDefaultBalances,
@@ -34,7 +30,6 @@ import {
   stubTransactionFailure,
   stubTransactionSuccess,
 } from '../../_mocks/transactions'
-import { mockDefaultBalance } from '../../setup'
 
 configure({ testIdAttribute: 'id' })
 
@@ -70,13 +65,6 @@ describe('UI: SubmitJudgementModal', () => {
     },
   }
 
-  const useMyAccounts: UseAccounts = {
-    isLoading: false,
-    hasAccounts: false,
-    allAccounts: [alice, bob],
-    error: undefined,
-  }
-
   const useMyMemberships = {
     active: getMember('alice'),
     setActive: () => undefined,
@@ -88,14 +76,6 @@ describe('UI: SubmitJudgementModal', () => {
     },
   }
 
-  const useMyBalances: AddressToBalanceMap = {
-    [useMyAccounts.allAccounts[0].address]: {
-      ...mockDefaultBalance,
-      total: new BN(10000),
-      transferable: new BN(10000),
-    },
-  }
-
   let transaction: any
   let txMock: jest.Mock
 
@@ -104,6 +84,8 @@ describe('UI: SubmitJudgementModal', () => {
   stubBountyConstants(api)
 
   beforeAll(async () => {
+    stubDefaultBalances()
+    stubAccounts([alice, bob])
     await cryptoWaitReady()
     seedMembers(server.server)
   })
@@ -357,15 +339,9 @@ describe('UI: SubmitJudgementModal', () => {
         <MockQueryNodeProviders>
           <MockKeyringProvider>
             <ApiContext.Provider value={api}>
-              <AccountsContext.Provider value={useMyAccounts}>
-                <BalancesContext.Provider value={useMyBalances}>
-                  <BalancesContextProvider>
-                    <MembershipContext.Provider value={useMyMemberships}>
-                      <SubmitJudgementModal />
-                    </MembershipContext.Provider>
-                  </BalancesContextProvider>
-                </BalancesContext.Provider>
-              </AccountsContext.Provider>
+              <MembershipContext.Provider value={useMyMemberships}>
+                <SubmitJudgementModal />
+              </MembershipContext.Provider>
             </ApiContext.Provider>
           </MockKeyringProvider>
         </MockQueryNodeProviders>

--- a/packages/ui/test/bounty/modals/SubmitWorkModal.test.tsx
+++ b/packages/ui/test/bounty/modals/SubmitWorkModal.test.tsx
@@ -1,10 +1,7 @@
 import { BountyWorkData } from '@joystream/metadata-protobuf'
 import { fireEvent, render, RenderResult, screen } from '@testing-library/react'
-import BN from 'bn.js'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { BalancesContext } from '@/accounts/providers/balances/context'
 import { SubmitWorkModal } from '@/bounty/modals/SubmitWorkModal'
 import { metadataFromBytes } from '@/common/model/JoystreamNode/metadataFromBytes'
 import { ApiContext } from '@/common/providers/api/context'
@@ -20,18 +17,14 @@ import { alice, bob } from '../../_mocks/keyring'
 import { MockApolloProvider, MockKeyringProvider } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import {
+  stubAccounts,
   stubApi,
   stubBountyConstants,
+  stubDefaultBalances,
   stubTransaction,
   stubTransactionFailure,
   stubTransactionSuccess,
 } from '../../_mocks/transactions'
-import { mockDefaultBalance } from '../../setup'
-
-const defaultBalance = {
-  ...mockDefaultBalance,
-  transferable: new BN(1000),
-}
 
 describe('UI: BountySubmitModal', () => {
   const mockServer = setupMockServer({ noCleanupAfterEach: true })
@@ -67,11 +60,6 @@ describe('UI: BountySubmitModal', () => {
     }
   })
 
-  const useBalances = {
-    [getMember('bob').controllerAccount]: { ...defaultBalance },
-    [getMember('alice').controllerAccount]: defaultBalance,
-  }
-
   const useMembership = {
     isLoading: false,
     active: getMember('bob'),
@@ -83,11 +71,10 @@ describe('UI: BountySubmitModal', () => {
     },
   }
 
-  const useAccounts = {
-    isLoading: false,
-    hasAccounts: true,
-    allAccounts: [bob, alice],
-  }
+  beforeAll(() => {
+    stubDefaultBalances()
+    stubAccounts([bob, alice])
+  })
 
   beforeEach(() => {
     renderResult = render(<RenderModal />)
@@ -164,11 +151,7 @@ describe('UI: BountySubmitModal', () => {
         <MockKeyringProvider>
           <ApiContext.Provider value={api}>
             <MembershipContext.Provider value={useMembership}>
-              <AccountsContext.Provider value={useAccounts}>
-                <BalancesContext.Provider value={useBalances}>
-                  <SubmitWorkModal />
-                </BalancesContext.Provider>
-              </AccountsContext.Provider>
+              <SubmitWorkModal />
             </MembershipContext.Provider>
           </ApiContext.Provider>
         </MockKeyringProvider>

--- a/packages/ui/test/bounty/modals/WithdrawContributionModal.test.tsx
+++ b/packages/ui/test/bounty/modals/WithdrawContributionModal.test.tsx
@@ -85,7 +85,7 @@ describe('UI: WithdrawContributionModal', () => {
   })
 
   beforeEach(async () => {
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     tx = stubTransaction(api, txPath)
     mockedTransactionFee.transaction = tx as any
     mockedTransactionFee.feeInfo = { transactionFee: new BN(10), canAfford: true }

--- a/packages/ui/test/bounty/modals/WithdrawWorkEntryWork.test.tsx
+++ b/packages/ui/test/bounty/modals/WithdrawWorkEntryWork.test.tsx
@@ -80,7 +80,7 @@ describe('UI: WithdrawWorkEntryModal', () => {
   })
 
   beforeEach(async () => {
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     tx = stubTransaction(api, txPath)
     mockedTransactionFee.feeInfo = { transactionFee: new BN(100), canAfford: true }
     mockedTransactionFee.transaction = tx as any

--- a/packages/ui/test/bounty/modals/WithdrawWorkEntryWork.test.tsx
+++ b/packages/ui/test/bounty/modals/WithdrawWorkEntryWork.test.tsx
@@ -3,8 +3,6 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import BN from 'bn.js'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { BalancesContext } from '@/accounts/providers/balances/context'
 import { WithdrawWorkEntryModal } from '@/bounty/modals/WithdrawWorkEntryModal'
 import { formatTokenValue } from '@/common/model/formatters'
 import { ApiContext } from '@/common/providers/api/context'
@@ -21,22 +19,18 @@ import { getButton } from '../../_helpers/getButton'
 import { alice, bob } from '../../_mocks/keyring'
 import { MockKeyringProvider, MockApolloProvider } from '../../_mocks/providers'
 import {
+  stubAccounts,
   stubApi,
   stubDefaultBalances,
   stubTransaction,
   stubTransactionFailure,
   stubTransactionSuccess,
 } from '../../_mocks/transactions'
-import { mockDefaultBalance, mockedTransactionFee } from '../../setup'
+import { mockedTransactionFee } from '../../setup'
 
 const bounty = bounties[0]
 const baseEntry = entries[1]
 const entry = { ...baseEntry, worker: getMember('bob'), works: [generateWork()] }
-
-const defaultBalance = {
-  ...mockDefaultBalance,
-  transferable: new BN(1000),
-}
 
 describe('UI: WithdrawWorkEntryModal', () => {
   const useModal: UseModal<any> = {
@@ -64,18 +58,9 @@ describe('UI: WithdrawWorkEntryModal', () => {
     },
   }
 
-  const useAccounts = {
-    isLoading: false,
-    hasAccounts: true,
-    allAccounts: [bob, alice],
-  }
-
-  const useBalances = {
-    [getMember('bob').controllerAccount]: { ...defaultBalance },
-    [getMember('alice').controllerAccount]: defaultBalance,
-  }
-
   beforeAll(async () => {
+    stubDefaultBalances()
+    stubAccounts([bob, alice])
     await cryptoWaitReady()
   })
 
@@ -166,15 +151,11 @@ describe('UI: WithdrawWorkEntryModal', () => {
       <MockApolloProvider>
         <ModalContext.Provider value={useModal}>
           <MockKeyringProvider>
-            <AccountsContext.Provider value={useAccounts}>
-              <MembershipContext.Provider value={useMyMemberships}>
-                <ApiContext.Provider value={api}>
-                  <BalancesContext.Provider value={useBalances}>
-                    <WithdrawWorkEntryModal />
-                  </BalancesContext.Provider>
-                </ApiContext.Provider>
-              </MembershipContext.Provider>
-            </AccountsContext.Provider>
+            <MembershipContext.Provider value={useMyMemberships}>
+              <ApiContext.Provider value={api}>
+                <WithdrawWorkEntryModal />
+              </ApiContext.Provider>
+            </MembershipContext.Provider>
           </MockKeyringProvider>
         </ModalContext.Provider>
       </MockApolloProvider>

--- a/packages/ui/test/common/components/TransactionButton.test.tsx
+++ b/packages/ui/test/common/components/TransactionButton.test.tsx
@@ -4,7 +4,6 @@ import { useMachine } from '@xstate/react'
 import { BaseDotsamaWallet } from 'injectweb3-connect'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
 import { ButtonPrimary } from '@/common/components/buttons'
 import { TransactionButton } from '@/common/components/buttons/TransactionButton'
 import { useSignAndSendTransaction } from '@/common/hooks/useSignAndSendTransaction'
@@ -15,7 +14,13 @@ import { TransactionStatusProvider } from '@/common/providers/transactionStatus/
 import { getButton } from '../../_helpers/getButton'
 import { alice } from '../../_mocks/keyring'
 import { MockApolloProvider, MockKeyringProvider } from '../../_mocks/providers'
-import { stubApi, stubTransaction, stubTransactionPending, stubTransactionSuccess } from '../../_mocks/transactions'
+import {
+  stubAccounts,
+  stubApi,
+  stubTransaction,
+  stubTransactionPending,
+  stubTransactionSuccess,
+} from '../../_mocks/transactions'
 
 describe('UI: TransactionButton', () => {
   const api = stubApi()
@@ -24,14 +29,8 @@ describe('UI: TransactionButton', () => {
 
   stubTransaction(api, txPath)
 
-  const useAccounts = {
-    isLoading: false,
-    allAccounts: [{ ...alice, name: 'Alice Account' }],
-    hasAccounts: true,
-    wallet: new BaseDotsamaWallet({ title: 'ExtraWallet' }),
-  }
-
   beforeAll(async () => {
+    stubAccounts([{ ...alice, name: 'Alice Account' }], { wallet: new BaseDotsamaWallet({ title: 'ExtraWallet' }) })
     await cryptoWaitReady()
   })
 
@@ -92,16 +91,14 @@ describe('UI: TransactionButton', () => {
     render(
       <MockKeyringProvider>
         <MockApolloProvider>
-          <AccountsContext.Provider value={useAccounts}>
-            <ApiContext.Provider value={api}>
-              <TransactionStatusProvider>
-                <TestButton />
-                <TransactionButton style="primary" size="large">
-                  Start new transaction
-                </TransactionButton>
-              </TransactionStatusProvider>
-            </ApiContext.Provider>
-          </AccountsContext.Provider>
+          <ApiContext.Provider value={api}>
+            <TransactionStatusProvider>
+              <TestButton />
+              <TransactionButton style="primary" size="large">
+                Start new transaction
+              </TransactionButton>
+            </TransactionStatusProvider>
+          </ApiContext.Provider>
         </MockApolloProvider>
       </MockKeyringProvider>
     )

--- a/packages/ui/test/common/hooks/useOnBoarding.test.tsx
+++ b/packages/ui/test/common/hooks/useOnBoarding.test.tsx
@@ -15,7 +15,7 @@ import { getAccount } from '../../../dev/node-mocks/data/addresses'
 import { alice } from '../../_mocks/keyring'
 import { MockApolloProvider } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
-import { stubAccounts } from '../../_mocks/transactions'
+import { stubAccounts, stubBalances } from '../../_mocks/transactions'
 
 let mockUseLocalStorage: [string | undefined, () => void] = [undefined, jest.fn()]
 
@@ -81,6 +81,7 @@ describe('useOnBoarding', () => {
 
       it('Create membership', async () => {
         stubAccounts([alice], { error: undefined, wallet })
+        stubBalances({ available: 0 })
         mockUseLocalStorage = [getAccount('alice'), jest.fn()]
 
         const { isLoading, status } = await renderUseOnBoarding()

--- a/packages/ui/test/common/hooks/useOnBoarding.test.tsx
+++ b/packages/ui/test/common/hooks/useOnBoarding.test.tsx
@@ -3,8 +3,6 @@ import { renderHook } from '@testing-library/react-hooks'
 import { BaseDotsamaWallet } from 'injectweb3-connect'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { useOnBoarding } from '@/common/hooks/useOnBoarding'
 import { ApiContext } from '@/common/providers/api/context'
 import { UseApi } from '@/common/providers/api/provider'
@@ -14,10 +12,14 @@ import { MyMemberships } from '@/memberships/providers/membership/provider'
 import { seedMembers } from '@/mocks/data'
 
 import { getAccount } from '../../../dev/node-mocks/data/addresses'
+import { alice } from '../../_mocks/keyring'
 import { MockApolloProvider } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
+import { stubAccounts } from '../../_mocks/transactions'
 
 let mockUseLocalStorage: [string | undefined, () => void] = [undefined, jest.fn()]
+
+const wallet = new BaseDotsamaWallet({ title: 'ExtraWallet' })
 
 jest.mock('@/common/hooks/useLocalStorage', () => ({
   useLocalStorage: () => mockUseLocalStorage,
@@ -26,11 +28,6 @@ jest.mock('@/common/hooks/useLocalStorage', () => ({
 describe('useOnBoarding', () => {
   const server = setupMockServer()
 
-  const useMyAccounts: UseAccounts = {
-    isLoading: true,
-    hasAccounts: false,
-    allAccounts: [],
-  }
   const useMyMemberships: MyMemberships = {
     helpers: {
       getMemberIdByBoundAccountAddress: () => undefined,
@@ -61,16 +58,13 @@ describe('useOnBoarding', () => {
 
     describe('Loaded', () => {
       beforeEach(() => {
-        useMyAccounts.isLoading = false
+        stubAccounts([], { error: undefined, wallet })
         useMyMemberships.isLoading = false
-        useMyAccounts.error = undefined
         useApi.isConnected = true
-        useMyAccounts.wallet = new BaseDotsamaWallet({ title: 'ExtraWallet' })
       })
 
       it('Install plugin', async () => {
-        useMyAccounts.error = 'NO_EXTENSION'
-        useMyAccounts.wallet = undefined
+        stubAccounts([], { error: 'NO_EXTENSION', wallet: undefined })
 
         const { isLoading, status } = await renderUseOnBoarding()
 
@@ -86,8 +80,7 @@ describe('useOnBoarding', () => {
       })
 
       it('Create membership', async () => {
-        useMyAccounts.hasAccounts = true
-        useMyAccounts.allAccounts = [{ name: 'Account', address: getAccount('alice') }]
+        stubAccounts([alice], { error: undefined, wallet })
         mockUseLocalStorage = [getAccount('alice'), jest.fn()]
 
         const { isLoading, status } = await renderUseOnBoarding()
@@ -97,7 +90,7 @@ describe('useOnBoarding', () => {
       })
 
       it('Finished', async () => {
-        useMyAccounts.hasAccounts = true
+        mockUseLocalStorage = [getAccount('alice'), jest.fn()]
         useMyMemberships.hasMembers = true
         mockUseLocalStorage = ['redeemed', jest.fn()]
         const { isLoading, status } = await renderUseOnBoarding()
@@ -113,11 +106,9 @@ describe('useOnBoarding', () => {
       wrapper: ({ children }) => (
         <MockApolloProvider>
           <ApiContext.Provider value={useApi}>
-            <AccountsContext.Provider value={useMyAccounts}>
-              <MembershipContext.Provider value={useMyMemberships}>
-                <OnBoardingProvider>{children}</OnBoardingProvider>
-              </MembershipContext.Provider>
-            </AccountsContext.Provider>
+            <MembershipContext.Provider value={useMyMemberships}>
+              <OnBoardingProvider>{children}</OnBoardingProvider>
+            </MembershipContext.Provider>
           </ApiContext.Provider>
         </MockApolloProvider>
       ),

--- a/packages/ui/test/common/modals/OnBoardingModal.test.tsx
+++ b/packages/ui/test/common/modals/OnBoardingModal.test.tsx
@@ -4,8 +4,6 @@ import React from 'react'
 import { act } from 'react-dom/test-utils'
 import { MemoryRouter } from 'react-router'
 
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
-import { AddressToBalanceMap } from '@/accounts/types'
 import { Colors } from '@/common/constants'
 import { OnBoardingModal } from '@/common/modals/OnBoardingModal'
 import { ModalContext } from '@/common/providers/modal/context'
@@ -13,31 +11,14 @@ import { UseModal } from '@/common/providers/modal/types'
 import { UseOnBoarding } from '@/common/providers/onboarding/types'
 
 import { MockApolloProvider } from '../../_mocks/providers'
-import { stubApi } from '../../_mocks/transactions'
-import { mockDefaultBalance } from '../../setup'
-
-const mockUseMyAccounts: UseAccounts = {
-  isLoading: false,
-  hasAccounts: false,
-  allAccounts: [],
-  error: undefined,
-}
+import { stubAccounts, stubApi } from '../../_mocks/transactions'
+import { mockedMyBalances, zeroBalance } from '../../setup'
 
 const mockOnBoarding: UseOnBoarding = {
   status: 'installPlugin',
   isLoading: false,
   setMembershipAccount: jest.fn(),
 }
-
-let mockMyBalances: AddressToBalanceMap = {}
-
-jest.mock('@/accounts/hooks/useMyAccounts', () => ({
-  useMyAccounts: () => mockUseMyAccounts,
-}))
-
-jest.mock('@/accounts/hooks/useMyBalances', () => ({
-  useMyBalances: () => mockMyBalances,
-}))
 
 jest.mock('@/common/hooks/useOnBoarding', () => ({
   useOnBoarding: () => mockOnBoarding,
@@ -128,8 +109,7 @@ describe('UI: OnBoardingModal', () => {
 
     describe('Pick account step', () => {
       beforeAll(() => {
-        mockUseMyAccounts.hasAccounts = true
-        mockUseMyAccounts.allAccounts = [
+        stubAccounts([
           {
             address: '123',
             name: 'Alice',
@@ -138,16 +118,16 @@ describe('UI: OnBoardingModal', () => {
             address: '321',
             name: 'Bob',
           },
-        ]
-        mockMyBalances = {
+        ])
+        mockedMyBalances.mockReturnValue({
           '123': {
-            ...mockDefaultBalance,
+            ...zeroBalance,
             total: new BN(10),
           },
           '321': {
-            ...mockDefaultBalance,
+            ...zeroBalance,
           },
-        }
+        })
       })
 
       it('Shows correct screen', () => {

--- a/packages/ui/test/council/components/ElectionVotes.test.tsx
+++ b/packages/ui/test/council/components/ElectionVotes.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
 import { RevealingStageVotes } from '@/council/components/election/CandidateVote/RevealingStageVotes'
 import { useCurrentElection } from '@/council/hooks/useCurrentElection'
 import { useElectionVotes } from '@/council/hooks/useElectionVotes'
@@ -18,6 +17,7 @@ import { CANDIDATE_DATA, VOTE_DATA } from '../../_mocks/council'
 import { alice, bob } from '../../_mocks/keyring'
 import { MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
+import { stubAccounts } from '../../_mocks/transactions'
 
 const Results = ({ onlyMyVotes }: { onlyMyVotes: boolean }) => {
   const { election } = useCurrentElection()
@@ -35,12 +35,6 @@ const Results = ({ onlyMyVotes }: { onlyMyVotes: boolean }) => {
 describe('UI: RevealingStageVotes', () => {
   const server = setupMockServer()
 
-  const useAccounts = {
-    isLoading: false,
-    hasAccounts: true,
-    allAccounts: [{ name: 'account', address: bob.address }],
-  }
-
   beforeEach(() => {
     seedMembers(server.server, 2)
     seedCouncilElection(
@@ -52,7 +46,7 @@ describe('UI: RevealingStageVotes', () => {
       server.server
     )
     seedCouncilCandidate(CANDIDATE_DATA, server.server)
-    useAccounts.allAccounts = [{ name: 'account', address: bob.address }]
+    stubAccounts([{ name: 'account', address: bob.address }])
   })
 
   it('No votes revealed', async () => {
@@ -161,10 +155,10 @@ describe('UI: RevealingStageVotes', () => {
     })
 
     it('Two votes for the same candidate, one of them revealed', async () => {
-      useAccounts.allAccounts = [
+      stubAccounts([
         { name: 'account', address: bob.address },
         { name: 'account2', address: alice.address },
-      ]
+      ])
       const salt1 = '0x7a0c114de774424abcd5d60fc58658a35341c9181b09e94a16dfff7ba2192206'
       seedCouncilVote(
         {
@@ -194,10 +188,10 @@ describe('UI: RevealingStageVotes', () => {
     })
 
     it('Two votes for different candidates, one of them revealed', async () => {
-      useAccounts.allAccounts = [
+      stubAccounts([
         { name: 'account', address: bob.address },
         { name: 'account2', address: alice.address },
-      ]
+      ])
       seedCouncilCandidate({ ...CANDIDATE_DATA, id: '1', memberId: '1' }, server.server)
       const salt = '0x7a0c114de774424abcd5d60fc58658a35341c9181b09e94a16dfff7ba2192206'
       seedCouncilVote(
@@ -278,10 +272,8 @@ describe('UI: RevealingStageVotes', () => {
 
   const renderComponent = (onlyMyVotes = false) =>
     render(
-      <AccountsContext.Provider value={useAccounts}>
-        <MockQueryNodeProviders>
-          <Results onlyMyVotes={onlyMyVotes} />
-        </MockQueryNodeProviders>
-      </AccountsContext.Provider>
+      <MockQueryNodeProviders>
+        <Results onlyMyVotes={onlyMyVotes} />
+      </MockQueryNodeProviders>
     )
 })

--- a/packages/ui/test/council/components/PastVotesList.test.tsx
+++ b/packages/ui/test/council/components/PastVotesList.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
 import { PastVotesList } from '@/council/components/PastVotes/PastVotesList'
 import {
   RawCouncilElectionMock,
@@ -15,15 +14,14 @@ import { CANDIDATE_DATA, VOTE_DATA } from '../../_mocks/council'
 import { alice } from '../../_mocks/keyring'
 import { MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
+import { stubAccounts } from '../../_mocks/transactions'
 
 describe('UI: PastVotesList', () => {
   const server = setupMockServer()
 
-  const useAccounts = {
-    isLoading: false,
-    hasAccounts: true,
-    allAccounts: [{ name: 'account', address: alice.address }],
-  }
+  beforeAll(() => {
+    stubAccounts([{ name: 'account', address: alice.address }])
+  })
 
   beforeEach(() => {
     seedMembers(server.server, 2)
@@ -80,10 +78,8 @@ describe('UI: PastVotesList', () => {
 
   const renderComponent = () =>
     render(
-      <AccountsContext.Provider value={useAccounts}>
-        <MockQueryNodeProviders>
-          <PastVotesList />
-        </MockQueryNodeProviders>
-      </AccountsContext.Provider>
+      <MockQueryNodeProviders>
+        <PastVotesList />
+      </MockQueryNodeProviders>
     )
 })

--- a/packages/ui/test/council/hooks/useMyPastVotesStats.test.tsx
+++ b/packages/ui/test/council/hooks/useMyPastVotesStats.test.tsx
@@ -1,7 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
 import { repeat } from '@/common/utils'
 import { useMyPastVotesStats } from '@/council/hooks/useMyPastVotesStats'
 import {
@@ -18,14 +17,14 @@ import { CANDIDATE_DATA, VOTE_DATA } from '../../_mocks/council'
 import { alice, bob } from '../../_mocks/keyring'
 import { MockApolloProvider } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
+import { stubAccounts } from '../../_mocks/transactions'
 
 describe('useMyPastVotesStats', () => {
   const server = setupMockServer()
-  const useAccounts = {
-    isLoading: false,
-    hasAccounts: false,
-    allAccounts: [alice, bob],
-  }
+
+  beforeAll(() => {
+    stubAccounts([alice, bob])
+  })
 
   describe('Counts total cast votes', () => {
     beforeEach(() => {
@@ -234,11 +233,7 @@ describe('useMyPastVotesStats', () => {
 
   const renderUseStats = async () => {
     const { result, waitForNextUpdate } = renderHook(() => useMyPastVotesStats(), {
-      wrapper: ({ children }) => (
-        <MockApolloProvider>
-          <AccountsContext.Provider value={useAccounts}>{children}</AccountsContext.Provider>
-        </MockApolloProvider>
-      ),
+      wrapper: ({ children }) => <MockApolloProvider>{children}</MockApolloProvider>,
     })
     while (result.current.isLoading) {
       await waitForNextUpdate()

--- a/packages/ui/test/council/modals/AnnounceCandidacyModal.test.tsx
+++ b/packages/ui/test/council/modals/AnnounceCandidacyModal.test.tsx
@@ -8,8 +8,6 @@ import { Router } from 'react-router'
 import { interpret } from 'xstate'
 
 import { MoveFundsModalCall } from '@/accounts/modals/MoveFoundsModal'
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { CurrencyName } from '@/app/constants/currency'
 import { CKEditorProps } from '@/common/components/CKEditor'
@@ -35,6 +33,7 @@ import { getMember } from '../../_mocks/members'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import {
+  stubAccounts,
   stubApi,
   stubCouncilConstants,
   stubDefaultBalances,
@@ -75,7 +74,6 @@ describe('UI: Announce Candidacy Modal', () => {
     },
   }
 
-  let useAccounts: UseAccounts
   let batchTx: any
   let announceCandidacyTx: any
   let bindAccountTx: any
@@ -86,12 +84,7 @@ describe('UI: Announce Candidacy Modal', () => {
   beforeAll(async () => {
     await cryptoWaitReady()
     seedMembers(server.server)
-
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
+    stubAccounts([alice, bob])
   })
 
   beforeEach(async () => {
@@ -653,15 +646,13 @@ describe('UI: Announce Candidacy Modal', () => {
         <ModalContext.Provider value={useModal}>
           <MockQueryNodeProviders>
             <MockKeyringProvider>
-              <AccountsContext.Provider value={useAccounts}>
-                <ApiContext.Provider value={api}>
-                  <BalancesContextProvider>
-                    <MembershipContext.Provider value={useMyMemberships}>
-                      <AnnounceCandidacyModal />
-                    </MembershipContext.Provider>
-                  </BalancesContextProvider>
-                </ApiContext.Provider>
-              </AccountsContext.Provider>
+              <ApiContext.Provider value={api}>
+                <BalancesContextProvider>
+                  <MembershipContext.Provider value={useMyMemberships}>
+                    <AnnounceCandidacyModal />
+                  </MembershipContext.Provider>
+                </BalancesContextProvider>
+              </ApiContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>
         </ModalContext.Provider>

--- a/packages/ui/test/council/modals/AnnounceCandidacyModal.test.tsx
+++ b/packages/ui/test/council/modals/AnnounceCandidacyModal.test.tsx
@@ -90,7 +90,7 @@ describe('UI: Announce Candidacy Modal', () => {
     useMyMemberships.members = [getMember('alice'), getMember('bob')]
     useMyMemberships.active = getMember('alice')
 
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     stubCouncilConstants(api)
     stubTransaction(api, 'api.tx.members.confirmStakingAccount', 5)
     bindAccountTx = stubTransaction(api, 'api.tx.members.addStakingAccountCandidate', 10)

--- a/packages/ui/test/council/modals/AnnounceCandidacyModal.test.tsx
+++ b/packages/ui/test/council/modals/AnnounceCandidacyModal.test.tsx
@@ -8,7 +8,6 @@ import { Router } from 'react-router'
 import { interpret } from 'xstate'
 
 import { MoveFundsModalCall } from '@/accounts/modals/MoveFoundsModal'
-import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { CurrencyName } from '@/app/constants/currency'
 import { CKEditorProps } from '@/common/components/CKEditor'
 import { createType } from '@/common/model/createType'
@@ -647,11 +646,9 @@ describe('UI: Announce Candidacy Modal', () => {
           <MockQueryNodeProviders>
             <MockKeyringProvider>
               <ApiContext.Provider value={api}>
-                <BalancesContextProvider>
-                  <MembershipContext.Provider value={useMyMemberships}>
-                    <AnnounceCandidacyModal />
-                  </MembershipContext.Provider>
-                </BalancesContextProvider>
+                <MembershipContext.Provider value={useMyMemberships}>
+                  <AnnounceCandidacyModal />
+                </MembershipContext.Provider>
               </ApiContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>

--- a/packages/ui/test/council/modals/AnnounceCandidacyModal.test.tsx
+++ b/packages/ui/test/council/modals/AnnounceCandidacyModal.test.tsx
@@ -131,7 +131,7 @@ describe('UI: Announce Candidacy Modal', () => {
         },
       }
 
-      expect(useModal.showModal).toBeCalledTimes(2)
+      expect(useModal.showModal).toBeCalledTimes(1)
       expect(useModal.showModal).toBeCalledWith({ ...switchMemberModalCall })
     })
 

--- a/packages/ui/test/council/modals/RevealVoteModal.test.tsx
+++ b/packages/ui/test/council/modals/RevealVoteModal.test.tsx
@@ -3,7 +3,6 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import BN from 'bn.js'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
 import { ModalCallData, UseModal } from '@/common/providers/modal/types'
@@ -14,6 +13,7 @@ import { alice, bob } from '../../_mocks/keyring'
 import { MockApolloProvider, MockKeyringProvider } from '../../_mocks/providers'
 import {
   currentStubErrorMessage,
+  stubAccounts,
   stubApi,
   stubTransaction,
   stubTransactionFailure,
@@ -46,16 +46,11 @@ describe('UI: RevealVoteModal', () => {
     modalData,
   }
 
-  const useAccounts = {
-    isLoading: false,
-    allAccounts: [
+  beforeAll(async () => {
+    stubAccounts([
       { ...alice, name: 'Alice Account' },
       { ...bob, name: 'Bob Account' },
-    ],
-    hasAccounts: true,
-  }
-
-  beforeAll(async () => {
+    ])
     await cryptoWaitReady()
   })
 
@@ -120,11 +115,9 @@ describe('UI: RevealVoteModal', () => {
       <MockApolloProvider>
         <ModalContext.Provider value={useModal}>
           <MockKeyringProvider>
-            <AccountsContext.Provider value={useAccounts}>
-              <ApiContext.Provider value={api}>
-                <RevealVoteModal />
-              </ApiContext.Provider>
-            </AccountsContext.Provider>
+            <ApiContext.Provider value={api}>
+              <RevealVoteModal />
+            </ApiContext.Provider>
           </MockKeyringProvider>
         </ModalContext.Provider>
       </MockApolloProvider>

--- a/packages/ui/test/council/modals/VoteForCouncilModal.test.tsx
+++ b/packages/ui/test/council/modals/VoteForCouncilModal.test.tsx
@@ -6,8 +6,6 @@ import { act } from 'react-dom/test-utils'
 import { MemoryRouter } from 'react-router'
 
 import { MoveFundsModalCall } from '@/accounts/modals/MoveFoundsModal'
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { CKEditorProps } from '@/common/components/CKEditor'
 import { createType } from '@/common/model/createType'
@@ -33,6 +31,7 @@ import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/provid
 import { setupMockServer } from '../../_mocks/server'
 import {
   currentStubErrorMessage,
+  stubAccounts,
   stubApi,
   stubCouncilConstants,
   stubDefaultBalances,
@@ -67,7 +66,6 @@ describe('UI: Vote for Council Modal', () => {
     },
   }
 
-  let useAccounts: UseAccounts
   let tx: any
 
   const server = setupMockServer({ noCleanupAfterEach: true })
@@ -112,11 +110,7 @@ describe('UI: Vote for Council Modal', () => {
     seedCouncilCandidates(server.server, [{ memberId: '0' }])
     resetVotes()
 
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
+    stubAccounts([alice, bob])
   })
 
   beforeEach(async () => {
@@ -267,15 +261,13 @@ describe('UI: Vote for Council Modal', () => {
         <ModalContext.Provider value={useModal}>
           <MockQueryNodeProviders>
             <MockKeyringProvider>
-              <AccountsContext.Provider value={useAccounts}>
-                <ApiContext.Provider value={api}>
-                  <BalancesContextProvider>
-                    <MembershipContext.Provider value={useMyMemberships}>
-                      <VoteForCouncilModal />
-                    </MembershipContext.Provider>
-                  </BalancesContextProvider>
-                </ApiContext.Provider>
-              </AccountsContext.Provider>
+              <ApiContext.Provider value={api}>
+                <BalancesContextProvider>
+                  <MembershipContext.Provider value={useMyMemberships}>
+                    <VoteForCouncilModal />
+                  </MembershipContext.Provider>
+                </BalancesContextProvider>
+              </ApiContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>
         </ModalContext.Provider>

--- a/packages/ui/test/council/modals/VoteForCouncilModal.test.tsx
+++ b/packages/ui/test/council/modals/VoteForCouncilModal.test.tsx
@@ -116,7 +116,7 @@ describe('UI: Vote for Council Modal', () => {
     useMyMemberships.members = [getMember('alice'), getMember('bob')]
     useMyMemberships.setActive(getMember('alice'))
 
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     stubCouncilConstants(api, { minStake: 500 })
     tx = stubTransaction(api, 'api.tx.referendum.vote', 25)
 

--- a/packages/ui/test/council/modals/VoteForCouncilModal.test.tsx
+++ b/packages/ui/test/council/modals/VoteForCouncilModal.test.tsx
@@ -6,7 +6,6 @@ import { act } from 'react-dom/test-utils'
 import { MemoryRouter } from 'react-router'
 
 import { MoveFundsModalCall } from '@/accounts/modals/MoveFoundsModal'
-import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { CKEditorProps } from '@/common/components/CKEditor'
 import { createType } from '@/common/model/createType'
 import { ApiContext } from '@/common/providers/api/context'
@@ -262,11 +261,9 @@ describe('UI: Vote for Council Modal', () => {
           <MockQueryNodeProviders>
             <MockKeyringProvider>
               <ApiContext.Provider value={api}>
-                <BalancesContextProvider>
-                  <MembershipContext.Provider value={useMyMemberships}>
-                    <VoteForCouncilModal />
-                  </MembershipContext.Provider>
-                </BalancesContextProvider>
+                <MembershipContext.Provider value={useMyMemberships}>
+                  <VoteForCouncilModal />
+                </MembershipContext.Provider>
               </ApiContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>

--- a/packages/ui/test/council/modals/WithdrawCandidacyModal.test.tsx
+++ b/packages/ui/test/council/modals/WithdrawCandidacyModal.test.tsx
@@ -47,7 +47,7 @@ describe('UI: Withdraw Candidacy Modal', () => {
   })
 
   beforeEach(async () => {
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     stubCouncilConstants(api)
     tx = stubTransaction(api, 'api.tx.council.withdrawCandidacy', 25)
   })

--- a/packages/ui/test/council/modals/WithdrawCandidacyModal.test.tsx
+++ b/packages/ui/test/council/modals/WithdrawCandidacyModal.test.tsx
@@ -3,7 +3,6 @@ import { configure, fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
-import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { CKEditorProps } from '@/common/components/CKEditor'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
@@ -103,9 +102,7 @@ describe('UI: Withdraw Candidacy Modal', () => {
           <MockQueryNodeProviders>
             <MockKeyringProvider>
               <ApiContext.Provider value={api}>
-                <BalancesContextProvider>
-                  <WithdrawCandidacyModal />
-                </BalancesContextProvider>
+                <WithdrawCandidacyModal />
               </ApiContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>

--- a/packages/ui/test/council/modals/WithdrawCandidacyModal.test.tsx
+++ b/packages/ui/test/council/modals/WithdrawCandidacyModal.test.tsx
@@ -3,8 +3,6 @@ import { configure, fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { CKEditorProps } from '@/common/components/CKEditor'
 import { ApiContext } from '@/common/providers/api/context'
@@ -21,6 +19,7 @@ import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/provid
 import { setupMockServer } from '../../_mocks/server'
 import {
   currentStubErrorMessage,
+  stubAccounts,
   stubApi,
   stubCouncilConstants,
   stubDefaultBalances,
@@ -38,7 +37,6 @@ jest.mock('@/common/components/CKEditor', () => ({
 describe('UI: Withdraw Candidacy Modal', () => {
   const api = stubApi()
 
-  let useAccounts: UseAccounts
   let tx: any
 
   const server = setupMockServer({ noCleanupAfterEach: true })
@@ -46,12 +44,7 @@ describe('UI: Withdraw Candidacy Modal', () => {
   beforeAll(async () => {
     await cryptoWaitReady()
     seedMembers(server.server, 2)
-
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
+    stubAccounts([alice, bob])
   })
 
   beforeEach(async () => {
@@ -109,13 +102,11 @@ describe('UI: Withdraw Candidacy Modal', () => {
         >
           <MockQueryNodeProviders>
             <MockKeyringProvider>
-              <AccountsContext.Provider value={useAccounts}>
-                <ApiContext.Provider value={api}>
-                  <BalancesContextProvider>
-                    <WithdrawCandidacyModal />
-                  </BalancesContextProvider>
-                </ApiContext.Provider>
-              </AccountsContext.Provider>
+              <ApiContext.Provider value={api}>
+                <BalancesContextProvider>
+                  <WithdrawCandidacyModal />
+                </BalancesContextProvider>
+              </ApiContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>
         </ModalContext.Provider>

--- a/packages/ui/test/council/pages/Election.test.tsx
+++ b/packages/ui/test/council/pages/Election.test.tsx
@@ -2,7 +2,6 @@ import { act, configure, fireEvent, render, screen, waitForElementToBeRemoved } 
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
 import { Election } from '@/app/pages/Election/Election'
 import { ApiContext } from '@/common/providers/api/context'
 import { calculateCommitment } from '@/council/model/calculateCommitment'
@@ -23,7 +22,7 @@ import { VOTE_DATA } from '../../_mocks/council'
 import { alice, bob } from '../../_mocks/keyring'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
-import { stubApi, stubCouncilAndReferendum } from '../../_mocks/transactions'
+import { stubAccounts, stubApi, stubCouncilAndReferendum } from '../../_mocks/transactions'
 
 configure({ testIdAttribute: 'id' })
 
@@ -338,29 +337,29 @@ describe('UI: Election page', () => {
   })
 
   async function renderComponent(accounts = [alice]) {
-    const rendered = render(
-      <MemoryRouter>
-        <ApiContext.Provider value={api}>
-          <MockQueryNodeProviders>
-            <MockKeyringProvider>
-              <AccountsContext.Provider
-                value={{ isLoading: false, hasAccounts: accounts.length > 0, allAccounts: accounts }}
-              >
+    stubAccounts(accounts)
+
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <ApiContext.Provider value={api}>
+            <MockQueryNodeProviders>
+              <MockKeyringProvider>
                 <MembershipContext.Provider value={useMyMemberships}>
                   <Election />
                 </MembershipContext.Provider>
-              </AccountsContext.Provider>
-            </MockKeyringProvider>
-          </MockQueryNodeProviders>
-        </ApiContext.Provider>
-      </MemoryRouter>
-    )
+              </MockKeyringProvider>
+            </MockQueryNodeProviders>
+          </ApiContext.Provider>
+        </MemoryRouter>
+      )
+    })
 
-    const loader = rendered.queryByText('Loading candidates...')
+    const loader = screen.queryByText('Loading candidates...')
     if (loader) {
       await waitForElementToBeRemoved(loader)
     }
 
-    return rendered
+    return screen
   }
 })

--- a/packages/ui/test/council/pages/PastElection.test.tsx
+++ b/packages/ui/test/council/pages/PastElection.test.tsx
@@ -3,8 +3,6 @@ import React from 'react'
 import { MemoryRouter } from 'react-router'
 import { generatePath, Route, Switch } from 'react-router-dom'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { PastElection } from '@/app/pages/Election/PastElections/PastElection'
 import { NotFound } from '@/app/pages/NotFound'
 import { ApiContext } from '@/common/providers/api/context'
@@ -25,7 +23,7 @@ import { randomRawBlock } from '@/mocks/helpers/randomBlock'
 import { alice } from '../../_mocks/keyring'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
-import { stubApi } from '../../_mocks/transactions'
+import { stubAccounts, stubApi } from '../../_mocks/transactions'
 
 const TEST_CANDIDATES: RawCouncilCandidateMock[] = [
   {
@@ -81,11 +79,6 @@ describe('UI: Past Election page', () => {
   const api = stubApi()
   let pageElectionId = 1
 
-  const useAccounts: UseAccounts = {
-    isLoading: false,
-    hasAccounts: true,
-    allAccounts: [alice],
-  }
   const useMyMemberships: MyMemberships = {
     active: undefined,
     members: [getMember('alice')],
@@ -96,6 +89,10 @@ describe('UI: Past Election page', () => {
       getMemberIdByBoundAccountAddress: () => undefined,
     },
   }
+
+  beforeAll(() => {
+    stubAccounts([alice])
+  })
 
   beforeEach(() => {
     pageElectionId = 1
@@ -187,14 +184,12 @@ describe('UI: Past Election page', () => {
         <ApiContext.Provider value={api}>
           <MockQueryNodeProviders>
             <MockKeyringProvider>
-              <AccountsContext.Provider value={useAccounts}>
-                <MembershipContext.Provider value={useMyMemberships}>
-                  <Switch>
-                    <Route path={ElectionRoutes.pastElection} component={PastElection} />
-                    <Route path="/404" component={NotFound} />
-                  </Switch>
-                </MembershipContext.Provider>
-              </AccountsContext.Provider>
+              <MembershipContext.Provider value={useMyMemberships}>
+                <Switch>
+                  <Route path={ElectionRoutes.pastElection} component={PastElection} />
+                  <Route path="/404" component={NotFound} />
+                </Switch>
+              </MembershipContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>
         </ApiContext.Provider>

--- a/packages/ui/test/forum/modals/CreatePostModal.test.tsx
+++ b/packages/ui/test/forum/modals/CreatePostModal.test.tsx
@@ -3,8 +3,6 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import BN from 'bn.js'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
 import { ModalCallData, UseModal } from '@/common/providers/modal/types'
@@ -24,6 +22,7 @@ import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/provid
 import { setupMockServer } from '../../_mocks/server'
 import {
   currentStubErrorMessage,
+  stubAccounts,
   stubApi,
   stubConst,
   stubDefaultBalances,
@@ -65,7 +64,6 @@ describe('UI: CreatePostModal', () => {
       getMemberIdByBoundAccountAddress: () => undefined,
     },
   }
-  let useAccounts: UseAccounts
 
   const server = setupMockServer({ noCleanupAfterEach: true })
 
@@ -77,11 +75,7 @@ describe('UI: CreatePostModal', () => {
     mockPosts.map((post) => seedForumPost(post, server.server))
     useMyMemberships.members = [getMember('alice'), getMember('bob')]
     useMyMemberships.setActive(getMember('alice'))
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
+    stubAccounts([alice, bob])
   })
 
   beforeEach(async () => {
@@ -146,13 +140,11 @@ describe('UI: CreatePostModal', () => {
       <ModalContext.Provider value={useModal}>
         <MockQueryNodeProviders>
           <MockKeyringProvider>
-            <AccountsContext.Provider value={useAccounts}>
-              <MembershipContext.Provider value={useMyMemberships}>
-                <ApiContext.Provider value={api}>
-                  <CreatePostModal />
-                </ApiContext.Provider>
-              </MembershipContext.Provider>
-            </AccountsContext.Provider>
+            <MembershipContext.Provider value={useMyMemberships}>
+              <ApiContext.Provider value={api}>
+                <CreatePostModal />
+              </ApiContext.Provider>
+            </MembershipContext.Provider>
           </MockKeyringProvider>
         </MockQueryNodeProviders>
       </ModalContext.Provider>

--- a/packages/ui/test/forum/modals/CreatePostModal.test.tsx
+++ b/packages/ui/test/forum/modals/CreatePostModal.test.tsx
@@ -81,7 +81,7 @@ describe('UI: CreatePostModal', () => {
   beforeEach(async () => {
     mockedTransactionFee.feeInfo = { transactionFee: new BN(100), canAfford: true }
 
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     tx = stubTransaction(api, txPath, 25)
     stubConst(api, 'forum.postDeposit', createBalanceOf(10))
     modalData.isEditable = false

--- a/packages/ui/test/forum/modals/CreateThreadModal.test.tsx
+++ b/packages/ui/test/forum/modals/CreateThreadModal.test.tsx
@@ -3,7 +3,6 @@ import BN from 'bn.js'
 import React from 'react'
 import { generatePath, MemoryRouter, Route } from 'react-router-dom'
 
-import { Account } from '@/accounts/types'
 import { CurrencyName } from '@/app/constants/currency'
 import { CKEditorProps } from '@/common/components/CKEditor'
 import { createType } from '@/common/model/createType'
@@ -18,9 +17,11 @@ import { MyMemberships } from '@/memberships/providers/membership/provider'
 import { getButton } from '../../_helpers/getButton'
 import { createBalanceOf } from '../../_mocks/chainTypes'
 import { mockCKEditor } from '../../_mocks/components/CKEditor'
+import { alice } from '../../_mocks/keyring'
 import { getMember } from '../../_mocks/members'
 import { MockApolloProvider, MockKeyringProvider } from '../../_mocks/providers'
 import {
+  stubAccounts,
   stubApi,
   stubConst,
   stubDefaultBalances,
@@ -36,14 +37,6 @@ jest.mock('@/common/components/CKEditor', () => ({
 
 jest.mock('@/common/hooks/useQueryNodeTransactionStatus', () => ({
   useQueryNodeTransactionStatus: () => 'confirmed',
-}))
-
-const mockMyAccounts = {
-  allAccounts: [] as Account[],
-}
-
-jest.mock('@/accounts/hooks/useMyAccounts', () => ({
-  useMyAccounts: () => mockMyAccounts,
 }))
 
 describe('CreateThreadModal', () => {
@@ -74,10 +67,13 @@ describe('CreateThreadModal', () => {
     },
   }
 
+  beforeAll(() => {
+    stubAccounts([alice])
+  })
+
   beforeEach(async () => {
     useMyMemberships.members = [getMember('alice'), getMember('bob')]
     useMyMemberships.setActive(getMember('alice'))
-    mockMyAccounts.allAccounts.push({ name: 'alice', address: getMember('alice').controllerAccount })
     tx = stubTransaction(api, txPath)
     mockedTransactionFee.feeInfo = { transactionFee: new BN(10), canAfford: true }
 

--- a/packages/ui/test/forum/modals/CreateThreadModal.test.tsx
+++ b/packages/ui/test/forum/modals/CreateThreadModal.test.tsx
@@ -41,7 +41,7 @@ jest.mock('@/common/hooks/useQueryNodeTransactionStatus', () => ({
 
 describe('CreateThreadModal', () => {
   const api = stubApi()
-  stubDefaultBalances(api)
+  stubDefaultBalances()
   const txPath = 'api.tx.forum.createThread'
   let tx = {}
   let pathname: string

--- a/packages/ui/test/forum/modals/DeletePostModal.test.tsx
+++ b/packages/ui/test/forum/modals/DeletePostModal.test.tsx
@@ -92,7 +92,7 @@ describe('UI: DeletePostModal', () => {
   beforeEach(async () => {
     mockedTransactionFee.feeInfo = { transactionFee: new BN(100), canAfford: true }
 
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     tx = stubTransaction(api, txPath)
     modalData.transaction = api.api.tx.forum.deletePosts(useMyMemberships.active?.id ?? 1, deleteMap, '')
   })

--- a/packages/ui/test/forum/modals/DeletePostModal.test.tsx
+++ b/packages/ui/test/forum/modals/DeletePostModal.test.tsx
@@ -3,8 +3,6 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import BN from 'bn.js'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { createType } from '@/common/model/createType'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
@@ -25,6 +23,7 @@ import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/provid
 import { setupMockServer } from '../../_mocks/server'
 import {
   currentStubErrorMessage,
+  stubAccounts,
   stubApi,
   stubDefaultBalances,
   stubTransaction,
@@ -76,7 +75,6 @@ describe('UI: DeletePostModal', () => {
       getMemberIdByBoundAccountAddress: () => undefined,
     },
   }
-  let useAccounts: UseAccounts
 
   const server = setupMockServer({ noCleanupAfterEach: true })
 
@@ -88,11 +86,7 @@ describe('UI: DeletePostModal', () => {
     mockPosts.map((post) => seedForumPost(post, server.server))
     useMyMemberships.members = [getMember('alice'), getMember('bob')]
     useMyMemberships.setActive(getMember('alice'))
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
+    stubAccounts([alice, bob])
   })
 
   beforeEach(async () => {
@@ -142,13 +136,11 @@ describe('UI: DeletePostModal', () => {
       <ModalContext.Provider value={useModal}>
         <MockQueryNodeProviders>
           <MockKeyringProvider>
-            <AccountsContext.Provider value={useAccounts}>
-              <MembershipContext.Provider value={useMyMemberships}>
-                <ApiContext.Provider value={api}>
-                  <DeletePostModal />
-                </ApiContext.Provider>
-              </MembershipContext.Provider>
-            </AccountsContext.Provider>
+            <MembershipContext.Provider value={useMyMemberships}>
+              <ApiContext.Provider value={api}>
+                <DeletePostModal />
+              </ApiContext.Provider>
+            </MembershipContext.Provider>
           </MockKeyringProvider>
         </MockQueryNodeProviders>
       </ModalContext.Provider>

--- a/packages/ui/test/forum/modals/DeleteThreadModal.test.tsx
+++ b/packages/ui/test/forum/modals/DeleteThreadModal.test.tsx
@@ -87,7 +87,7 @@ describe('UI: DeleteThreadModal', () => {
 
   beforeEach(async () => {
     mockedTransactionFee.feeInfo = { transactionFee: new BN(100), canAfford: true }
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     transaction = stubTransaction(api, txPath, 100)
     txMock = api.api.tx.forum.deleteThread as unknown as jest.Mock
   })

--- a/packages/ui/test/forum/modals/DeleteThreadModal.test.tsx
+++ b/packages/ui/test/forum/modals/DeleteThreadModal.test.tsx
@@ -3,8 +3,6 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import BN from 'bn.js'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
@@ -26,6 +24,7 @@ import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/provid
 import { setupMockServer } from '../../_mocks/server'
 import {
   currentStubErrorMessage,
+  stubAccounts,
   stubApi,
   stubDefaultBalances,
   stubTransaction,
@@ -72,7 +71,6 @@ describe('UI: DeleteThreadModal', () => {
     },
   }
 
-  let useAccounts: UseAccounts
   let transaction: any
   let txMock: jest.Mock
 
@@ -85,11 +83,7 @@ describe('UI: DeleteThreadModal', () => {
     seedForumThread(mockThreads[0], server.server)
     useMyMemberships.members = [getMember('alice'), getMember('bob')]
     useMyMemberships.setActive(getMember('alice'))
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
+    stubAccounts([alice, bob])
   })
 
   beforeEach(async () => {
@@ -143,15 +137,13 @@ describe('UI: DeleteThreadModal', () => {
       <ModalContext.Provider value={useModal}>
         <MockQueryNodeProviders>
           <MockKeyringProvider>
-            <AccountsContext.Provider value={useAccounts}>
-              <MembershipContext.Provider value={useMyMemberships}>
-                <ApiContext.Provider value={api}>
-                  <BalancesContextProvider>
-                    <DeleteThreadModal />
-                  </BalancesContextProvider>
-                </ApiContext.Provider>
-              </MembershipContext.Provider>
-            </AccountsContext.Provider>
+            <MembershipContext.Provider value={useMyMemberships}>
+              <ApiContext.Provider value={api}>
+                <BalancesContextProvider>
+                  <DeleteThreadModal />
+                </BalancesContextProvider>
+              </ApiContext.Provider>
+            </MembershipContext.Provider>
           </MockKeyringProvider>
         </MockQueryNodeProviders>
       </ModalContext.Provider>

--- a/packages/ui/test/forum/modals/DeleteThreadModal.test.tsx
+++ b/packages/ui/test/forum/modals/DeleteThreadModal.test.tsx
@@ -3,7 +3,6 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import BN from 'bn.js'
 import React from 'react'
 
-import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
 import { ModalCallData, UseModal } from '@/common/providers/modal/types'
@@ -139,9 +138,7 @@ describe('UI: DeleteThreadModal', () => {
           <MockKeyringProvider>
             <MembershipContext.Provider value={useMyMemberships}>
               <ApiContext.Provider value={api}>
-                <BalancesContextProvider>
-                  <DeleteThreadModal />
-                </BalancesContextProvider>
+                <DeleteThreadModal />
               </ApiContext.Provider>
             </MembershipContext.Provider>
           </MockKeyringProvider>

--- a/packages/ui/test/forum/modals/EditPostModal.test.tsx
+++ b/packages/ui/test/forum/modals/EditPostModal.test.tsx
@@ -3,8 +3,6 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import BN from 'bn.js'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
 import { ModalCallData, UseModal } from '@/common/providers/modal/types'
@@ -23,6 +21,7 @@ import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/provid
 import { setupMockServer } from '../../_mocks/server'
 import {
   currentStubErrorMessage,
+  stubAccounts,
   stubApi,
   stubDefaultBalances,
   stubTransaction,
@@ -64,7 +63,6 @@ describe('UI: EditPostModal', () => {
       getMemberIdByBoundAccountAddress: () => undefined,
     },
   }
-  let useAccounts: UseAccounts
 
   const server = setupMockServer({ noCleanupAfterEach: true })
 
@@ -76,11 +74,7 @@ describe('UI: EditPostModal', () => {
     mockPosts.map((post) => seedForumPost(post, server.server))
     useMyMemberships.members = [getMember('alice'), getMember('bob')]
     useMyMemberships.setActive(getMember('alice'))
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
+    stubAccounts([alice, bob])
   })
 
   beforeEach(async () => {
@@ -128,13 +122,11 @@ describe('UI: EditPostModal', () => {
       <ModalContext.Provider value={useModal}>
         <MockQueryNodeProviders>
           <MockKeyringProvider>
-            <AccountsContext.Provider value={useAccounts}>
-              <MembershipContext.Provider value={useMyMemberships}>
-                <ApiContext.Provider value={api}>
-                  <EditPostModal />
-                </ApiContext.Provider>
-              </MembershipContext.Provider>
-            </AccountsContext.Provider>
+            <MembershipContext.Provider value={useMyMemberships}>
+              <ApiContext.Provider value={api}>
+                <EditPostModal />
+              </ApiContext.Provider>
+            </MembershipContext.Provider>
           </MockKeyringProvider>
         </MockQueryNodeProviders>
       </ModalContext.Provider>

--- a/packages/ui/test/forum/modals/EditPostModal.test.tsx
+++ b/packages/ui/test/forum/modals/EditPostModal.test.tsx
@@ -79,7 +79,7 @@ describe('UI: EditPostModal', () => {
 
   beforeEach(async () => {
     mockedTransactionFee.feeInfo = { transactionFee: new BN(100), canAfford: true }
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     tx = stubTransaction(api, txPath)
     modalData.transaction = api.api.tx.forum.editPostText(1, 1, 1, 1, '')
   })

--- a/packages/ui/test/forum/pages/ForumThread.test.tsx
+++ b/packages/ui/test/forum/pages/ForumThread.test.tsx
@@ -3,8 +3,6 @@ import React from 'react'
 import { MemoryRouter } from 'react-router'
 import { generatePath, Route, Switch } from 'react-router-dom'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { ForumThread as ForumThreadPage } from '@/app/pages/Forum/ForumThread'
 import { NotFound } from '@/app/pages/NotFound'
 import { CKEditorProps } from '@/common/components/CKEditor'
@@ -20,6 +18,7 @@ import { alice, bob } from '../../_mocks/keyring'
 import { getMember } from '../../_mocks/members'
 import { MockApiProvider, MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
+import { stubAccounts } from '../../_mocks/transactions'
 
 let mockThread: { isLoading: boolean; thread: ForumThread | null }
 let mockSuggestedThreads: { isLoading: boolean; threads: ForumThread[] }
@@ -39,11 +38,6 @@ jest.mock('@/common/components/CKEditor', () => ({
 describe('UI: Forum Thread Page', () => {
   const mockServer = setupMockServer()
 
-  const useAccounts: UseAccounts = {
-    isLoading: false,
-    hasAccounts: true,
-    allAccounts: [alice, bob],
-  }
   const useMyMemberships: MyMemberships = {
     active: undefined,
     members: [getMember('alice'), getMember('bob')],
@@ -68,6 +62,7 @@ describe('UI: Forum Thread Page', () => {
   }
 
   beforeAll(() => {
+    stubAccounts([alice, bob])
     seedMembers(mockServer.server, 2)
   })
 
@@ -115,14 +110,12 @@ describe('UI: Forum Thread Page', () => {
         <MemoryRouter initialEntries={[generatePath(ForumRoutes.thread, { id: '1' })]}>
           <MockQueryNodeProviders>
             <MockKeyringProvider>
-              <AccountsContext.Provider value={useAccounts}>
-                <MembershipContext.Provider value={useMyMemberships}>
-                  <Switch>
-                    <Route path={ForumRoutes.thread} component={ForumThreadPage} />
-                    <Route path="/404" component={NotFound} />
-                  </Switch>
-                </MembershipContext.Provider>
-              </AccountsContext.Provider>
+              <MembershipContext.Provider value={useMyMemberships}>
+                <Switch>
+                  <Route path={ForumRoutes.thread} component={ForumThreadPage} />
+                  <Route path="/404" component={NotFound} />
+                </Switch>
+              </MembershipContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>
         </MemoryRouter>

--- a/packages/ui/test/membership/components/CurrentMember.test.tsx
+++ b/packages/ui/test/membership/components/CurrentMember.test.tsx
@@ -3,7 +3,6 @@ import { act, fireEvent, render, screen, waitForElementToBeRemoved, within } fro
 import { BaseDotsamaWallet } from 'injectweb3-connect'
 import React from 'react'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
 import { GlobalModals } from '@/app/GlobalModals'
 import { ModalContextProvider } from '@/common/providers/modal/provider'
 import { CurrentMember } from '@/memberships/components/CurrentMember'
@@ -14,6 +13,7 @@ import { alice, aliceStash, bob, bobStash } from '../../_mocks/keyring'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import { MEMBER_ALICE_DATA } from '../../_mocks/server/seeds'
+import { stubAccounts } from '../../_mocks/transactions'
 
 jest.mock('@/common/hooks/useLocalStorage', () => ({
   useLocalStorage: () => [undefined, jest.fn()],
@@ -23,6 +23,7 @@ describe('UI: CurrentMember component', () => {
   const mockServer = setupMockServer()
 
   beforeAll(async () => {
+    stubAccounts([alice, aliceStash, bob, bobStash], { wallet: new BaseDotsamaWallet({ title: 'ExtraWallet' }) })
     await cryptoWaitReady()
   })
 
@@ -78,38 +79,12 @@ describe('UI: CurrentMember component', () => {
   function renderComponent() {
     return render(
       <MockKeyringProvider>
-        <AccountsContext.Provider
-          value={{
-            isLoading: false,
-            hasAccounts: true,
-            allAccounts: [
-              {
-                address: alice.address,
-                name: 'Alice',
-              },
-              {
-                address: aliceStash.address,
-                name: 'AliceStash',
-              },
-              {
-                address: bob.address,
-                name: 'Bob',
-              },
-              {
-                address: bobStash.address,
-                name: 'BobStash',
-              },
-            ],
-            wallet: new BaseDotsamaWallet({ title: 'ExtraWallet' }),
-          }}
-        >
-          <MockQueryNodeProviders>
-            <ModalContextProvider>
-              <CurrentMember />
-              <GlobalModals />
-            </ModalContextProvider>
-          </MockQueryNodeProviders>
-        </AccountsContext.Provider>
+        <MockQueryNodeProviders>
+          <ModalContextProvider>
+            <CurrentMember />
+            <GlobalModals />
+          </ModalContextProvider>
+        </MockQueryNodeProviders>
       </MockKeyringProvider>
     )
   }

--- a/packages/ui/test/membership/components/MyMemberships.test.tsx
+++ b/packages/ui/test/membership/components/MyMemberships.test.tsx
@@ -3,7 +3,6 @@ import { render, waitForElementToBeRemoved } from '@testing-library/react'
 import React from 'react'
 import { HashRouter } from 'react-router-dom'
 
-import { Account } from '@/accounts/types'
 import { Memberships } from '@/app/pages/Profile/components/Memberships'
 import { MembershipContextProvider } from '@/memberships/providers/membership/provider'
 import { seedMembers } from '@/mocks/data'
@@ -11,22 +10,12 @@ import { seedMembers } from '@/mocks/data'
 import { alice, aliceStash, bob, bobStash } from '../../_mocks/keyring'
 import { MockApolloProvider } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
-
-const useMyAccounts: { hasAccounts: boolean; allAccounts: Account[] } = {
-  hasAccounts: true,
-  allAccounts: [],
-}
-
-jest.mock('../../../src/accounts/hooks/useMyAccounts', () => {
-  return {
-    useMyAccounts: () => useMyAccounts,
-  }
-})
+import { stubAccounts } from '../../_mocks/transactions'
 
 describe('UI: Memberships list', () => {
   beforeAll(async () => {
     await cryptoWaitReady()
-    useMyAccounts.allAccounts.push(alice, aliceStash, bob, bobStash)
+    stubAccounts([alice, aliceStash, bob, bobStash])
   })
 
   const mockServer = setupMockServer()

--- a/packages/ui/test/membership/hooks/useMyMemberships.test.tsx
+++ b/packages/ui/test/membership/hooks/useMyMemberships.test.tsx
@@ -24,7 +24,7 @@ describe('useMyMemberships', () => {
   })
 
   it('Returns loading state', () => {
-    stubAccounts([], true)
+    stubAccounts([], { isLoading: true })
 
     const { result } = renderUseMembership()
 

--- a/packages/ui/test/membership/hooks/useMyMemberships.test.tsx
+++ b/packages/ui/test/membership/hooks/useMyMemberships.test.tsx
@@ -1,7 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks'
 import React from 'react'
 
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 import { seedMembers } from '@/mocks/data'
 
@@ -9,6 +8,7 @@ import { alice, aliceStash, bob, bobStash } from '../../_mocks/keyring'
 import { getMember } from '../../_mocks/members'
 import { MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
+import { stubAccounts } from '../../_mocks/transactions'
 
 const renderUseMembership = () => {
   return renderHook(() => useMyMemberships(), {
@@ -16,29 +16,15 @@ const renderUseMembership = () => {
   })
 }
 
-const useMyAccounts: UseAccounts = {
-  isLoading: false,
-  hasAccounts: false,
-  allAccounts: [],
-}
-
-jest.mock('../../../src/accounts/hooks/useMyAccounts', () => {
-  return {
-    useMyAccounts: () => useMyAccounts,
-  }
-})
-
 describe('useMyMemberships', () => {
   const mockServer = setupMockServer()
 
   beforeEach(() => {
-    useMyAccounts.isLoading = false
-    useMyAccounts.hasAccounts = false
-    useMyAccounts.allAccounts.splice(0)
+    stubAccounts([])
   })
 
   it('Returns loading state', () => {
-    useMyAccounts.isLoading = true
+    stubAccounts([], true)
 
     const { result } = renderUseMembership()
 
@@ -64,9 +50,7 @@ describe('useMyMemberships', () => {
   it('Matched rootAccount', async () => {
     seedMembers(mockServer.server, 2)
     const aliceMember = getMember('alice')
-    useMyAccounts.hasAccounts = true
-    useMyAccounts.allAccounts.push(alice)
-    useMyAccounts.allAccounts.push(aliceStash)
+    stubAccounts([alice, aliceStash])
 
     const { result, waitForNextUpdate } = renderUseMembership()
     await waitForNextUpdate()
@@ -82,9 +66,7 @@ describe('useMyMemberships', () => {
   it('Matched controllerAccount', async () => {
     seedMembers(mockServer.server, 2)
     const bobMember = getMember('bob')
-    useMyAccounts.hasAccounts = true
-    useMyAccounts.allAccounts.push(bob)
-    useMyAccounts.allAccounts.push(bobStash)
+    stubAccounts([bob, bobStash])
 
     const { result, waitForNextUpdate } = renderUseMembership()
     await waitForNextUpdate()
@@ -100,9 +82,7 @@ describe('useMyMemberships', () => {
   it('Allows to set active member', async () => {
     seedMembers(mockServer.server, 2)
     const aliceMember = getMember('alice')
-    useMyAccounts.hasAccounts = true
-    useMyAccounts.allAccounts.push(alice)
-    useMyAccounts.allAccounts.push(aliceStash)
+    stubAccounts([alice, aliceStash])
 
     const { result, waitForNextUpdate } = renderUseMembership()
     await waitForNextUpdate()

--- a/packages/ui/test/membership/modals/BuyMembershipModal.test.tsx
+++ b/packages/ui/test/membership/modals/BuyMembershipModal.test.tsx
@@ -136,7 +136,7 @@ describe('UI: BuyMembershipModal', () => {
     })
 
     it('Without required balance', async () => {
-      stubBalances(api, { available: 0, locked: 0 })
+      stubBalances({ available: 0, locked: 0 })
 
       await renderAuthorizeStep()
 

--- a/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
+++ b/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
@@ -5,7 +5,6 @@ import { set } from 'lodash'
 import React from 'react'
 import { of } from 'rxjs'
 
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { createType } from '@/common/model/createType'
 import { ApiContext } from '@/common/providers/api/context'
 import { InviteMemberModal } from '@/memberships/modals/InviteMemberModal'
@@ -18,6 +17,7 @@ import { alice, aliceStash, bobStash } from '../../_mocks/keyring'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import {
+  stubAccounts,
   stubApi,
   stubBalances,
   stubDefaultBalances,
@@ -27,18 +27,6 @@ import {
   stubTransactionSuccess,
 } from '../../_mocks/transactions'
 
-const useMyAccounts: UseAccounts = {
-  isLoading: false,
-  hasAccounts: false,
-  allAccounts: [],
-}
-
-jest.mock('@/accounts/hooks/useMyAccounts', () => {
-  return {
-    useMyAccounts: () => useMyAccounts,
-  }
-})
-
 jest.mock('@/common/hooks/useQueryNodeTransactionStatus', () => ({
   useQueryNodeTransactionStatus: () => 'confirmed',
 }))
@@ -47,7 +35,7 @@ describe('UI: InviteMemberModal', () => {
   beforeAll(async () => {
     await cryptoWaitReady()
     jest.spyOn(console, 'log').mockImplementation()
-    useMyAccounts.allAccounts.push(alice, aliceStash)
+    stubAccounts([alice, aliceStash])
   })
 
   afterAll(() => {

--- a/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
+++ b/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
@@ -48,7 +48,7 @@ describe('UI: InviteMemberModal', () => {
   let inviteMemberTx: any
 
   beforeEach(async () => {
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     stubQuery(api, 'membershipWorkingGroup.budget', createBalanceOf(1000))
     stubQuery(api, 'members.membershipPrice', createBalanceOf(100))
     set(api, 'api.query.members.memberIdByHandleHash.size', () => of(new BN(0)))
@@ -155,7 +155,7 @@ describe('UI: InviteMemberModal', () => {
     })
 
     it('Validate funds', async () => {
-      stubBalances(api, { available: 0 })
+      stubBalances({ available: 0 })
       await fillFormAndProceed()
 
       expect(await getButton(/^Sign and create/i)).toBeDisabled()

--- a/packages/ui/test/membership/modals/TransferInviteModal.test.tsx
+++ b/packages/ui/test/membership/modals/TransferInviteModal.test.tsx
@@ -30,7 +30,7 @@ describe('UI: TransferInviteModal', () => {
   })
 
   beforeEach(async () => {
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     stubTransaction(api, 'api.tx.members.transferInvites')
   })
 

--- a/packages/ui/test/membership/modals/UpdateMembershipModal.test.tsx
+++ b/packages/ui/test/membership/modals/UpdateMembershipModal.test.tsx
@@ -47,7 +47,7 @@ describe('UI: UpdatedMembershipModal', () => {
   let member: Member
 
   beforeEach(() => {
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     set(api, 'api.query.members.membershipPrice', () => of(createBalanceOf(100)))
     set(api, 'api.query.members.memberIdByHandleHash.size', () => of(new BN(0)))
     stubTransaction(api, 'api.tx.members.updateProfile')

--- a/packages/ui/test/membership/modals/UpdateMembershipModal.test.tsx
+++ b/packages/ui/test/membership/modals/UpdateMembershipModal.test.tsx
@@ -5,7 +5,6 @@ import { set } from 'lodash'
 import React from 'react'
 import { of } from 'rxjs'
 
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { ApiContext } from '@/common/providers/api/context'
 import { UpdateMembershipModal } from '@/memberships/modals/UpdateMembershipModal'
 import { Member } from '@/memberships/types'
@@ -18,24 +17,13 @@ import { getMember } from '../../_mocks/members'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import {
+  stubAccounts,
   stubApi,
   stubBatchTransactionFailure,
   stubBatchTransactionSuccess,
   stubDefaultBalances,
   stubTransaction,
 } from '../../_mocks/transactions'
-
-const useMyAccounts: UseAccounts = {
-  isLoading: false,
-  hasAccounts: true,
-  allAccounts: [],
-}
-
-jest.mock('../../../src/accounts/hooks/useMyAccounts', () => {
-  return {
-    useMyAccounts: () => useMyAccounts,
-  }
-})
 
 jest.mock('@/common/hooks/useQueryNodeTransactionStatus', () => ({
   useQueryNodeTransactionStatus: () => 'confirmed',
@@ -45,7 +33,7 @@ describe('UI: UpdatedMembershipModal', () => {
   beforeAll(async () => {
     await cryptoWaitReady()
     jest.spyOn(console, 'log').mockImplementation()
-    useMyAccounts.allAccounts.push(alice, aliceStash, bob, bobStash)
+    stubAccounts([alice, aliceStash, bob, bobStash])
   })
 
   afterAll(() => {

--- a/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
@@ -7,7 +7,6 @@ import { MemoryRouter } from 'react-router'
 import { interpret } from 'xstate'
 
 import { MoveFundsModalCall } from '@/accounts/modals/MoveFoundsModal'
-import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { CurrencyName } from '@/app/constants/currency'
 import { CKEditorProps } from '@/common/components/CKEditor'
 import { camelCaseToText } from '@/common/helpers'
@@ -1655,11 +1654,9 @@ describe('UI: AddNewProposalModal', () => {
           <MockQueryNodeProviders>
             <MockKeyringProvider>
               <ApiContext.Provider value={api}>
-                <BalancesContextProvider>
-                  <MembershipContext.Provider value={useMyMemberships}>
-                    <AddNewProposalModal />
-                  </MembershipContext.Provider>
-                </BalancesContextProvider>
+                <MembershipContext.Provider value={useMyMemberships}>
+                  <AddNewProposalModal />
+                </MembershipContext.Provider>
               </ApiContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>

--- a/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
@@ -179,7 +179,7 @@ describe('UI: AddNewProposalModal', () => {
     useMyMemberships.members = [getMember('alice'), getMember('bob')]
     useMyMemberships.setActive(getMember('alice'))
 
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     stubProposalConstants(api)
 
     createProposalTx = stubTransaction(api, 'api.tx.proposalsCodex.createProposal', 25)

--- a/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/AddNewProposalModal.test.tsx
@@ -7,8 +7,6 @@ import { MemoryRouter } from 'react-router'
 import { interpret } from 'xstate'
 
 import { MoveFundsModalCall } from '@/accounts/modals/MoveFoundsModal'
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { CurrencyName } from '@/app/constants/currency'
 import { CKEditorProps } from '@/common/components/CKEditor'
@@ -50,6 +48,7 @@ import { getMember } from '../../_mocks/members'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import {
+  stubAccounts,
   stubApi,
   stubConst,
   stubDefaultBalances,
@@ -151,7 +150,6 @@ describe('UI: AddNewProposalModal', () => {
   }
   const forumLeadId = workingGroups.find((group) => group.id === 'forumWorkingGroup')?.leadId
 
-  let useAccounts: UseAccounts
   let createProposalTx: any
   let batchTx: any
   let bindAccountTx: any
@@ -173,12 +171,7 @@ describe('UI: AddNewProposalModal', () => {
     seedApplication(APPLICATION_DATA, server.server)
     seedWorkers(server.server)
     updateWorkingGroups(server.server)
-
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
+    stubAccounts([alice, bob])
   })
 
   beforeEach(async () => {
@@ -1661,15 +1654,13 @@ describe('UI: AddNewProposalModal', () => {
         <ModalContext.Provider value={useModal}>
           <MockQueryNodeProviders>
             <MockKeyringProvider>
-              <AccountsContext.Provider value={useAccounts}>
-                <ApiContext.Provider value={api}>
-                  <BalancesContextProvider>
-                    <MembershipContext.Provider value={useMyMemberships}>
-                      <AddNewProposalModal />
-                    </MembershipContext.Provider>
-                  </BalancesContextProvider>
-                </ApiContext.Provider>
-              </AccountsContext.Provider>
+              <ApiContext.Provider value={api}>
+                <BalancesContextProvider>
+                  <MembershipContext.Provider value={useMyMemberships}>
+                    <AddNewProposalModal />
+                  </MembershipContext.Provider>
+                </BalancesContextProvider>
+              </ApiContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>
         </ModalContext.Provider>

--- a/packages/ui/test/proposals/modals/VoteForProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/VoteForProposalModal.test.tsx
@@ -74,7 +74,7 @@ describe('UI: Vote for Proposal Modal', () => {
   beforeEach(() => {
     tx = stubTransaction(api, 'api.tx.proposalsEngine.vote', 100)
     mockedTransactionFee.feeInfo = { transactionFee: new BN(100), canAfford: true }
-    stubDefaultBalances(api)
+    stubDefaultBalances()
   })
 
   it('Requirements verification', async () => {

--- a/packages/ui/test/proposals/modals/VoteForProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/VoteForProposalModal.test.tsx
@@ -4,7 +4,6 @@ import BN from 'bn.js'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
-import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { CKEditorProps } from '@/common/components/CKEditor'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
@@ -207,11 +206,9 @@ describe('UI: Vote for Proposal Modal', () => {
           <MockQueryNodeProviders>
             <MockKeyringProvider>
               <ApiContext.Provider value={api}>
-                <BalancesContextProvider>
-                  <MembershipContext.Provider value={useMyMemberships}>
-                    <VoteForProposalModal />
-                  </MembershipContext.Provider>
-                </BalancesContextProvider>
+                <MembershipContext.Provider value={useMyMemberships}>
+                  <VoteForProposalModal />
+                </MembershipContext.Provider>
               </ApiContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>

--- a/packages/ui/test/proposals/modals/VoteForProposalModal.test.tsx
+++ b/packages/ui/test/proposals/modals/VoteForProposalModal.test.tsx
@@ -4,8 +4,6 @@ import BN from 'bn.js'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { CKEditorProps } from '@/common/components/CKEditor'
 import { ApiContext } from '@/common/providers/api/context'
@@ -25,6 +23,7 @@ import { setupMockServer } from '../../_mocks/server'
 import { PROPOSAL_DATA } from '../../_mocks/server/seeds'
 import {
   currentStubErrorMessage,
+  stubAccounts,
   stubApi,
   stubDefaultBalances,
   stubTransaction,
@@ -62,8 +61,6 @@ describe('UI: Vote for Proposal Modal', () => {
     },
   }
 
-  let useAccounts: UseAccounts
-
   const server = setupMockServer({ noCleanupAfterEach: true })
 
   let tx: any
@@ -72,12 +69,7 @@ describe('UI: Vote for Proposal Modal', () => {
     await cryptoWaitReady()
     seedMembers(server.server, 2)
     seedProposal(PROPOSAL_DATA, server.server)
-
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
+    stubAccounts([alice, bob])
   })
 
   beforeEach(() => {
@@ -214,15 +206,13 @@ describe('UI: Vote for Proposal Modal', () => {
         <ModalContext.Provider value={useModal}>
           <MockQueryNodeProviders>
             <MockKeyringProvider>
-              <AccountsContext.Provider value={useAccounts}>
-                <ApiContext.Provider value={api}>
-                  <BalancesContextProvider>
-                    <MembershipContext.Provider value={useMyMemberships}>
-                      <VoteForProposalModal />
-                    </MembershipContext.Provider>
-                  </BalancesContextProvider>
-                </ApiContext.Provider>
-              </AccountsContext.Provider>
+              <ApiContext.Provider value={api}>
+                <BalancesContextProvider>
+                  <MembershipContext.Provider value={useMyMemberships}>
+                    <VoteForProposalModal />
+                  </MembershipContext.Provider>
+                </BalancesContextProvider>
+              </ApiContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>
         </ModalContext.Provider>

--- a/packages/ui/test/setup.ts
+++ b/packages/ui/test/setup.ts
@@ -1,6 +1,8 @@
 import '@testing-library/jest-dom'
 import BN from 'bn.js'
+import React from 'react'
 
+import { Balances } from '@/accounts/types'
 import { BN_ZERO } from '@/common/constants'
 import { UseTransaction } from '@/common/providers/transactionFees/context'
 
@@ -30,6 +32,19 @@ export const mockedTransactionFee: UseTransaction = {
 
 jest.mock('@/accounts/hooks/useTransactionFee', () => ({
   useTransactionFee: jest.fn(() => mockedTransactionFee),
+}))
+
+export const mockedMyBalances = jest.fn<Balances, []>(() => ({} as Balances))
+
+jest.mock('@/accounts/hooks/useMyBalances', () => ({
+  useMyBalances: () =>
+    new Proxy({} as Balances, {
+      get: mockedMyBalances,
+    }),
+}))
+
+jest.mock('@/accounts/providers/balances/provider', () => ({
+  BalancesContextProvider: ({ children }: { children: React.ReactNode }) => children,
 }))
 
 jest.mock('@/common/constants/numbers', () => ({

--- a/packages/ui/test/setup.ts
+++ b/packages/ui/test/setup.ts
@@ -67,19 +67,6 @@ jest.mock('@/accounts/providers/balances/provider', () => ({
   BalancesContextProvider: ({ children }: { children: React.ReactNode }) => children,
 }))
 
-jest.mock('@/accounts/providers/accounts/context', () => ({
-  AccountsContext: {
-    Provider: ({ children, value }: { children: React.ReactNode; value: UseAccounts }) => {
-      mockedUseMyAccounts.mockReturnValue(value)
-      const balance = mockedBalances()
-      if (balance) {
-        mockedMyBalances.mockReturnValue(Object.fromEntries(value.allAccounts.map(({ address }) => [address, balance])))
-      }
-      return children
-    },
-  },
-}))
-
 jest.mock('@/common/constants/numbers', () => ({
   ...jest.requireActual('@/common/constants/numbers'),
   JOY_DECIMAL_PLACES: 0,

--- a/packages/ui/test/setup.ts
+++ b/packages/ui/test/setup.ts
@@ -1,7 +1,6 @@
 import { BN_THOUSAND } from '@polkadot/util'
 import '@testing-library/jest-dom'
 import BN from 'bn.js'
-import React from 'react'
 
 import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { AddressToBalanceMap, Balances } from '@/accounts/types'
@@ -61,10 +60,6 @@ export const mockedMyBalances = jest.fn<AddressToBalanceMap | undefined, []>(() 
 
 jest.mock('@/accounts/hooks/useMyBalances', () => ({
   useMyBalances: mockedMyBalances,
-}))
-
-jest.mock('@/accounts/providers/balances/provider', () => ({
-  BalancesContextProvider: ({ children }: { children: React.ReactNode }) => children,
 }))
 
 jest.mock('@/common/constants/numbers', () => ({

--- a/packages/ui/test/setup.ts
+++ b/packages/ui/test/setup.ts
@@ -57,7 +57,7 @@ jest.mock('@/accounts/hooks/useBalance', () => ({
   useBalance: mockedBalances,
 }))
 
-export const mockedMyBalances = jest.fn<AddressToBalanceMap, []>(() => ({} as AddressToBalanceMap))
+export const mockedMyBalances = jest.fn<AddressToBalanceMap | undefined, []>(() => ({} as AddressToBalanceMap))
 
 jest.mock('@/accounts/hooks/useMyBalances', () => ({
   useMyBalances: mockedMyBalances,

--- a/packages/ui/test/working-groups/components/MyEarningsStat.test.tsx
+++ b/packages/ui/test/working-groups/components/MyEarningsStat.test.tsx
@@ -4,8 +4,6 @@ import { startOfToday, subDays } from 'date-fns'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { MembershipContext } from '@/memberships/providers/membership/context'
 import { MyMemberships } from '@/memberships/providers/membership/provider'
 import { seedApplication, seedEvent, seedMember, seedOpening, seedWorker } from '@/mocks/data'
@@ -17,17 +15,13 @@ import { getMember } from '../../_mocks/members'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import { APPLICATION_DATA, MEMBER_ALICE_DATA, OPENING_DATA, WORKER_DATA } from '../../_mocks/server/seeds'
+import { stubAccounts } from '../../_mocks/transactions'
 
 configure({ testIdAttribute: 'id' })
 
 describe('MyEarningsStat', () => {
   const mockServer = setupMockServer()
 
-  const useAccounts: UseAccounts = {
-    isLoading: false,
-    hasAccounts: true,
-    allAccounts: [alice, bob],
-  }
   const useMyMemberships: MyMemberships = {
     active: undefined,
     members: [getMember('alice'), getMember('bob')],
@@ -40,6 +34,7 @@ describe('MyEarningsStat', () => {
   }
 
   beforeAll(async () => {
+    stubAccounts([alice, bob])
     await cryptoWaitReady()
   })
 
@@ -98,11 +93,9 @@ describe('MyEarningsStat', () => {
       <MemoryRouter>
         <MockQueryNodeProviders>
           <MockKeyringProvider>
-            <AccountsContext.Provider value={useAccounts}>
-              <MembershipContext.Provider value={useMyMemberships}>
-                <MyEarningsStat />
-              </MembershipContext.Provider>
-            </AccountsContext.Provider>
+            <MembershipContext.Provider value={useMyMemberships}>
+              <MyEarningsStat />
+            </MembershipContext.Provider>
           </MockKeyringProvider>
         </MockQueryNodeProviders>
       </MemoryRouter>

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -105,7 +105,7 @@ describe('UI: ApplyForRoleModal', () => {
     useMyMemberships.setActive(getMember('alice'))
 
     stubConst(api, 'forumWorkingGroup.rewardPeriod', createType('u32', 14410))
-    stubBalances(api, {
+    stubBalances({
       available: 2000,
     })
     applyTransaction = stubTransaction(api, 'api.tx.forumWorkingGroup.applyOnOpening')

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -8,7 +8,6 @@ import { MemoryRouter } from 'react-router'
 import { interpret } from 'xstate'
 
 import { MoveFundsModalCall } from '@/accounts/modals/MoveFoundsModal'
-import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { createType } from '@/common/model/createType'
 import { metadataFromBytes } from '@/common/model/JoystreamNode/metadataFromBytes'
 import { getSteps } from '@/common/model/machines/getSteps'
@@ -485,9 +484,7 @@ describe('UI: ApplyForRoleModal', () => {
               <MockKeyringProvider>
                 <ApiContext.Provider value={api}>
                   <MembershipContext.Provider value={useMyMemberships}>
-                    <BalancesContextProvider>
-                      <ApplyForRoleModal />
-                    </BalancesContextProvider>
+                    <ApplyForRoleModal />
                   </MembershipContext.Provider>
                 </ApiContext.Provider>
               </MockKeyringProvider>

--- a/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ApplyForRoleModal.test.tsx
@@ -8,8 +8,6 @@ import { MemoryRouter } from 'react-router'
 import { interpret } from 'xstate'
 
 import { MoveFundsModalCall } from '@/accounts/modals/MoveFoundsModal'
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { BalancesContextProvider } from '@/accounts/providers/balances/provider'
 import { createType } from '@/common/model/createType'
 import { metadataFromBytes } from '@/common/model/JoystreamNode/metadataFromBytes'
@@ -35,6 +33,7 @@ import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/provid
 import { setupMockServer } from '../../_mocks/server'
 import { OPENING_DATA } from '../../_mocks/server/seeds'
 import {
+  stubAccounts,
   stubApi,
   stubBalances,
   stubConst,
@@ -79,7 +78,6 @@ describe('UI: ApplyForRoleModal', () => {
     },
   }
 
-  let useAccounts: UseAccounts
   let batchTx: any
   let bindAccountTx: any
   let applyTransaction: any
@@ -94,12 +92,7 @@ describe('UI: ApplyForRoleModal', () => {
     seedWorkingGroups(server.server)
     seedOpeningStatuses(server.server)
     seedOpening(OPENING_DATA, server.server)
-
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
+    stubAccounts([alice, bob])
   })
 
   beforeEach(async () => {
@@ -148,7 +141,7 @@ describe('UI: ApplyForRoleModal', () => {
     it('No active member', async () => {
       useMyMemberships.active = undefined
 
-      renderModal()
+      await renderModal()
 
       expect(useModal.showModal).toBeCalledWith({
         modal: 'SwitchMember',
@@ -170,7 +163,7 @@ describe('UI: ApplyForRoleModal', () => {
       useModal.modalData = { opening }
       batchTx = stubTransaction(api, 'api.tx.forumWorkingGroup.applyOnOpening', 10_000)
       mockedTransactionFee.feeInfo = { canAfford: false, transactionFee: new BN(10000) }
-      renderModal()
+      await renderModal()
 
       const moveFundsModalCall: MoveFundsModalCall = {
         modal: 'MoveFundsModal',
@@ -185,21 +178,21 @@ describe('UI: ApplyForRoleModal', () => {
   })
 
   it('Renders a modal', async () => {
-    renderModal()
+    await renderModal()
 
     expect(await screen.findByText('Applying for role')).toBeDefined()
   })
 
   describe('Stake step', () => {
     it('Empty fields', async () => {
-      renderModal()
+      await renderModal()
 
       const button = await getNextStepButton()
       expect(button).toBeDisabled()
     })
 
     it('Too low stake', async () => {
-      renderModal()
+      await renderModal()
 
       await selectFromDropdown('Select account for Staking', 'alice')
       await fillFieldByLabel(/Select amount for staking/i, '50')
@@ -209,7 +202,7 @@ describe('UI: ApplyForRoleModal', () => {
     })
 
     it('Valid fields', async () => {
-      renderModal()
+      await renderModal()
 
       await selectFromDropdown('Select account for Staking', 'alice')
       await fillFieldByLabel(/Select amount for staking/i, '2000')
@@ -483,25 +476,25 @@ describe('UI: ApplyForRoleModal', () => {
     fireEvent.blur(amountInput)
   }
 
-  function renderModal() {
-    return render(
-      <MemoryRouter>
-        <ModalContext.Provider value={useModal}>
-          <MockQueryNodeProviders>
-            <MockKeyringProvider>
-              <ApiContext.Provider value={api}>
-                <AccountsContext.Provider value={useAccounts}>
+  async function renderModal() {
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <ModalContext.Provider value={useModal}>
+            <MockQueryNodeProviders>
+              <MockKeyringProvider>
+                <ApiContext.Provider value={api}>
                   <MembershipContext.Provider value={useMyMemberships}>
                     <BalancesContextProvider>
                       <ApplyForRoleModal />
                     </BalancesContextProvider>
                   </MembershipContext.Provider>
-                </AccountsContext.Provider>
-              </ApiContext.Provider>
-            </MockKeyringProvider>
-          </MockQueryNodeProviders>
-        </ModalContext.Provider>
-      </MemoryRouter>
-    )
+                </ApiContext.Provider>
+              </MockKeyringProvider>
+            </MockQueryNodeProviders>
+          </ModalContext.Provider>
+        </MemoryRouter>
+      )
+    })
   }
 })

--- a/packages/ui/test/working-groups/modals/ChangeAccountModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ChangeAccountModal.test.tsx
@@ -76,7 +76,7 @@ describe('UI: ChangeRoleModal', () => {
 
   beforeEach(async () => {
     useMyMemberships.setActive(getMember('alice'))
-    stubDefaultBalances(api)
+    stubDefaultBalances()
   })
 
   describe('Change role account - authorize step', () => {

--- a/packages/ui/test/working-groups/modals/ChangeAccountModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ChangeAccountModal.test.tsx
@@ -3,8 +3,6 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { createType } from '@/common/model/createType'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
@@ -27,6 +25,7 @@ import { setupMockServer } from '../../_mocks/server'
 import { APPLICATION_DATA, OPENING_DATA, WORKER_DATA } from '../../_mocks/server/seeds'
 import {
   currentStubErrorMessage,
+  stubAccounts,
   stubApi,
   stubDefaultBalances,
   stubTransaction,
@@ -59,7 +58,6 @@ describe('UI: ChangeRoleModal', () => {
     },
   }
 
-  let useAccounts: UseAccounts
   let transaction: any
 
   const server = setupMockServer({ noCleanupAfterEach: true })
@@ -67,13 +65,7 @@ describe('UI: ChangeRoleModal', () => {
   beforeAll(async () => {
     jest.spyOn(console, 'log').mockImplementation()
     await cryptoWaitReady()
-
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice, bob],
-    }
-
+    stubAccounts([alice, bob])
     seedMembers(server.server)
     seedWorkingGroups(server.server)
     seedOpeningStatuses(server.server)
@@ -149,13 +141,11 @@ describe('UI: ChangeRoleModal', () => {
         <ModalContext.Provider value={useModal}>
           <MockQueryNodeProviders>
             <MockKeyringProvider>
-              <AccountsContext.Provider value={useAccounts}>
-                <MembershipContext.Provider value={useMyMemberships}>
-                  <ApiContext.Provider value={api}>
-                    <ChangeAccountModal />
-                  </ApiContext.Provider>
-                </MembershipContext.Provider>
-              </AccountsContext.Provider>
+              <MembershipContext.Provider value={useMyMemberships}>
+                <ApiContext.Provider value={api}>
+                  <ChangeAccountModal />
+                </ApiContext.Provider>
+              </MembershipContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>
         </ModalContext.Provider>

--- a/packages/ui/test/working-groups/modals/IncreaseWorkerStakeModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/IncreaseWorkerStakeModal.test.tsx
@@ -3,7 +3,6 @@ import { configure, fireEvent, render, screen } from '@testing-library/react'
 import BN from 'bn.js'
 import React from 'react'
 
-import { Account } from '@/accounts/types'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
 import { IncreaseWorkerStakeModal } from '@/working-groups/modals/IncreaseWorkerStakeModal'
@@ -12,6 +11,7 @@ import { getButton } from '../../_helpers/getButton'
 import { alice, bob } from '../../_mocks/keyring'
 import { MockApolloProvider, MockKeyringProvider } from '../../_mocks/providers'
 import {
+  stubAccounts,
   stubApi,
   stubDefaultBalances,
   stubTransaction,
@@ -20,17 +20,6 @@ import {
 } from '../../_mocks/transactions'
 
 configure({ testIdAttribute: 'id' })
-
-const useMyAccounts: { hasAccounts: boolean; allAccounts: Account[] } = {
-  hasAccounts: true,
-  allAccounts: [],
-}
-
-jest.mock('@/accounts/hooks/useMyAccounts', () => {
-  return {
-    useMyAccounts: () => useMyAccounts,
-  }
-})
 
 describe('UI: IncreaseWorkerStakeModal', () => {
   const api = stubApi()
@@ -56,7 +45,7 @@ describe('UI: IncreaseWorkerStakeModal', () => {
 
   beforeAll(async () => {
     await cryptoWaitReady()
-    useMyAccounts.allAccounts.push(alice, bob)
+    stubAccounts([alice, bob])
   })
 
   beforeEach(async () => {

--- a/packages/ui/test/working-groups/modals/IncreaseWorkerStakeModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/IncreaseWorkerStakeModal.test.tsx
@@ -49,7 +49,7 @@ describe('UI: IncreaseWorkerStakeModal', () => {
   })
 
   beforeEach(async () => {
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     transfer = stubTransaction(api, 'api.tx.storageWorkingGroup.increaseStake')
   })
 

--- a/packages/ui/test/working-groups/modals/LeaveRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/LeaveRoleModal.test.tsx
@@ -68,7 +68,7 @@ describe('UI: LeaveRoleModal', () => {
 
   beforeEach(async () => {
     useMyMemberships.setActive(getMember('alice'))
-    stubDefaultBalances(api)
+    stubDefaultBalances()
     transaction = stubTransaction(api, 'api.tx.forumWorkingGroup.leaveRole')
   })
 

--- a/packages/ui/test/working-groups/modals/LeaveRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/LeaveRoleModal.test.tsx
@@ -3,8 +3,6 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { MemoryRouter } from 'react-router'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { createType } from '@/common/model/createType'
 import { ApiContext } from '@/common/providers/api/context'
 import { ModalContext } from '@/common/providers/modal/context'
@@ -24,6 +22,7 @@ import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/provid
 import { setupMockServer } from '../../_mocks/server'
 import { APPLICATION_DATA, OPENING_DATA, WORKER_DATA } from '../../_mocks/server/seeds'
 import {
+  stubAccounts,
   stubApi,
   stubDefaultBalances,
   stubTransaction,
@@ -50,7 +49,6 @@ describe('UI: LeaveRoleModal', () => {
     },
   }
 
-  let useAccounts: UseAccounts
   let transaction: any
 
   const server = setupMockServer({ noCleanupAfterEach: true })
@@ -65,12 +63,7 @@ describe('UI: LeaveRoleModal', () => {
     seedOpening(OPENING_DATA, server.server)
     seedApplication(APPLICATION_DATA, server.server)
     seedWorker(WORKER_DATA, server.server)
-
-    useAccounts = {
-      isLoading: false,
-      hasAccounts: true,
-      allAccounts: [alice],
-    }
+    stubAccounts([alice])
   })
 
   beforeEach(async () => {
@@ -122,15 +115,13 @@ describe('UI: LeaveRoleModal', () => {
       <MemoryRouter>
         <MockQueryNodeProviders>
           <MockKeyringProvider>
-            <AccountsContext.Provider value={useAccounts}>
-              <MembershipContext.Provider value={useMyMemberships}>
-                <ApiContext.Provider value={api}>
-                  <ModalContext.Provider value={modalContext}>
-                    <LeaveRoleModal />
-                  </ModalContext.Provider>
-                </ApiContext.Provider>
-              </MembershipContext.Provider>
-            </AccountsContext.Provider>
+            <MembershipContext.Provider value={useMyMemberships}>
+              <ApiContext.Provider value={api}>
+                <ModalContext.Provider value={modalContext}>
+                  <LeaveRoleModal />
+                </ModalContext.Provider>
+              </ApiContext.Provider>
+            </MembershipContext.Provider>
           </MockKeyringProvider>
         </MockQueryNodeProviders>
       </MemoryRouter>

--- a/packages/ui/test/working-groups/pages/MyRoles.test.tsx
+++ b/packages/ui/test/working-groups/pages/MyRoles.test.tsx
@@ -4,8 +4,6 @@ import React from 'react'
 import { MemoryRouter } from 'react-router'
 import { Route } from 'react-router-dom'
 
-import { AccountsContext } from '@/accounts/providers/accounts/context'
-import { UseAccounts } from '@/accounts/providers/accounts/provider'
 import { MyRole } from '@/app/pages/WorkingGroups/MyRoles/MyRole'
 import { createType } from '@/common/model/createType'
 import { ApiContext } from '@/common/providers/api/context'
@@ -22,16 +20,11 @@ import { getMember } from '../../_mocks/members'
 import { MockKeyringProvider, MockQueryNodeProviders } from '../../_mocks/providers'
 import { setupMockServer } from '../../_mocks/server'
 import { APPLICATION_DATA, OPENING_DATA, WORKER_DATA } from '../../_mocks/server/seeds'
-import { stubApi, stubConst } from '../../_mocks/transactions'
+import { stubAccounts, stubApi, stubConst } from '../../_mocks/transactions'
 
 describe('UI: My Role Page', () => {
   const mockServer = setupMockServer()
 
-  const useAccounts: UseAccounts = {
-    isLoading: false,
-    hasAccounts: true,
-    allAccounts: [alice, bob],
-  }
   const useMyMemberships: MyMemberships = {
     active: undefined,
     members: [getMember('alice'), getMember('bob')],
@@ -46,6 +39,7 @@ describe('UI: My Role Page', () => {
   stubConst(api, 'forumWorkingGroup.rewardPeriod', createType('u32', 14410))
 
   beforeAll(async () => {
+    stubAccounts([alice, bob])
     await cryptoWaitReady()
   })
 
@@ -112,13 +106,11 @@ describe('UI: My Role Page', () => {
         <MemoryRouter initialEntries={[`working-groups/my-roles/${WORKER_DATA.id}`]}>
           <MockQueryNodeProviders>
             <MockKeyringProvider>
-              <AccountsContext.Provider value={useAccounts}>
-                <MembershipContext.Provider value={useMyMemberships}>
-                  <Route path="working-groups/my-roles/:id">
-                    <MyRole />
-                  </Route>
-                </MembershipContext.Provider>
-              </AccountsContext.Provider>
+              <MembershipContext.Provider value={useMyMemberships}>
+                <Route path="working-groups/my-roles/:id">
+                  <MyRole />
+                </Route>
+              </MembershipContext.Provider>
             </MockKeyringProvider>
           </MockQueryNodeProviders>
         </MemoryRouter>


### PR DESCRIPTION
Part of #2798

The original goal was to not return a `{}` (implying there is no balances) before the api is connected. But it's now mostly a tests refactor.