### PR TITLE
changed quorum bar with council's size

### DIFF
--- a/packages/ui/src/proposals/components/StatisticsPreview/ProposalStatistics.stories.tsx
+++ b/packages/ui/src/proposals/components/StatisticsPreview/ProposalStatistics.stories.tsx
@@ -70,6 +70,7 @@ Default.args = {
   approve: 2,
   reject: 2,
   slash: 0,
+  abstain: 3,
   councilSize: 20,
   unknownConstants: false,
   approvalQuorumPercentage: 30,

--- a/packages/ui/src/proposals/components/StatisticsPreview/ProposalStatistics.stories.tsx
+++ b/packages/ui/src/proposals/components/StatisticsPreview/ProposalStatistics.stories.tsx
@@ -14,6 +14,7 @@ export default {
     approve: voteControl,
     reject: voteControl,
     slash: voteControl,
+    abstain: voteControl,
     councilSize: { control: { type: 'range', min: 0, max: 20 } },
     approvalQuorumPercentage: percentageControl,
     approvalThresholdPercentage: percentageControl,

--- a/packages/ui/src/proposals/components/StatisticsPreview/ProposalStatistics.tsx
+++ b/packages/ui/src/proposals/components/StatisticsPreview/ProposalStatistics.tsx
@@ -13,7 +13,7 @@ interface ProposalStatisticsProps {
   constants: ProposalConstants | null
 }
 export const ProposalStatistics = ({ voteCount, constants }: ProposalStatisticsProps) => {
-  const { approve, slash, total, remain } = voteCount
+  const { approve, slash, total, remain, abstain } = voteCount
   const councilSize = isDefined(remain) ? total + remain : undefined
   const {
     approvalQuorumPercentage = undefined,
@@ -31,9 +31,12 @@ export const ProposalStatistics = ({ voteCount, constants }: ProposalStatisticsP
   const approvalQuorum = councilSize && approvalQuorumRatio && Math.ceil(councilSize * approvalQuorumRatio)
   const slashingQuorum = councilSize && slashingQuorumRatio && Math.ceil(councilSize * slashingQuorumRatio)
 
-  const quorumRatio = councilSize ? total / councilSize : 0
-  const approvalRatio = total && approve / total
-  const slashingRatio = total && slash / total
+  const quorumRatio = councilSize ? (total - abstain) / councilSize : 0
+  const abstainRatio = councilSize ? abstain / councilSize : 0
+  const remainRatio = councilSize ? (isDefined(remain) ? remain : 0) / councilSize : 0
+
+  const approvalRatio = total - abstain && approve / (total - abstain)
+  const slashingRatio = total - abstain && slash / (total - abstain)
 
   return (
     <Statistics>
@@ -44,8 +47,8 @@ export const ProposalStatistics = ({ voteCount, constants }: ProposalStatisticsP
           tooltipLinkURL={tooltipLinkURL}
           value={quorumRatio}
           threshold={approvalQuorumRatio}
-          numerator={total}
-          denominator={`${approvalQuorum ?? '-'} vote${plural(approvalQuorum)}`}
+          numerator={total - abstain}
+          denominator={`${councilSize ?? '-'} vote${plural(approvalQuorum)}`}
         />
         <StatisticBar
           title="Approval Threshold"
@@ -65,8 +68,8 @@ export const ProposalStatistics = ({ voteCount, constants }: ProposalStatisticsP
           tooltipLinkURL={tooltipLinkURL}
           value={quorumRatio}
           threshold={slashingQuorumRatio}
-          numerator={total}
-          denominator={`max ${slashingQuorum ?? '-'} vote${plural(slashingQuorum)}`}
+          numerator={total - abstain}
+          denominator={`${councilSize ?? '-'} vote${plural(slashingQuorum)}`}
         />
         <StatisticBar
           title="Slashing Threshold"
@@ -75,7 +78,25 @@ export const ProposalStatistics = ({ voteCount, constants }: ProposalStatisticsP
           value={slashingRatio}
           threshold={slashingThresholdRatio}
           numerator={`${Math.floor(slashingRatio * 100)}%`}
-          denominator={`max ${slashingThresholdRatio?.toLocaleString('en', { style: 'percent' }) ?? '-'}`}
+          denominator={`${slashingThresholdRatio?.toLocaleString('en', { style: 'percent' }) ?? '-'}`}
+        />
+      </TwoRowStatistic>
+      <TwoRowStatistic>
+        <StatisticBar
+          title="Abstained"
+          tooltipText="Number of votes abstained"
+          tooltipLinkURL={tooltipLinkURL}
+          value={abstainRatio}
+          numerator={abstain}
+          denominator={`${councilSize ?? '-'} vote${plural(slashingQuorum)}`}
+        />
+        <StatisticBar
+          title="Remained"
+          tooltipText="Remained votes"
+          tooltipLinkURL={tooltipLinkURL}
+          value={remainRatio}
+          numerator={remain}
+          denominator={`${councilSize ?? '-'} vote${plural(slashingQuorum)}`}
         />
       </TwoRowStatistic>
     </Statistics>

--- a/packages/ui/src/proposals/components/StatisticsPreview/ProposalStatistics.tsx
+++ b/packages/ui/src/proposals/components/StatisticsPreview/ProposalStatistics.tsx
@@ -32,9 +32,6 @@ export const ProposalStatistics = ({ voteCount, constants }: ProposalStatisticsP
   const slashingQuorum = councilSize && slashingQuorumRatio && Math.ceil(councilSize * slashingQuorumRatio)
 
   const quorumRatio = councilSize ? (total - abstain) / councilSize : 0
-  const abstainRatio = councilSize ? abstain / councilSize : 0
-  const remainRatio = councilSize ? (isDefined(remain) ? remain : 0) / councilSize : 0
-
   const approvalRatio = total - abstain && approve / (total - abstain)
   const slashingRatio = total - abstain && slash / (total - abstain)
 
@@ -79,24 +76,6 @@ export const ProposalStatistics = ({ voteCount, constants }: ProposalStatisticsP
           threshold={slashingThresholdRatio}
           numerator={`${Math.floor(slashingRatio * 100)}%`}
           denominator={`${slashingThresholdRatio?.toLocaleString('en', { style: 'percent' }) ?? '-'}`}
-        />
-      </TwoRowStatistic>
-      <TwoRowStatistic>
-        <StatisticBar
-          title="Abstained"
-          tooltipText="Number of votes abstained"
-          tooltipLinkURL={tooltipLinkURL}
-          value={abstainRatio}
-          numerator={abstain}
-          denominator={`${councilSize ?? '-'} vote${plural(slashingQuorum)}`}
-        />
-        <StatisticBar
-          title="Remained"
-          tooltipText="Remained votes"
-          tooltipLinkURL={tooltipLinkURL}
-          value={remainRatio}
-          numerator={remain}
-          denominator={`${councilSize ?? '-'} vote${plural(slashingQuorum)}`}
         />
       </TwoRowStatistic>
     </Statistics>


### PR DESCRIPTION
Fixed the issue : [USERSNAP] Approval / Slashing votes bars show all votes #2715
https://github.com/Joystream/pioneer/issues/2715

changed the approval / slash quorum bar. 
The following is the formula for those bars.
- approval quorum bar :  
blue bar indicates approve / councilSize & quorum ratio
- slash quorum bar
blue bar indicates slash / councilSize & quorum ratio
- approval threshold bar :
blue bar indicates approve / total (councilsize - remain) & thresold ratio
- slash threshold bar :
blue bar indicates slash / total (councilSize - remain) & thresold ratio

I checked the notes about reject bar, so should i add new one reject bar or twos like above?