### PR TITLE
Updated text "Blog Posts" to "Forum Posts"

### DIFF
--- a/packages/ui/src/memberships/components/MemberProfile/MemberDetails.tsx
+++ b/packages/ui/src/memberships/components/MemberProfile/MemberDetails.tsx
@@ -124,7 +124,7 @@ export const MemberDetails = React.memo(({ member }: Props) => {
         <SidePaneText>{initiatingLeaving}</SidePaneText>
       </SidePaneRow>
       <SidePaneRow>
-        <SidePaneLabel text="Blog posts" />
+        <SidePaneLabel text="Forum posts" />
         <SidePaneText>{blogPosts}</SidePaneText>
       </SidePaneRow>
     </SidePaneTable>


### PR DESCRIPTION
Changed the "Blog Posts" text to "Forum posts" in the MemberDetails.tsx file from issue [#3471](https://github.com/Joystream/pioneer/issues/3471)