### PR TITLE
🗃️ Fix votes storage

### DIFF
--- a/packages/ui/src/common/hooks/useLocalStorage.ts
+++ b/packages/ui/src/common/hooks/useLocalStorage.ts
@@ -1,3 +1,4 @@
+import { isFunction } from 'lodash'
 import { useCallback, useEffect, useState } from 'react'
 
 const getItem = (key?: string) => {
@@ -32,21 +33,22 @@ const setItem = (key?: string, value?: any) => {
 }
 
 export const useLocalStorage = <T>(key?: string) => {
-  const [value, setValue] = useState<T | undefined>(() => {
+  const [state, setState] = useState<T | undefined>(() => {
     return getItem(key)
   })
 
   useEffect(() => {
-    setValue(getItem(key))
+    setState(getItem(key))
   }, [key])
 
-  const set = useCallback(
-    (value: T) => {
-      setValue(value)
+  const dispatch = useCallback(
+    (setStateAction: T | ((prevState?: T) => T)) => {
+      const value = isFunction(setStateAction) ? setStateAction(getItem(key)) : setStateAction
+      setState(value)
       setItem(key, value)
     },
     [key]
   )
 
-  return [value, set] as const
+  return [state, dispatch] as const
 }

--- a/packages/ui/src/council/hooks/useCommitment.ts
+++ b/packages/ui/src/council/hooks/useCommitment.ts
@@ -12,11 +12,11 @@ export interface VotingAttempt {
   optionId: string
 }
 
-export const useCommitment = (accountId: string, candidateId: string) => {
+export const useCommitment = (accountId: string | undefined, candidateId: string) => {
   const { candidate } = useCandidate(candidateId)
 
   const vote = useMemo(() => {
-    if (!candidate) return
+    if (!accountId || !candidate) return
 
     // See https://polkadot.js.org/docs/util-crypto/examples/encrypt-decrypt
     const salt = randomAsHex()

--- a/packages/ui/src/council/hooks/useCommitment.ts
+++ b/packages/ui/src/council/hooks/useCommitment.ts
@@ -32,11 +32,11 @@ export const useCommitment = (accountId: string | undefined, candidateId: string
   }, [accountId, candidate?.id])
 
   const [isVoteStored, setIsVoteStored] = useState(false)
-  const [votingAttempts, setVotingAttempts] = useLocalStorage<VotingAttempt[]>(vote?.key)
+  const [, updateVotingAttempts] = useLocalStorage<VotingAttempt[]>(vote?.key)
   useEffect(() => {
     if (!vote) return
 
-    setVotingAttempts([...(votingAttempts ?? []), vote.value])
+    updateVotingAttempts((attempts = []) => [...attempts, vote.value])
     setIsVoteStored(true)
   }, [vote?.key, vote?.value])
 

--- a/packages/ui/src/council/modals/VoteForCouncil/VoteForCouncilModal.tsx
+++ b/packages/ui/src/council/modals/VoteForCouncil/VoteForCouncilModal.tsx
@@ -22,7 +22,7 @@ import { VoteForCouncilSuccessModal } from './VoteForCouncilSuccessModal'
 export const VoteForCouncilModal = () => {
   const [state, send] = useMachine(VoteForCouncilMachine)
   const { showModal, hideModal, modalData } = useModal<VoteForCouncilModalCall>()
-  const { commitment, isVoteStored } = useCommitment(state.context.account?.address ?? '', modalData.id)
+  const { commitment, isVoteStored } = useCommitment(state.context.account?.address, modalData.id)
 
   const { api } = useApi()
 


### PR DESCRIPTION
- #3711 

I'm guessing that in the issue multiple tabs were opened so the local storage item kept on getting overridden (that's the source of most local storage issue). The empty `accountId` entry was due the commitment first getting calculated before the staking account was set.