### PR TITLE
fix: avg stake tooltip typos and link

### DIFF
--- a/packages/ui/src/app/pages/WorkingGroups/WorkingGroup/OpeningsTab.tsx
+++ b/packages/ui/src/app/pages/WorkingGroups/WorkingGroup/OpeningsTab.tsx
@@ -53,10 +53,9 @@ export const OpeningsTab = ({ workingGroup }: Props) => {
           title="Avg stake"
           tooltipText={
             <>
-              If funds are insufficient over payout periods, the working group can incur a debt, which is owed to
-              workers.{' '}
+              Average stake size by members undertaking the roles of workers and the lead in this group.{' '}
               <TooltipExternalLink
-                href="https://joystream.gitbook.io/joystream-handbook/governance/working-groups#staking"
+                href="https://joystream.gitbook.io/testnet-workspace/system/working-groups?q=lock#staking"
                 target="_blank"
               >
                 <TextMedium>Link</TextMedium> <LinkSymbol />


### PR DESCRIPTION
Fixes https://github.com/Joystream/pioneer/issues/2929