### PR TITLE
Fix: Hide delete button for `ThreadStatusModerated` (#3266)

### DIFF
--- a/packages/ui/src/common/components/page/PageTitle.tsx
+++ b/packages/ui/src/common/components/page/PageTitle.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components'
 
-export const PageTitle = styled.h2<{ $isRemovedThread?: boolean }>`
+export const PageTitle = styled.h2<{ $isRemovedOrModerated?: boolean }>`
   margin-right: auto;
   text-transform: capitalize;
   display: -webkit-box;
@@ -8,12 +8,12 @@ export const PageTitle = styled.h2<{ $isRemovedThread?: boolean }>`
   -webkit-box-orient: vertical;
   -moz-box-orient: vertical;
   overflow: hidden;
-  ${({ $isRemovedThread }) =>
-    $isRemovedThread &&
+  ${({ $isRemovedOrModerated }) =>
+    $isRemovedOrModerated &&
     css`
       text-decoration-line: line-through;
     `}
 `
 PageTitle.defaultProps = {
-  $isRemovedThread: false,
+  $isRemovedOrModerated: false,
 }

--- a/packages/ui/src/forum/components/Thread/ThreadTitle.tsx
+++ b/packages/ui/src/forum/components/Thread/ThreadTitle.tsx
@@ -35,8 +35,8 @@ export const ThreadTitle = ({ thread }: ThreadTitleProps) => {
     return thread && active && thread.authorId === active.id
   }, [thread, active])
 
-  const isRemovedThread = useMemo(() => {
-    return thread.status.__typename === 'ThreadStatusRemoved'
+  const isRemovedOrModerated = useMemo(() => {
+    return ['ThreadStatusModerated', 'ThreadStatusRemoved'].includes(thread.status.__typename)
   }, [thread.status.__typename])
 
   const formInitializer: TitleFormFields = {
@@ -78,7 +78,7 @@ export const ThreadTitle = ({ thread }: ThreadTitleProps) => {
 
   return (
     <>
-      {!isEditTitle && <PageTitle $isRemovedThread={isRemovedThread}>{fields.initialTitle}</PageTitle>}
+      {!isEditTitle && <PageTitle $isRemovedOrModerated={isRemovedOrModerated}>{fields.initialTitle}</PageTitle>}
       {isEditTitle && (
         <EditTitleWrapper>
           <EditTitleInputComponent inputSize="m" onSubmit={() => submitTitle(fields.title)}>
@@ -104,12 +104,12 @@ export const ThreadTitle = ({ thread }: ThreadTitleProps) => {
           </EditTitleInputComponent>
         </EditTitleWrapper>
       )}
-      {isMyThread && !isEditTitle && !isRemovedThread && (
+      {isMyThread && !isEditTitle && !isRemovedOrModerated && (
         <ActionButtonWrapper onClick={toggleEditTitle} size="small" square>
           <EditSymbol />
         </ActionButtonWrapper>
       )}
-      {isMyThread && !isRemovedThread && (
+      {isMyThread && !isRemovedOrModerated && (
         <ActionButtonWrapper onClick={() => deleteThread()} size="small" square>
           <DeleteIcon />
         </ActionButtonWrapper>


### PR DESCRIPTION
Fixes https://github.com/Joystream/pioneer/issues/3266