### PR TITLE
Show withdrawn Applications on Opening stats (#2404)

### DIFF
--- a/packages/ui/src/app/pages/WorkingGroups/WorkingGroupsOpening.tsx
+++ b/packages/ui/src/app/pages/WorkingGroups/WorkingGroupsOpening.tsx
@@ -31,6 +31,7 @@ import { useModal } from '@/common/hooks/useModal'
 import { getUrl } from '@/common/utils/getUrl'
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 import { ApplicantsList } from '@/working-groups/components/ApplicantsList'
+import { Withdrawn } from '@/working-groups/components/Applications/Withdrawn'
 import { ApplicationStatusWrapper } from '@/working-groups/components/ApplicationStatusWrapper'
 import { OpeningIcon } from '@/working-groups/components/OpeningIcon'
 import { MappedStatuses, OpeningStatuses, WorkingGroupsRoutes } from '@/working-groups/constants'
@@ -46,22 +47,18 @@ export const WorkingGroupOpening = () => {
   const { active: activeMembership } = useMyMemberships()
   const { isLoading, opening } = useOpening(urlParamToOpeningId(id))
 
-  const activeApplications = useMemo(() => {
-    if (opening) {
-      return opening.applications?.filter((application) => application.status !== 'ApplicationStatusWithdrawn')
-    }
-  }, opening?.applications)
-
-  const hiringApplication = useMemo(() => {
-    if (activeApplications) {
-      return activeApplications.find(({ status }) => status === 'ApplicationStatusAccepted')
-    }
-  }, [opening?.id])
-  const myApplication = useMemo(() => {
-    if (activeApplications) {
-      return activeApplications.find(({ id }) => id === activeMembership?.id)
-    }
-  }, [opening?.id, activeMembership?.id])
+  const activeApplications = useMemo(
+    () => opening?.applications?.filter((application) => application.status !== 'ApplicationStatusWithdrawn'),
+    [opening?.applications]
+  )
+  const hiringApplication = useMemo(
+    () => activeApplications?.find(({ status }) => status === 'ApplicationStatusAccepted'),
+    [opening?.id]
+  )
+  const myApplication = useMemo(
+    () => activeApplications?.find(({ id }) => id === activeMembership?.id),
+    [opening?.id, activeMembership?.id]
+  )
   const rewardPeriod = useRewardPeriod(opening?.groupId)
 
   if (isLoading || !opening) {
@@ -200,7 +197,7 @@ const ApplicationStats = ({
       <StatiscticContentColumn>
         <StatisticHeader title="Applicants" />
         <NumericValue>
-          {applicants} {hiring.current > applicants && <> ({hiring.current - applicants}</>}
+          {hiring.current} <Withdrawn current={hiring.current} total={applicants} />
         </NumericValue>
       </StatiscticContentColumn>
       {status === OpeningStatuses.FILLED || status === OpeningStatuses.CANCELLED ? (

--- a/packages/ui/src/app/pages/WorkingGroups/WorkingGroupsOpening.tsx
+++ b/packages/ui/src/app/pages/WorkingGroups/WorkingGroupsOpening.tsx
@@ -199,7 +199,9 @@ const ApplicationStats = ({
     <MultiColumnsStatistic>
       <StatiscticContentColumn>
         <StatisticHeader title="Applicants" />
-        <NumericValue>{applicants}</NumericValue>
+        <NumericValue>
+          {applicants} {hiring.current > applicants && <> ({hiring.current - applicants}</>}
+        </NumericValue>
       </StatiscticContentColumn>
       {status === OpeningStatuses.FILLED || status === OpeningStatuses.CANCELLED ? (
         <StatiscticContentColumn>

--- a/packages/ui/src/working-groups/components/Applications/Withdrawn.tsx
+++ b/packages/ui/src/working-groups/components/Applications/Withdrawn.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export const Withdrawn = (props: { current: number; total: number }) => {
+  const { current, total } = props
+  const withdrawn = total - current
+  return current && withdrawn > 0 ? <> / {withdrawn}</> : <></>
+}

--- a/packages/ui/src/working-groups/components/OpeningsList/Opening/OpeningDetails.tsx
+++ b/packages/ui/src/working-groups/components/OpeningsList/Opening/OpeningDetails.tsx
@@ -23,6 +23,7 @@ import { groupNameToURLParam } from '@/working-groups/model/workingGroupName'
 
 export const OpeningDetails = ({ opening, onClick, past }: OpeningListItemProps) => {
   const { showModal } = useModal()
+  const { applicants, hiring } = opening
   const rewardPeriod = useRewardPeriod(opening.groupId)
   const groupName = groupNameToURLParam(nameMapping(opening.groupName))
   const openingRoute = `/working-groups/openings/${groupName}-${opening.runtimeId}`
@@ -49,7 +50,7 @@ export const OpeningDetails = ({ opening, onClick, past }: OpeningListItemProps)
               {past && (
                 <StatiscticContentColumn>
                   <TextBig value bold>
-                    {opening.hiring.current}
+                    {applicants} {hiring.current > applicants && <> ({hiring.current - applicants}</>}
                   </TextBig>
                   <Subscription>Hired</Subscription>
                 </StatiscticContentColumn>

--- a/packages/ui/src/working-groups/components/OpeningsList/Opening/OpeningDetails.tsx
+++ b/packages/ui/src/working-groups/components/OpeningsList/Opening/OpeningDetails.tsx
@@ -9,6 +9,7 @@ import { Subscription } from '@/common/components/typography/Subscription'
 import { isInFuture, nameMapping } from '@/common/helpers'
 import { useModal } from '@/common/hooks/useModal'
 import { relativeTime } from '@/common/model/relativeTime'
+import { Withdrawn } from '@/working-groups/components/Applications/Withdrawn'
 import { OpeningListItemProps } from '@/working-groups/components/OpeningsList/Opening/OpeningListItem'
 import {
   OpenedContainer,
@@ -50,7 +51,7 @@ export const OpeningDetails = ({ opening, onClick, past }: OpeningListItemProps)
               {past && (
                 <StatiscticContentColumn>
                   <TextBig value bold>
-                    {applicants} {hiring.current > applicants && <> ({hiring.current - applicants}</>}
+                    {hiring.current} <Withdrawn current={hiring.current} total={applicants} />
                   </TextBig>
                   <Subscription>Hired</Subscription>
                 </StatiscticContentColumn>

--- a/packages/ui/src/working-groups/components/OpeningsList/Opening/OpeningListItem.tsx
+++ b/packages/ui/src/working-groups/components/OpeningsList/Opening/OpeningListItem.tsx
@@ -26,6 +26,7 @@ export type OpeningListItemProps = {
 
 export const OpeningListItem = ({ opening, past, onClick }: OpeningListItemProps) => {
   const rewardPeriod = useRewardPeriod(opening.groupId)
+  const { applicants, hiring } = opening
 
   return (
     <ToggleableItemWrap past={past} onClick={onClick}>
@@ -48,7 +49,9 @@ export const OpeningListItem = ({ opening, past, onClick }: OpeningListItemProps
           <ToggleableSubscriptionWide>Reward per {rewardPeriod?.toString()} blocks.</ToggleableSubscriptionWide>
         </OpenItemSummaryColumn>
         <OpenItemSummaryColumn>
-          <TextBig>{opening.applicants}</TextBig>
+          <TextBig>
+            {applicants} {hiring.current > applicants && <> ({hiring.current - applicants}</>}
+          </TextBig>
           <Subscription>Applications</Subscription>
         </OpenItemSummaryColumn>
         {past ? (

--- a/packages/ui/src/working-groups/components/OpeningsList/Opening/OpeningListItem.tsx
+++ b/packages/ui/src/working-groups/components/OpeningsList/Opening/OpeningListItem.tsx
@@ -6,6 +6,7 @@ import { Fraction } from '@/common/components/typography/Fraction'
 import { Subscription } from '@/common/components/typography/Subscription'
 import { isInFuture } from '@/common/helpers'
 import { relativeTime } from '@/common/model/relativeTime'
+import { Withdrawn } from '@/working-groups/components/Applications/Withdrawn'
 import {
   ToggleableItemInfo,
   ToggleableItemInfoTop,
@@ -50,7 +51,7 @@ export const OpeningListItem = ({ opening, past, onClick }: OpeningListItemProps
         </OpenItemSummaryColumn>
         <OpenItemSummaryColumn>
           <TextBig>
-            {applicants} {hiring.current > applicants && <> ({hiring.current - applicants}</>}
+            {hiring.current} <Withdrawn current={hiring.current} total={applicants} />
           </TextBig>
           <Subscription>Applications</Subscription>
         </OpenItemSummaryColumn>


### PR DESCRIPTION
Fixes #2404

This implements the third option to also show withdrawn applications in the same field when `applicants > hiring.current`.

