### PR TITLE
Show sum of my vote stakes on `CandidateVote` (#2985)

### DIFF
--- a/packages/ui/src/council/components/election/CandidateVote/CandidateVote.stories.tsx
+++ b/packages/ui/src/council/components/election/CandidateVote/CandidateVote.stories.tsx
@@ -33,9 +33,9 @@ const args: CandidateVoteProps = {
   candidateId: '1',
   sumOfAllStakes: new BN(5000000),
   totalStake: new BN(500000),
-  ownStake: new BN(32000),
   votes: 20,
   index: 1,
+  myStake: new BN(32000),
   myVotes: [],
 }
 Default.args = args

--- a/packages/ui/src/council/components/election/CandidateVote/CandidateVote.tsx
+++ b/packages/ui/src/council/components/election/CandidateVote/CandidateVote.tsx
@@ -25,20 +25,26 @@ export interface CandidateVoteProps {
   member: Member
   sumOfAllStakes: BN
   totalStake: BN
-  ownStake?: BN
   votes: number
   index: number
   myVotes: MyCastVote[]
+  myStake?: BN
 }
+
+const AllRevealedButton = (
+  <ButtonPrimary size="medium" disabled>
+    Revealed
+  </ButtonPrimary>
+)
 
 export const CandidateVote = ({
   candidateId,
   member,
   sumOfAllStakes,
   totalStake,
-  ownStake,
   votes,
   index,
+  myStake,
   myVotes,
 }: CandidateVoteProps) => {
   const { showModal } = useModal()
@@ -50,9 +56,11 @@ export const CandidateVote = ({
   }, [showModal])
 
   const roundedPercentage = totalStake.gt(BN_ZERO) ? sumOfAllStakes.muln(100).divRound(totalStake).toNumber() : 0
-  const hasOwnStake = ownStake && ownStake.gt(BN_ZERO)
-  const hasMyVotes = myVotes.length > 0
+  const userVoted = myVotes.length > 0
   const allVotesRevealed = myVotes.every((vote) => vote.voteFor)
+
+  const RevealButton = <RevealVoteButton myVotes={myVotes} voteForHandle={member.handle} />
+
   return (
     <CandidateVoteWrapper onClick={showCandidate}>
       <VoteIndex lighter inter>
@@ -74,11 +82,11 @@ export const CandidateVote = ({
             </StatsValue>
           </StakeAndVotesRow>
           <StakeAndVotesRow>
-            {hasOwnStake && (
+            {myStake?.gt(BN_ZERO) && (
               <>
                 <Subscription>My Stake</Subscription>
                 <StatsValue>
-                  <TokenValue value={ownStake} />
+                  <TokenValue value={myStake} />
                 </StatsValue>
               </>
             )}
@@ -91,16 +99,7 @@ export const CandidateVote = ({
           </StakeAndVotesRow>
         </StakeAndVotesGroup>
       </VoteIndicatorWrapper>
-      <ButtonsGroup>
-        {hasMyVotes &&
-          (allVotesRevealed ? (
-            <ButtonPrimary size="medium" disabled>
-              Revealed
-            </ButtonPrimary>
-          ) : (
-            <RevealVoteButton myVotes={myVotes} voteForHandle={member.handle} />
-          ))}
-      </ButtonsGroup>
+      <ButtonsGroup>{userVoted && (allVotesRevealed ? AllRevealedButton : RevealButton)}</ButtonsGroup>
       <CandidateCardArrow>
         <Arrow direction="right" />
       </CandidateCardArrow>

--- a/packages/ui/src/council/components/election/CandidateVote/RevealingStageVotes.tsx
+++ b/packages/ui/src/council/components/election/CandidateVote/RevealingStageVotes.tsx
@@ -39,7 +39,7 @@ export const RevealingStageVotes = ({ candidateWithVotes, totalStake, onlyMyVote
         sumOfAllStakes: candidate.totalStake,
         totalStake: totalStake ?? BN_ZERO,
         votes: candidate.votesNumber,
-        ownStake: candidate.ownStake,
+        myStake: candidate.myStake,
         myVotes: candidate.myVotes,
       }))}
     />

--- a/packages/ui/src/council/components/election/pastElection/PastElectionTabs.tsx
+++ b/packages/ui/src/council/components/election/pastElection/PastElectionTabs.tsx
@@ -58,11 +58,11 @@ export const PastElectionTabs = ({ election }: PastElectionTabsProps) => {
             revealed: !!myVote,
             member: votingResult.candidate.member,
             sumOfAllStakes: votingResult.totalStake,
-            ownStake: myVote ? myVote.stake : undefined,
             totalStake: election.totalStake,
             votes: votingResult.votes.length,
             index: index + 1,
             myVotes: [],
+            myStake: myVote?.stake,
           }
         })}
       />

--- a/packages/ui/src/council/components/election/revealing/RevealingStage.tsx
+++ b/packages/ui/src/council/components/election/revealing/RevealingStage.tsx
@@ -32,7 +32,7 @@ export const RevealingStage = ({ election, isLoading }: Props) => {
         return {
           ...candidate,
           myVotes: myVotesForCandidate,
-          ownStake: myVotesForCandidate.reduce((prev, next) => prev.add(next.stake), BN_ZERO),
+          myStake: myVotesForCandidate.reduce((prev, next) => prev.add(next.stake), BN_ZERO),
         }
       })
       .sort(electionVotingResultComparator)

--- a/packages/ui/src/council/hooks/useMyCastVotes.ts
+++ b/packages/ui/src/council/hooks/useMyCastVotes.ts
@@ -14,7 +14,7 @@ export interface MyCastVote extends Vote {
 }
 
 export interface CandidateWithMyVotes extends ElectionCandidate {
-  ownStake: BN
+  myStake: BN
   myVotes: MyCastVote[]
 }
 

--- a/packages/ui/test/council/components/ElectionVotes.test.tsx
+++ b/packages/ui/test/council/components/ElectionVotes.test.tsx
@@ -37,7 +37,7 @@ const Results = ({ onlyMyVotes }: { onlyMyVotes: boolean }) => {
         return {
           ...candidate,
           myVotes: myVotesForCandidate,
-          ownStake: myVotesForCandidate.reduce((prev, next) => prev.add(next.stake), BN_ZERO),
+          myStake: myVotesForCandidate.reduce((prev, next) => prev.add(next.stake), BN_ZERO),
         }
       })
       .sort(electionVotingResultComparator)
@@ -153,7 +153,7 @@ describe('UI: RevealingStageVotes', () => {
     expect(voteNumbers[1].nextSibling?.textContent).toEqual('1')
   })
 
-  it('Own stake', async () => {
+  it('My stake', async () => {
     seedInformations(server.server, {
       votes: [{ voteForId: '0', stake: 2000, castBy: bob.address }],
       candidate: [{ memberId: '0', votePower: '3000', votesNumber: 2 }],


### PR DESCRIPTION
#2985

Renames `ownStake` to `myStake` in line with  `CandidateVote` view to prevent confusion with candidate's "own" stake.