### PR TITLE
 Deeplinks to Bounty tabs (#3095)

### DIFF
--- a/packages/ui/src/app/pages/Bounty/Bounty.tsx
+++ b/packages/ui/src/app/pages/Bounty/Bounty.tsx
@@ -11,7 +11,7 @@ import { useRefetchQueries } from '@/common/hooks/useRefetchQueries'
 import { MILLISECONDS_PER_BLOCK } from '@/common/model/formatters'
 
 export const Bounty = () => {
-  const { id } = useParams<BountyRouteParams>()
+  const { id, tab } = useParams<BountyRouteParams>()
   const history = useHistory()
   const { isLoading, bounty } = useBounty(id)
 

--- a/packages/ui/src/app/pages/Bounty/BountyModule.tsx
+++ b/packages/ui/src/app/pages/Bounty/BountyModule.tsx
@@ -7,17 +7,26 @@ import { BountyRoutes } from '@/bounty/constants'
 import { TextExtraHuge, TextMedium } from '@/common/components/typography'
 import { Colors } from '@/common/constants'
 
+import { BountiesCurrent } from './BountiesCurrent'
+import { BountiesMyBounties } from './BountiesMyBounties'
+import { BountiesMyContributions } from './BountiesMyContributions'
+import { BountiesMyEntries } from './BountiesMyEntries'
+import { BountiesPast } from './BountiesPast'
+import { BountiesTags } from './BountiesTags'
+import { Bounty } from './Bounty'
+
 export const BountyModule = () => {
   return (
     <Switch>
-      {/*<Route exact path={BountyRoutes.currentBounties} component={BountiesCurrent} />*/}
-      {/*<Route exact path={BountyRoutes.pastBounties} component={BountiesPast} />*/}
-      {/*<Route exact path={BountyRoutes.myBounties} component={BountiesMyBounties} />*/}
-      {/*<Route exact path={BountyRoutes.myContributions} component={BountiesMyContributions} />*/}
-      {/*<Route exact path={BountyRoutes.myEntries} component={BountiesMyEntries} />*/}
-      {/*<Route exact path={BountyRoutes.bountyTags} component={BountiesTags} />*/}
-      {/*<Route exact path={BountyRoutes.bounty} component={Bounty} />*/}
-      {/*<Redirect exact path={BountyRoutes.bounties} to={BountyRoutes.currentBounties} />*/}
+      <Route exact path={BountyRoutes.currentBounties} component={BountiesCurrent} />
+      <Route exact path={BountyRoutes.pastBounties} component={BountiesPast} />
+      <Route exact path={BountyRoutes.myBounties} component={BountiesMyBounties} />
+      <Route exact path={BountyRoutes.myContributions} component={BountiesMyContributions} />
+      <Route exact path={BountyRoutes.myEntries} component={BountiesMyEntries} />
+      <Route exact path={BountyRoutes.bountyTags} component={BountiesTags} />
+      <Route exact path={BountyRoutes.bountyTab} component={Bounty} />
+      <Route exact path={BountyRoutes.bounty} component={Bounty} />
+      <Redirect exact path={BountyRoutes.bounties} to={BountyRoutes.currentBounties} />
       <Route exact path={BountyRoutes.bounties} component={EmptyPageComponent} />
       <Redirect from="*" to={BountyRoutes.bounties} />
     </Switch>

--- a/packages/ui/src/bounty/constants/routes.ts
+++ b/packages/ui/src/bounty/constants/routes.ts
@@ -1,10 +1,17 @@
 export const BountyRoutes = {
+  // new shortcuts
+  show: '/bounties/:id',
+  tab: '/bounties/:id/:tab',
+  page: '/bounty/:page',
+
+  // legacy
   currentBounties: '/bounty/current',
   pastBounties: '/bounty/past',
   myBounties: '/bounty/my-bounties',
   myContributions: '/bounty/my-contributions',
   myEntries: '/bounty/my-entries',
   bountyTags: '/bounty/tags',
+  bountyTab: '/bounty/preview/:id/:tab',
   bounty: '/bounty/preview/:id',
   bounties: '/bounty',
 } as const

--- a/packages/ui/src/bounty/constants/routes.ts
+++ b/packages/ui/src/bounty/constants/routes.ts
@@ -13,6 +13,7 @@ type BountyRoutesType = typeof BountyRoutes
 
 export interface BountyRouteParams {
   id: string
+  tab?: string
 }
 
 declare module '@/app/constants/routes' {

--- a/packages/ui/src/common/components/Tabs.tsx
+++ b/packages/ui/src/common/components/Tabs.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react'
+import { Link } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 
 import { BorderRad, Colors, Transitions } from '../constants'
@@ -46,7 +47,9 @@ export const TabsContainer: FC<Omit<TabsProps, 'tabs'>> = ({ className, tabsSize
 
 const Tab = ({ active, onClick, title, count, changes }: TabProps) => (
   <TabContainer active={active} onClick={onClick}>
-    {title} {count !== undefined && <CountBadge count={count} />} {changes && <ChangesIndicator />}
+    <Link to={`/bounties/${title}`}>
+      {title} {count !== undefined && <CountBadge count={count} />} {changes && <ChangesIndicator />}
+    </Link>
   </TabContainer>
 )
 


### PR DESCRIPTION
#3095

This is as far as i go, please share thoughts on the new routes and if you want this based on an existing branch like [josytream/pioneer/tag/feature/bounties](https://github.com/Joystream/pioneer/commits/feature/bounties)

Refactoring suggestions:
- `src/app/pages/Bounty/Pages` <= move from `src/app/pages/Bounty/*` and strip "Bounty" prefix from filenames
- `src/bounties/components/Bounty/Stages` <= move from `BountyMain*`
- `src/bounties/components/Lists/components` <= move from `src/bounties/components`
- How much can be moved from `app/pages` to `src/bounties/components/` without breaks?