### PR TITLE
debugging api + qn connection issues (#3805)

### DIFF
--- a/packages/ui/src/proxyApi/client/ProxyApi.ts
+++ b/packages/ui/src/proxyApi/client/ProxyApi.ts
@@ -70,4 +70,6 @@ export class ProxyApi extends Events {
 
     // TODO emit errors too
   }
+
+  //disconnect() {} // TODO
 }


### PR DESCRIPTION
Debugging #3805

![qnStatus](https://user-images.githubusercontent.com/31551045/200988459-5605d120-8066-43a8-9c7a-7d2b54412457.png)

Spent a while implementing api (dis-)connect history inside the tooltip for debugging until it became clear the assumption was wrong and the api connection is fine.
For QN the problem is that remote delays are communicated to the user as connection issue.
> // We should not infer connection issues from indexer delays. => add 'warning' state with yellow dot
> // to signal that values could be outdated and finalized blocks may be picked up late (vs showing alarming connection error).

Needs a closer look at tooltipText memo logic in [ConnectionStatusDot.tsx](https://github.com/Joystream/pioneer/pull/3784/files#diff-b108a22550e00931458a37bafc0a2cc861cc99887a9c8b85d43d5c023a6eaff2)

`Head Indexer Delay MaxDelay`
![qnLate](https://user-images.githubusercontent.com/31551045/200988275-ededdec3-055a-4b5c-8533-b1615128cccc.png)

With better diagnostic switching between QN would become possible. For example based on ranked choice for preferred connections defined in settings. Although the goal is to hide such complexity there are situations (and advanced users like FM) who should get a chance to fix it (for example by adding alternative endpoints or importing another network config from a link without page reload. There can also be QN "Lighthouse" for automated selection in the background without red lamp.