### PR TITLE
Rename leader to lead

### DIFF
--- a/packages/ui/src/working-groups/components/WorkingGroupListItem.tsx
+++ b/packages/ui/src/working-groups/components/WorkingGroupListItem.tsx
@@ -58,7 +58,7 @@ export function WorkingGroupListItem({ group }: WorkingGroupProps) {
             ) : (
               <PlaceholderWrapper>
                 <AvatarPlaceholder />
-                <MemberHandle>No Leader</MemberHandle>
+                <MemberHandle>No Lead</MemberHandle>
               </PlaceholderWrapper>
             )}
           </StatsValue>

--- a/packages/ui/src/working-groups/components/WorkingGroupsList.tsx
+++ b/packages/ui/src/working-groups/components/WorkingGroupsList.tsx
@@ -20,7 +20,7 @@ export const WorkingGroupsList = ({ groups }: WorkingGroupsListProps) => {
           <HeaderColumnTitle>Workers</HeaderColumnTitle>
           <HeaderColumnTitle>Current Budget</HeaderColumnTitle>
           <HeaderColumnTitle>Openings</HeaderColumnTitle>
-          <HeaderColumnTitle>Wg leader</HeaderColumnTitle>
+          <HeaderColumnTitle>WG Lead</HeaderColumnTitle>
           <HeaderColumnTitle />
         </ElementsWrapper>
       </HeaderColumnWrapper>


### PR DESCRIPTION
Like #1098

Replaces user facing `leader` to `lead`.

There are more occurrences in code including types and queries for another day.