### PR TITLE
hiringLimit 0 to 1 (#2451)

### DIFF
--- a/packages/ui/src/working-groups/types/WorkingGroupOpening.ts
+++ b/packages/ui/src/working-groups/types/WorkingGroupOpening.ts
@@ -116,7 +116,7 @@ export const asWorkingGroupOpening = (fields: WorkingGroupOpeningFieldsFragment)
       : 0,
     hiring: {
       current: fields.openingfilledeventopening?.reduce((total, event) => total + event.workersHired.length, 0) ?? 0,
-      limit: fields.metadata?.hiringLimit ?? 0,
+      limit: fields.metadata?.hiringLimit ?? 1,
     },
     unstakingPeriod: fields.unstakingPeriod,
   }


### PR DESCRIPTION
The issue is manifested when WG opening is created with Joystream CLI.
The variable "fields.metadata?.hiringLimit" is NULL when CLI is used. 
