### PR TITLE
Removed account info auto-fill from account selector (#2596)

### DIFF
--- a/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
@@ -23,7 +23,7 @@ export const OptionAccount = ({ option, isForStaking }: Props) => {
 
   return (
     <>
-      <AccountInfo account={option} locked={isLocked} />
+      {/*<AccountInfo account={option} locked={isLocked} />  // Address info commented out */}
       <BalanceInfoInRow>
         <InfoTitle>{balanceType} balance</InfoTitle>
         <InfoValueWithLocks>

--- a/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
@@ -23,14 +23,14 @@ export const OptionAccount = ({ option, isForStaking }: Props) => {
 
   return (
     <>
-      {/*<AccountInfo account={option} locked={isLocked} />  // Address info commented out */}
-      <BalanceInfoInRow>
+    <AccountInfo account={option} locked={isLocked} />
+       {/* <BalanceInfoInRow>
         <InfoTitle>{balanceType} balance</InfoTitle>
         <InfoValueWithLocks>
           <Value value={balance} locked={isLocked} />
           <AccountLocks locks={balances?.locks} />
         </InfoValueWithLocks>
-      </BalanceInfoInRow>
+      </BalanceInfoInRow>// Address info commented out */}
     </>
   )
 }

--- a/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/OptionAccount.tsx
@@ -23,14 +23,14 @@ export const OptionAccount = ({ option, isForStaking }: Props) => {
 
   return (
     <>
-    <AccountInfo account={option} locked={isLocked} />
-       {/* <BalanceInfoInRow>
+      <AccountInfo account={option} locked={isLocked} />
+      <BalanceInfoInRow>
         <InfoTitle>{balanceType} balance</InfoTitle>
         <InfoValueWithLocks>
           <Value value={balance} locked={isLocked} />
           <AccountLocks locks={balances?.locks} />
         </InfoValueWithLocks>
-      </BalanceInfoInRow>// Address info commented out */}
+      </BalanceInfoInRow>
     </>
   )
 }

--- a/packages/ui/src/accounts/components/SelectAccount/OptionListAccount.tsx
+++ b/packages/ui/src/accounts/components/SelectAccount/OptionListAccount.tsx
@@ -19,11 +19,12 @@ export const OptionListAccount = React.memo(({ options, onChange, className, isF
   const lockedAccounts = options.filter((option) => !!option.optionLocks?.length)
   return (
     <OptionsListComponent className={className}>
-      {freeAccounts.map((option) => (
+      {/*
+        freeAccounts.map((option) => (
         <Option key={option.address} onClick={() => onChange && onChange(option)}>
           <OptionAccount option={option} isForStaking={isForStaking} />
         </Option>
-      ))}
+      ))*/}
       {lockedAccounts.map((option) => (
         <AccountLockTooltip boundaryClassName={className} key={option.address} locks={option.optionLocks}>
           <Option key={option.address} onClick={() => onChange && onChange(option)} disabled>


### PR DESCRIPTION
#2596
Removed <AccountInfo> component from 
pioneer\packages\ui\src\accounts\components\SelectAccount\OptionAccount.tsx