### PR TITLE
Hide tooltip on locked accounts as soon as contents of scroll bar (accounts) start to get scrolled #3885

### DIFF
--- a/packages/ui/src/common/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/common/components/Tooltip/Tooltip.tsx
@@ -57,9 +57,10 @@ export const Tooltip = ({
   const [referenceElementRef, setReferenceElementRef] = useState<HTMLElement | null>(null)
   const [popperElementRef, setPopperElementRef] = useState<HTMLDivElement | null>(null)
   const [boundaryElement, setBoundaryElement] = useState<HTMLElement | null>(null)
+  const [isDetached, setIsDetached] = useState(false)
 
-  const { styles, attributes } = usePopper(referenceElementRef, popperElementRef, {
-    placement: 'bottom-start',
+  const { styles, attributes, state } = usePopper(referenceElementRef, popperElementRef, {
+    placement: isDetached ? 'top-start' : 'bottom-start',
     modifiers: [
       {
         name: 'offset',
@@ -67,15 +68,17 @@ export const Tooltip = ({
           offset: offset ?? [0, 0],
         },
       },
-      {
-        name: 'flip',
-        options: {
-          fallbackPlacements: ['top-start'],
-          boundary: boundaryElement ?? 'clippingParents',
-        },
-      },
     ],
   })
+
+  useEffect(() => {
+    if (referenceElementRef && boundaryElement) {
+      const refBox = referenceElementRef.getBoundingClientRect()
+      const boundaryBox = boundaryElement.getBoundingClientRect()
+
+      setIsDetached(boundaryBox.bottom + boundaryBox.y < refBox.bottom + refBox.y)
+    }
+  }, [!state, !boundaryElement])
 
   useEffect(() => {
     if (boundaryClassName) {

--- a/packages/ui/src/common/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/common/components/Tooltip/Tooltip.tsx
@@ -278,6 +278,7 @@ export const TooltipLink = styled(Link)<{ to: string; target: string }>`
   font-weight: 400;
   color: ${Colors.Black[400]};
   transition: ${Transitions.all};
+  transition: opacity 0s;
   text-transform: capitalize;
 
   ${LinkSymbolStyle} {
@@ -312,6 +313,7 @@ export const TooltipExternalLink = styled.a<{ href: string | undefined; target: 
   font-weight: 400;
   color: ${Colors.Black[400]};
   transition: ${Transitions.all};
+  transition: opacity 0s;
   text-transform: capitalize;
 
   ${LinkSymbolStyle} {

--- a/packages/ui/src/common/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/common/components/Tooltip/Tooltip.tsx
@@ -76,7 +76,7 @@ export const Tooltip = ({
       const refBox = referenceElementRef.getBoundingClientRect()
       const boundaryBox = boundaryElement.getBoundingClientRect()
 
-      setIsDetached(boundaryBox.bottom + boundaryBox.y < refBox.bottom + refBox.y)
+      setIsDetached(boundaryBox.bottom + boundaryBox.y < refBox.bottom + refBox.y + boundaryBox.height)
     }
   }, [!state, !boundaryElement])
 


### PR DESCRIPTION
@WRadoslaw applied your suggestion, it is not flipping, but still not ideal, the tooltip link is hidden later than the tooltip itself, because of `transition: ${Transitions.all};` (resetting transition for opacity to 0s helps )

But the requirements are to hide on scroll is started.

Fixes: https://github.com/Joystream/pioneer/issues/3885