### PR TITLE
Post-merge cleanup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,9 +66,6 @@ For code quality & standards we rely on ESLint and Prettier. To run both checks 
 ```shell
 ## Run linter
 yarn lint
-
-## Run lint & apply automatic fixes
-yarn lint:fix
 ```
 
 ## Testing

--- a/docs/testenv.md
+++ b/docs/testenv.md
@@ -27,14 +27,6 @@ In the `.env` file at the root of the `joystream` repo, find the line which cont
 
 All the below commands should be run inside `joystream` repo.
 
-### 0. Rebuild the packages
-
-In order to build required packages run the below command. This step is only needed after updating the branch.
-
-```shell
-yarn run build:packages
-```
-
 ### 1. Run the joystream node image
 
 ```shell

--- a/packages/ui/src/council/hooks/useCouncilRemainingPeriod.ts
+++ b/packages/ui/src/council/hooks/useCouncilRemainingPeriod.ts
@@ -1,5 +1,5 @@
 import { sum } from 'lodash'
-import { map, combineLatest, concatMap, EMPTY, merge, Observable, of } from 'rxjs'
+import { map, combineLatest } from 'rxjs'
 
 import { useApi } from '@/api/hooks/useApi'
 import { useObservable } from '@/common/hooks/useObservable'

--- a/packages/ui/src/forum/queries/__generated__/forum.generated.tsx
+++ b/packages/ui/src/forum/queries/__generated__/forum.generated.tsx
@@ -1,9 +1,8 @@
 import * as Types from '../../../common/api/queries/__generated__/baseTypes.generated'
 
-import * as Apollo from '@apollo/client'
 import { gql } from '@apollo/client'
 import { MemberFieldsFragmentDoc } from '../../../memberships/queries/__generated__/members.generated'
-
+import * as Apollo from '@apollo/client'
 const defaultOptions = {} as const
 export type ForumBaseCategoryFieldsFragment = {
   __typename: 'ForumCategory'

--- a/packages/ui/src/forum/queries/forum.graphql
+++ b/packages/ui/src/forum/queries/forum.graphql
@@ -164,7 +164,7 @@ fragment ForumPostWithoutReplyFields on ForumPost {
   }
   threadId
   thread {
-     categoryId
+    categoryId
   }
 }
 

--- a/packages/ui/src/proposals/queries/__generated__/proposals.generated.tsx
+++ b/packages/ui/src/proposals/queries/__generated__/proposals.generated.tsx
@@ -1,9 +1,8 @@
 import * as Types from '../../../common/api/queries/__generated__/baseTypes.generated'
 
-import * as Apollo from '@apollo/client'
 import { gql } from '@apollo/client'
 import { MemberFieldsFragmentDoc } from '../../../memberships/queries/__generated__/members.generated'
-
+import * as Apollo from '@apollo/client'
 const defaultOptions = {} as const
 export type WorkerProposalDetailsFragment = {
   __typename: 'Worker'

--- a/packages/ui/src/working-groups/queries/workingGroups.graphql
+++ b/packages/ui/src/working-groups/queries/workingGroups.graphql
@@ -384,7 +384,11 @@ fragment WorkingGroupApplicationFields on WorkingGroupApplication {
   roleAccount
 }
 
-query GetWorkingGroupApplications($where: WorkingGroupApplicationWhereInput, $orderBy: [WorkingGroupApplicationOrderByInput!], $limit: Int) {
+query GetWorkingGroupApplications(
+  $where: WorkingGroupApplicationWhereInput
+  $orderBy: [WorkingGroupApplicationOrderByInput!]
+  $limit: Int
+) {
   workingGroupApplications(where: $where, orderBy: $orderBy, limit: $limit) {
     ...WorkingGroupApplicationFields
   }

--- a/packages/ui/test/_mocks/transactions.ts
+++ b/packages/ui/test/_mocks/transactions.ts
@@ -153,9 +153,9 @@ export const stubConst = <T>(api: UseApi, constSubPath: string, value: T) => {
 
 export const stubApi = () => {
   const api: UseApi = {
-    api: ({
+    api: {
       isConnected: true,
-    } as unknown) as Api,
+    } as unknown as Api,
     isConnected: true,
     connectionState: 'connected',
     setQnConnectionState: () => undefined,
@@ -267,7 +267,7 @@ export const stubBalances = ({ available, lockId, locked }: Balances) => {
   const availableBalance = new BN(available ?? 0)
   const lockedBalance = new BN(locked ?? 0)
 
-  const deriveBalances = ({
+  const deriveBalances = {
     availableBalance: createType('Balance', availableBalance),
     lockedBalance: createType('Balance', lockedBalance),
     accountId: createType('AccountId', '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'),
@@ -286,7 +286,7 @@ export const stubBalances = ({ available, lockId, locked }: Balances) => {
     vestingTotal: new BN(0),
     votingBalance: new BN(0),
     vesting: [],
-  } as unknown) as DeriveBalancesAll
+  } as unknown as DeriveBalancesAll
 
   const balance = toBalances(deriveBalances)
   mockedBalances.mockReturnValue(balance)

--- a/packages/ui/test/bounty/modals/AddBountyModal.test.tsx
+++ b/packages/ui/test/bounty/modals/AddBountyModal.test.tsx
@@ -45,8 +45,6 @@ jest.mock('@/common/hooks/useCurrentBlockNumber', () => ({
   useCurrentBlockNumber: () => mockUseCurrentBlockNumber(),
 }))
 
-
-
 describe('UI: AddNewBountyModal', () => {
   const api = stubApi()
   const showModal = jest.fn()

--- a/packages/ui/test/bounty/modals/SubmitJudgementModal.test.tsx
+++ b/packages/ui/test/bounty/modals/SubmitJudgementModal.test.tsx
@@ -33,8 +33,6 @@ import {
 
 configure({ testIdAttribute: 'id' })
 
-
-
 jest.mock('@/common/components/CKEditor', () => ({
   CKEditor: (props: CKEditorProps) => mockCKEditor(props),
 }))

--- a/packages/ui/test/membership/modals/BuyMembershipModal.test.tsx
+++ b/packages/ui/test/membership/modals/BuyMembershipModal.test.tsx
@@ -67,7 +67,7 @@ describe('UI: BuyMembershipModal', () => {
       fireEvent.click(screen.getByTestId('email-tile'))
       fireEvent.change(screen.getByTestId('email-input'), { target: { value: 'invalid email' } })
     })
-    Expect(submitButton).toBeDisabled()
+    expect(submitButton).toBeDisabled()
   })
 
   it('Enables button when valid form', async () => {

--- a/packages/ui/test/membership/modals/BuyMembershipModal.test.tsx
+++ b/packages/ui/test/membership/modals/BuyMembershipModal.test.tsx
@@ -31,8 +31,6 @@ import { mockUseModalCall } from '../../setup'
 
 configure({ testIdAttribute: 'id' })
 
-
-
 describe('UI: BuyMembershipModal', () => {
   const api = stubApi()
   let transaction: any
@@ -69,7 +67,7 @@ describe('UI: BuyMembershipModal', () => {
       fireEvent.click(screen.getByTestId('email-tile'))
       fireEvent.change(screen.getByTestId('email-input'), { target: { value: 'invalid email' } })
     })
-    expect(submitButton).toBeDisabled()
+    Expect(submitButton).toBeDisabled()
   })
 
   it('Enables button when valid form', async () => {

--- a/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
+++ b/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
@@ -31,8 +31,6 @@ import {
 
 configure({ testIdAttribute: 'id' })
 
-
-
 describe('UI: InviteMemberModal', () => {
   beforeAll(async () => {
     await cryptoWaitReady()

--- a/packages/ui/test/working-groups/modals/ChangeAccountModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/ChangeAccountModal.test.tsx
@@ -34,8 +34,6 @@ import {
 import { WORKER as worker } from '../../_mocks/working-groups'
 import { mockUseModalCall } from '../../setup'
 
-
-
 describe('UI: ChangeRoleModal', () => {
   const api = stubApi()
 

--- a/packages/ui/test/working-groups/modals/LeaveRoleModal.test.tsx
+++ b/packages/ui/test/working-groups/modals/LeaveRoleModal.test.tsx
@@ -33,8 +33,6 @@ import {
 } from '../../_mocks/transactions'
 import { WORKER } from '../../_mocks/working-groups'
 
-
-
 const mockUseModal: UseModal<any> = {
   modal: null,
   modalData: { workerId: 'forumWorkingGroup-1' },


### PR DESCRIPTION
Latest changes obsoleted some commands (see https://github.com/Joystream/pioneer/pull/3898#pullrequestreview-1195872995).

Is eslint 8 supported? Encountered issues (see below)

## Before
### build
```
yarn --frozen-lockfile
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 36s 110ms
➤ YN0000: ┌ Post-resolution validation
➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
➤ YN0000: └ Completed in 0s 201ms
➤ YN0000: Failed with errors in 36s 322ms

yarn
➤ YN0000: └ Completed in 4s 914ms
yarn build
@joystream/markdown-editor in exclude list, skipping
@joystream/types
 | internal/modules/cjs/loader.js:905
 |   throw err;
 |   ^
 |
 | Error: Cannot find module './polkadot-types-from-defs'

rm -r node_modules
yarn && yarn build
 | src/utils.ts(11,22): error TS2769: No overload matches this call.
 |   Overload 1 of 2, '(o: {}): string[]', gave the following error.
 |     Argument of type 'T' is not assignable to parameter of type '{}'.
 |   Overload 2 of 2, '(o: object): string[]', gave the following error.
 |     Argument of type 'T' is not assignable to parameter of type 'object'.
 | `yarn build` failed with exit code 2
```

## lint

```
yarn lint
[warn] src/working-groups/queries/workingGroups.graphql
[warn] test/_mocks/transactions.ts
[warn] test/bounty/modals/AddBountyModal.test.tsx
[warn] test/bounty/modals/SubmitJudgementModal.test.tsx
[warn] test/membership/modals/BuyMembershipModal.test.tsx
[warn] test/membership/modals/InviteMemberModal.test.tsx
[warn] test/working-groups/modals/ChangeAccountModal.test.tsx
[warn] test/working-groups/modals/LeaveRoleModal.test.tsx
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
error Command failed with exit code 1.

...

/home/debian/pioneer/packages/ui/src/app/pages/Election/Election.tsx
   7:10  warning  'LinkSymbol' is defined but never used  @typescript-eslint/no-unused-vars
  12:20  warning  'TextMedium' is defined but never used  @typescript-eslint/no-unused-vars

/home/debian/pioneer/packages/ui/src/app/pages/WorkingGroups/WorkingGroup/OpeningsTab.tsx
  5:10  warning  'LinkSymbol' is defined but never used  @typescript-eslint/no-unused-vars
  9:17  warning  'TextMedium' is defined but never used  @typescript-eslint/no-unused-vars

/home/debian/pioneer/packages/ui/src/council/hooks/useCouncilRemainingPeriod.ts
  2:30  warning  'concatMap' is defined but never used   @typescript-eslint/no-unused-vars
  2:41  warning  'EMPTY' is defined but never used       @typescript-eslint/no-unused-vars
  2:48  warning  'merge' is defined but never used       @typescript-eslint/no-unused-vars
  2:55  warning  'Observable' is defined but never used  @typescript-eslint/no-unused-vars
  2:67  warning  'of' is defined but never used          @typescript-eslint/no-unused-vars

/home/debian/pioneer/packages/ui/src/forum/components/threads/ThreadListItem.tsx
  9:19  warning  'TooltipDefault' is defined but never used  @typescript-eslint/no-unused-vars

/home/debian/pioneer/packages/ui/src/proposals/components/ProposalList/ProposalListItem.tsx
   8:10  warning  'LinkSymbol' is defined but never used  @typescript-eslint/no-unused-vars
  13:21  warning  'TextMedium' is defined but never used  @typescript-eslint/no-unused-vars

/home/debian/pioneer/packages/ui/src/working-groups/components/ApplicantsList.tsx
  19:87  warning  'leadId' is defined but never used  @typescript-eslint/no-unused-vars

/home/debian/pioneer/packages/ui/src/working-groups/components/Worker.tsx
  8:10  warning  'Member' is defined but never used  @typescript-eslint/no-unused-vars

/home/debian/pioneer/packages/ui/test/membership/modals/BuyMembershipModal.test.tsx
  70:5  error  'Expect' is not defined  no-undef

✖ 15 problems (1 error, 14 warnings)
```

## After
``` rebuild_types.sh
#!/bin/bash
set -ev
cd $(dirname $0)
rm -r node_modules

yarn install
yarn --frozen-lockfile
yarn workspace @joystream/types clean
yarn workspace @joystream/types build
yarn build
 | <s> [webpack.Progress] 100% 
 | 
 | assets by info 15.1 MiB [immutable]
 |   assets by chunk 327 KiB (auxiliary name: main)
 |     assets by path *.png 105 KiB 5 assets
 |     assets by path *.woff2 221 KiB 4 assets
 |   assets by path *.js 14.8 MiB
 |     assets by status 14.7 MiB [big]
 |       asset main.4898846fee0f77ab5edd.js 13.4 MiB [emitted] [immutable] [minimized] [big] (name: main) 2 related assets
 |       asset 343.19ee4979a57ac9aca381.js 1.25 MiB [emitted] [immutable] [minimized] [big] (id hint: defaultVendors) 2 related assets
 |     asset 494.5b21e6f2856cbf54a773.js 110 KiB [emitted] [immutable] [minimized] 1 related asset
 |     asset runtime~main.0b0fa3e09ba2dc01e001.js 2.2 KiB [emitted] [immutable] [minimized] (name: runtime~main) 1 related asset
 | asset index.html 835 bytes [emitted]
 | asset favicon.svg 729 bytes [emitted] [from: src/app/assets/favicon.svg] [copied]
 | Entrypoint main [big] 13.4 MiB (31.7 MiB) = runtime~main.0b0fa3e09ba2dc01e001.js 2.2 KiB main.4898846fee0f77ab5edd.js 13.4 MiB 11 auxiliary assets
 | orphan modules 1.96 MiB [orphan] 805 modules
 | runtime modules 8.89 KiB 20 modules
 | modules by path ../ 11.3 MiB
 |   modules by path ../../node_modules/ 9.96 MiB 3099 modules
 |   modules by path ../types/ 192 KiB 11 modules
 |   modules by path ../metadata-protobuf/ 473 KiB 2 modules
 |   ../markdown-editor/dist/ckeditor.js 664 KiB [built] [code generated]
 | modules by path ./ 10.2 MiB
 |   javascript modules 8.79 MiB 1268 modules
 |   json modules 1.43 MiB
 |     modules by path ./src/mocks/ 1.41 MiB 34 modules
 |     modules by path ./src/services/i18n/ 24 KiB 8 modules
 | 
 | WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
 | This can impact web performance.
 | Assets: 
 |   main.4898846fee0f77ab5edd.js (13.4 MiB)
 |   343.19ee4979a57ac9aca381.js (1.25 MiB)
 | WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
 | webpack 5.64.3 compiled with 2 warnings in 110184 ms
Done in 131.34s.

pioneer/packages/ui$ yarn lint
yarn run v1.22.19
$ yarn lint:prettier --check && yarn lint:eslint
$ yarn prettier "./{src,test}/**/*.{ts,tsx,html,graphql}" --check
$ /home/debian/pioneer/node_modules/.bin/prettier './{src,test}/**/*.{ts,tsx,html,graphql}' --check
Checking formatting...
All matched files use Prettier code style!
$ eslint "./{src,test}/**/*.{ts,tsx}"
Done in 106.34s

yarn start
<s> [webpack.Progress] 100%

20 assets
5478 modules
webpack 5.64.3 compiled successfully in 3094 ms
Issues checking in progress...
No issues found.
```

### eslint 8

e5529ccf2edddfb83efb847251765a41bd8e11b8 ([eslint branch](https://github.com/traumschule/pioneer/compare/eslint)), possibly only the tested env.

``` yarn lint
ESLint: 8.29.0

ESLint couldn't determine the plugin "react-hooks" uniquely.

- /home/debian/pioneer/packages/ui/node_modules/eslint-plugin-react-hooks/index.js (loaded in ".eslintrc.js")
- null (loaded in "../../.eslintrc.json")

Please remove the "plugins" setting from either config or remove either plugin installation

$ which eslint
/usr/local/bin/eslint

...

ESLint: 8.29.0

ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin".

(The package "@typescript-eslint/eslint-plugin" was not found when loaded as a Node module from the directory "/home/debian/pioneer".)

It's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm install @typescript-eslint/eslint-plugin@latest --save-dev
```

https://stackoverflow.com/questions/71417877/eslint-failed-to-load-plugin-typescript-eslint
> This seems to be a known typescript-eslint issue that may appear upon upgrading to eslint version 8.0.0, which has some breaking changes. Some comments on that first link indicate resolution by downgrading to eslint version 7.32.0.
> If I understand correctly, typescript-eslint v4 does not support eslint v8, but typescript-eslint v5 does. So you might try either downgrading your eslint to version 7.32.0 or upgrading your typescript-eslint to v5.

