### PR TITLE
the replies counter is not working properly (#3912)

### DIFF
--- a/packages/ui/src/forum/components/threads/ThreadListItem.tsx
+++ b/packages/ui/src/forum/components/threads/ThreadListItem.tsx
@@ -39,7 +39,7 @@ export const ThreadListItem = ({ thread, isArchive }: ThreadListItemProps) => {
         </Thread>
       </Tooltip>
 
-      <TextMedium bold>{thread.visiblePostsCount - 1}</TextMedium>
+      <TextMedium bold>{ thread.visiblePostsCount > 0 ? thread.visiblePostsCount - 1 : thread.visiblePostsCount }</TextMedium>
 
       <LatestActivity threadId={thread.id} />
 

--- a/packages/ui/src/forum/components/threads/ThreadListItem.tsx
+++ b/packages/ui/src/forum/components/threads/ThreadListItem.tsx
@@ -39,7 +39,7 @@ export const ThreadListItem = ({ thread, isArchive }: ThreadListItemProps) => {
         </Thread>
       </Tooltip>
 
-      <TextMedium bold>{ thread.visiblePostsCount > 0 ? thread.visiblePostsCount - 1 : thread.visiblePostsCount }</TextMedium>
+      <TextMedium bold>{ thread.visiblePostsCount > 0 ? thread.visiblePostsCount - 1 : 0 }</TextMedium>
 
       <LatestActivity threadId={thread.id} />
 


### PR DESCRIPTION
issue #3912 

I have found the line of code related to this issue

(packages\ui\src\forum\components\threads\ThreadListItem.tsx)
`<TextMedium bold>{thread.visiblePostsCount - 1}</TextMedium>`

The problem is that the variable `thread.visiblePostsCount` is zero.