### PR TITLE
fix types

### DIFF
--- a/packages/ui/src/working-groups/hooks/useGroupMaxWorkersNumber.tsx
+++ b/packages/ui/src/working-groups/hooks/useGroupMaxWorkersNumber.tsx
@@ -5,5 +5,5 @@ import { GroupIdName } from '../types'
 export const useGroupMaxWorkersNumber = (groupId: GroupIdName) => {
   const { api } = useApi()
   const maxWorkerNumber = api?.consts[groupId].maxWorkerNumberLimit
-  return maxWorkerNumber?.toNumber()
+  return Number(maxWorkerNumber ?? -1)
 }

--- a/packages/ui/src/working-groups/model/getNextPayout.ts
+++ b/packages/ui/src/working-groups/model/getNextPayout.ts
@@ -9,7 +9,7 @@ export function getNextPayout(workers: Pick<Worker, 'group'>[], blockNumber: BN,
   const blocksUntilNext = (interval?: BN) => interval?.sub(blockNumber.mod(interval))
 
   const userGroups = [...new Set(workers.map((worker) => worker.group.id))]
-  const nextPayoutPerGroup = userGroups.map((name) => api?.consts[name].rewardPeriod.toBn()).map(blocksUntilNext)
+  const nextPayoutPerGroup = userGroups.map((name) => api?.consts[name].rewardPeriod as BN).map(blocksUntilNext)
 
   if (nextPayoutPerGroup.length) {
     return nextPayoutPerGroup.reduce((closest, time) => (closest = BN.min(closest ?? BN_ZERO, time ?? BN_MILLION)))


### PR DESCRIPTION
Fixes 
```
TS2339: Property 'toNumber' does not exist on type 'Codec | (u32 & AugmentedConst<"rxjs">)'.
  Property 'toNumber' does not exist on type 'Codec'.
     6 |   const { api } = useApi()
     7 |   const maxWorkerNumber = api?.consts[groupId].maxWorkerNumberLimit
  >  8 |   return maxWorkerNumber?.toNumber()
       |                           ^^^^^^^^
     9 | }
    10 |
index.js:558 [webpack-dev-server] ERROR in src/working-groups/model/getNextPayout.ts:12:86
TS2339: Property 'toBn' does not exist on type 'Codec | (u32 & AugmentedConst<"rxjs">)'.
  Property 'toBn' does not exist on type 'Codec'.
    10 |
    11 |   const userGroups = [...new Set(workers.map((worker) => worker.group.id))]
  > 12 |   const nextPayoutPerGroup = userGroups.map((name) => api?.consts[name].rewardPeriod.toBn()).map(blocksUntilNext)
       |                                                                                      ^^^^
    13 |
    14 |   if (nextPayoutPerGroup.length) {
    15 |     return nextPayoutPerGroup.reduce((closest, time) => (closest = BN.min(closest ?? BN_ZERO, time ?? BN_MILLION)))
```

There are more errors:
```
 ERROR in dev/node-mocks/commands/opening/apply.ts:32:44
TS2345: Argument of type '"contentWorkingGroup" | "forumWorkingGroup" | "appWorkingGroup" | "membershipWorkingGroup" | "distributionWorkingGroup" | "storageWorkingGroup" | "operationsWorkingGroupAlpha" | "operationsWorkingGroupBeta" | "operationsWorkingGroupGamma"' is not assignable to parameter of type 'keyof AugmentedEvents<"rxjs">'.
  Type '"appWorkingGroup"' is not assignable to type 'keyof AugmentedEvents<"rxjs">'.
    30 |     const events = await signAndSend(tx, alice.controllerAccount)
    31 |
  > 32 |     return String(getDataFromEvent(events, group, 'AppliedOnOpening', 1))
       |                                            ^^^^^
    33 |   })
    34 |
index.js:558 [webpack-dev-server] ERROR in dev/node-mocks/commands/opening/create.ts:34:44
TS2345: Argument of type '"contentWorkingGroup" | "forumWorkingGroup" | "appWorkingGroup" | "membershipWorkingGroup" | "distributionWorkingGroup" | "storageWorkingGroup" | "operationsWorkingGroupAlpha" | "operationsWorkingGroupBeta" | "operationsWorkingGroupGamma"' is not assignable to parameter of type 'keyof AugmentedEvents<"rxjs">'.
    32 |     const events = await signAndSend(api.tx.sudo.sudo(tx), getSudoAccount())
    33 |
  > 34 |     return String(getDataFromEvent(events, group, 'OpeningAdded'))
       |                                            ^^^^^
    35 |   })
    36 | }
    37 |
```