### PR TITLE
Fixed StakeSlash/Reduce/IncreasedEvent status

### DIFF
--- a/packages/ui/src/working-groups/components/Activities/ActivitiesModals/StakeChanged/StakeChangedModal.tsx
+++ b/packages/ui/src/working-groups/components/Activities/ActivitiesModals/StakeChanged/StakeChangedModal.tsx
@@ -50,7 +50,7 @@ export const StakeChangedModal = ({ onClose, amount, eventType, id }: StakeChang
                 <StatusBadge>{eventType === 'StakeDecreasedEvent' ? 'reduce' : 'increase'}</StatusBadge>
               </SidePaneRow>
               <SidePaneRow>
-                <SidePaneLabel text="slashed by" />
+                <SidePaneLabel text={eventType === 'StakeDecreasedEvent' ? 'reduced by' : 'increased by'} />
                 <SidePaneText>
                   <TokenValue value={amount} />
                 </SidePaneText>

--- a/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
+++ b/packages/ui/src/working-groups/components/Activities/StakeSlashedContent.tsx
@@ -9,16 +9,13 @@ export const StakeSlashedContent: ActivityContentComponent<StakeSlashedActivity>
   const { member, groupName } = activity
 
   if (isOwn) {
-    return <>Your stake was reduced by the {groupName} Working Group Lead.</>
+    return <>Your stake was slashed by the {groupName} Working Group Lead.</>
   }
 
   return (
     <>
       <MemberModalLink call={{ modal: 'Member', data: { id: member.id } }}>{member.handle}</MemberModalLink> has been
-      reduced by the {groupName} Working Group Lead.{' '}
-      <ButtonLink size="small" inline>
-        Read more
-      </ButtonLink>
+      slashed by the {groupName} Working Group Lead.{' '}
     </>
   )
 }


### PR DESCRIPTION
Fixed the issue : https://github.com/Joystream/pioneer/issues/3458

This issue happened on StakeSlashedEvent, and then there is not any amount option, so I removed "Read more" button from the UI. 
Also I fixed the status comment from StakeReducedEvent, StateIncreasedEvent associated dialog. 