### PR TITLE
🔬 Add a decode helper command

### DIFF
--- a/docs/mocks.md
+++ b/docs/mocks.md
@@ -55,6 +55,37 @@ Another way to influence the on-chain state for testing purpose, is to provide a
       <path to the runtime> --tmp --alice --validator --unsafe-ws-external --unsafe-rpc-external --rpc-cors=all --chain packages/ui/dev/chain-spec/data/chain-spec.json --log runtime
       ```
 ### Other helper commands
+
+#### Decoding data from the chain:
+
+This command requires two arguments:
+- `-t`, `--type`: The expected type of the value to decode.
+- `-v`, `--value`: The hash or the string representation of the `Uint8Array` to decode.
+
+With `-t text` this command will simply decode encoded plaint text values. E.g:
+```shell
+> yarn workspace @joystream/pioneer run helpers decode -t text -v 0x4c6f72656d20697370756d
+Lorem ispum
+```
+
+Otherwhise the type options should refer to a metadata class. It can be the name of the class:
+```shell
+> yarn workspace @joystream/pioneer run helpers decode -t CouncilCandidacyNoteMetadata -v 0x0a0a616...
+CouncilCandidacyNoteMetadata {
+  ...
+}
+```
+
+Or it can be an alias:
+```shell
+> yarn workspace @joystream/pioneer run helpers decode -t candidacy -v 0x0a0a616...
+CouncilCandidacyNoteMetadata {
+  ...
+}
+```
+The available aliases are: `post`, `opening`, `thread`, `bounty`, `candidacy`, `candidate`, `application`, `member`, and `membership`.
+
+#### Others
 - `yarn workspace @joystream/pioneer run helpers commitment -s <salt> [-a <accountId>] [-o <optionId>] [-c <cycleId>]` - Calculate a commitment
 - `yarn workspace @joystream/pioneer run helpers nextCouncilStage` - Wait until the next council stage start
 

--- a/docs/mocks.md
+++ b/docs/mocks.md
@@ -58,8 +58,12 @@ Another way to influence the on-chain state for testing purpose, is to provide a
 
 #### Decoding data from the chain:
 
+```shell
+> yarn workspace @joystream/pioneer run helpers decode -t [TYPE] -v [VALUE]
+```
+
 This command requires two arguments:
-- `-t`, `--type`: The expected type of the value to decode.
+- `-t`, `--type`: The expected type of the value to decode. It can be `text`, or the name or alias of a [metadata class](https://github.com/Joystream/joystream/blob/master/metadata-protobuf/doc/index.md).
 - `-v`, `--value`: The hash or the string representation of the `Uint8Array` to decode.
 
 With `-t text` this command will simply decode encoded plaint text values. E.g:
@@ -68,7 +72,7 @@ With `-t text` this command will simply decode encoded plaint text values. E.g:
 Lorem ispum
 ```
 
-Otherwhise the type options should refer to a metadata class. It can be the name of the class:
+Otherwhise the type options should refer to a [metadata class](https://github.com/Joystream/joystream/blob/master/metadata-protobuf/doc/index.md). It can be the name of the class:
 ```shell
 > yarn workspace @joystream/pioneer run helpers decode -t CouncilCandidacyNoteMetadata -v 0x0a0a616...
 CouncilCandidacyNoteMetadata {

--- a/packages/ui/dev/helpers/decode.ts
+++ b/packages/ui/dev/helpers/decode.ts
@@ -1,19 +1,38 @@
+import * as MetaClasses from '@joystream/metadata-protobuf'
+import { AnyMetadataClass } from '@joystream/metadata-protobuf/types'
 import { createType } from '@joystream/types'
 import chalk from 'chalk'
 import yargs from 'yargs'
 
+import { metadataFromBytes } from '../../src/common/model/JoystreamNode'
+
+const MetaClassAliases = {
+  post: 'ForumPostMetadata',
+  opening: 'OpeningMetadata',
+  thread: 'ForumThreadMetadata',
+  bounty: 'BountyMetadata',
+  candidacy: 'CouncilCandidacyNoteMetadata',
+  candidate: 'CouncilCandidacyNoteMetadata',
+  application: 'ApplicationMetadata',
+  member: 'MembershipMetadata',
+  membership: 'MembershipMetadata',
+} as Record<string, keyof typeof MetaClasses>
+
 const options = {
-  type: { choices: ['text'], alias: 't', default: 'text' },
+  type: { type: 'string', alias: 't', example: ['text', 'post', 'ForumPostMetadata'], default: 'text' },
   value: { type: 'string', alias: 'b', demand: true },
 } as const
 
 type CommandOptions = yargs.InferredOptionTypes<typeof options>
 type Args = yargs.Arguments<CommandOptions>
 
-const decode = (type: Args['type'], value: string) => {
-  switch (type) {
-    case 'text':
-      return createType('Text', value).toHuman()
+const decode = (type: string, value: string): string => {
+  if (type === 'text') {
+    return createType('Text', value).toHuman()
+  } else {
+    const metaType = (MetaClassAliases[type as any] ?? type) as keyof typeof MetaClasses
+    const metadata = metadataFromBytes(MetaClasses[metaType] as AnyMetadataClass<any>, value)
+    return `${metaType} ${JSON.stringify(metadata, null, 2)}`
   }
 }
 const handler = ({ type, value }: Args) => {

--- a/packages/ui/dev/helpers/decode.ts
+++ b/packages/ui/dev/helpers/decode.ts
@@ -1,0 +1,28 @@
+import { createType } from '@joystream/types'
+import chalk from 'chalk'
+import yargs from 'yargs'
+
+const options = {
+  type: { choices: ['text'], alias: 't', default: 'text' },
+  value: { type: 'string', alias: 'b', demand: true },
+} as const
+
+type CommandOptions = yargs.InferredOptionTypes<typeof options>
+type Args = yargs.Arguments<CommandOptions>
+
+const decode = (type: Args['type'], value: string) => {
+  switch (type) {
+    case 'text':
+      return createType('Text', value).toHuman()
+  }
+}
+const handler = ({ type, value }: Args) => {
+  process.stdout.write(chalk.green(decode(type, value)) + '\n')
+}
+
+export const decodeModule = {
+  command: 'decode',
+  describe: 'Decode chain data',
+  handler,
+  builder: (argv: yargs.Argv<unknown>) => argv.options(options),
+}

--- a/packages/ui/dev/helpers/decode.ts
+++ b/packages/ui/dev/helpers/decode.ts
@@ -20,7 +20,7 @@ const MetaClassAliases = {
 
 const options = {
   type: { type: 'string', alias: 't', example: ['text', 'post', 'ForumPostMetadata'], default: 'text' },
-  value: { type: 'string', alias: 'b', demand: true },
+  value: { type: 'string', alias: 'v', demand: true },
 } as const
 
 type CommandOptions = yargs.InferredOptionTypes<typeof options>

--- a/packages/ui/dev/helpers/index.ts
+++ b/packages/ui/dev/helpers/index.ts
@@ -3,6 +3,7 @@ import yargs from 'yargs'
 import { apiBenchmarking } from './apiBenchmarking'
 import { setChainSpecModule } from './chain-spec'
 import { commitmentModule } from './commitment'
+import { decodeModule } from './decode'
 import { nextCouncilStageModule } from './nextCouncilStage'
 
 yargs(process.argv.slice(2))
@@ -11,5 +12,6 @@ yargs(process.argv.slice(2))
   .command(apiBenchmarking)
   .command(setChainSpecModule)
   .command(commitmentModule)
+  .command(decodeModule)
   .command(nextCouncilStageModule)
   .demandCommand().argv

--- a/packages/ui/src/common/model/JoystreamNode/index.ts
+++ b/packages/ui/src/common/model/JoystreamNode/index.ts
@@ -1,5 +1,6 @@
 export * from './errorEvents'
 export * from './getDataFromEvent'
 export * from './isModuleEvent'
+export * from './metadataFromBytes'
 export * from './metadataToBytes'
 export * from './types'

--- a/packages/ui/src/common/model/JoystreamNode/metadataFromBytes.ts
+++ b/packages/ui/src/common/model/JoystreamNode/metadataFromBytes.ts
@@ -1,8 +1,7 @@
 import { AnyMessage, AnyMetadataClass, DecodedMetadataObject } from '@joystream/metadata-protobuf/types'
+import { createType } from '@joystream/types'
 import { Bytes } from '@polkadot/types/primitive'
 import { isObject } from '@polkadot/util'
-
-import { createType } from '@/common/model/createType'
 
 function metaToObject<T>(metaClass: AnyMetadataClass<T>, value: AnyMessage<T>) {
   return metaClass.toObject(value, { arrays: false, longs: String }) as DecodedMetadataObject<T>


### PR DESCRIPTION
- #3525

This command requires two arguments:
- `-t`, `--type`: The expected type of the value to decode.
- `-v`, `--value`: The hash or the string representation of the `Uint8Array` to decode.

With `-t text` this command will simply decode encoded plaint text values. E.g:
```shell
> yarn workspace @joystream/pioneer run helpers decode -t text -v 0x4c6f72656d20697370756d
Lorem ispum
```

Otherwhise the type options should refer to a metadata class. It can be the name of the class:
```shell
> yarn workspace @joystream/pioneer run helpers decode -t CouncilCandidacyNoteMetadata -v 0x0a0a616...
CouncilCandidacyNoteMetadata {
  ...
}
```

Or it can be an alias:
```shell
> yarn workspace @joystream/pioneer run helpers decode -t candidacy -v 0x0a0a616...
CouncilCandidacyNoteMetadata {
  ...
}
```
The available aliases are: `post`, `opening`, `thread`, `bounty`, `candidacy`, `candidate`, `application`, `member`, and `membership`.