### PR TITLE
Fix icon on the Polkadot Block Explorer Menu item #3974

### DIFF
--- a/packages/ui/src/common/components/page/Sidebar/NavigationLink.tsx
+++ b/packages/ui/src/common/components/page/Sidebar/NavigationLink.tsx
@@ -119,7 +119,21 @@ const NavigationItemLinkChildren = styled.div`
   ${Overflow.FullDots};
 
   svg {
-    width: 20px;
+    width: 16px;
+    height: 16px;
+
+    path {
+      fill: ${Colors.Black[400]}!important;
+      transition: ${Transitions.all};
+    }
+  }
+
+  &:hover {
+    svg {
+      path {
+        fill: ${Colors.White}!important;
+      }
+    }
   }
 `
 


### PR DESCRIPTION
- #3974
<img width="224" alt="image" src="https://user-images.githubusercontent.com/9252017/207450670-9423e6af-c6af-4363-84a5-b9c294560ea6.png">
<img width="231" alt="image" src="https://user-images.githubusercontent.com/9252017/207450694-d02cacc3-a345-40ee-ba48-809f9dd75193.png">
