### PR TITLE
Invite A Member Modal bug #4053

### DIFF
--- a/packages/ui/src/app/GlobalModals.tsx
+++ b/packages/ui/src/app/GlobalModals.tsx
@@ -54,6 +54,8 @@ import { MemberModalCall, MemberProfile } from '@/memberships/components/MemberP
 import { useMyMemberships } from '@/memberships/hooks/useMyMemberships'
 import { BuyMembershipModal, BuyMembershipModalCall } from '@/memberships/modals/BuyMembershipModal'
 import { DisconnectWalletModal, DisconnectWalletModalCall } from '@/memberships/modals/DisconnectWalletModal'
+import { InviteMemberModal } from '@/memberships/modals/InviteMemberModal'
+import { InviteMemberModalCall } from '@/memberships/modals/InviteMemberModal/types'
 import { SignOutModal } from '@/memberships/modals/SignOutModal/SignOutModal'
 import { SignOutModalCall } from '@/memberships/modals/SignOutModal/types'
 import { SwitchMemberModal, SwitchMemberModalCall } from '@/memberships/modals/SwitchMemberModal'
@@ -119,6 +121,7 @@ export type ModalNames =
   | ModalName<UpdateMembershipModalCall>
   | ModalName<ReportContentModalCall>
   | ModalName<PostReplyModalCall>
+  | ModalName<InviteMemberModalCall>
 
 const modals: Record<ModalNames, ReactElement> = {
   Member: <MemberProfile />,
@@ -149,6 +152,7 @@ const modals: Record<ModalNames, ReactElement> = {
   RevealVote: <RevealVoteModal />,
   RecoverBalance: <RecoverBalanceModal />,
   IncreaseWorkerStake: <IncreaseWorkerStakeModal />,
+  InviteMemberModal: <InviteMemberModal />,
   OnBoardingModal: <OnBoardingModal />,
   RestoreVotes: <RestoreVotesModal />,
   // AddBounty: <AddBountyModal />,

--- a/packages/ui/src/memberships/components/InviteMemberButton.tsx
+++ b/packages/ui/src/memberships/components/InviteMemberButton.tsx
@@ -16,9 +16,7 @@ export const InviteMemberButton = ({ className, children, size }: InviteMemberBu
   const { showModal } = useModal()
   const { isTransactionPending } = useTransactionStatus()
 
-  const openModal = () => {
-    showModal({ modal: 'InviteMemberModal' })
-  }
+  const openModal = () => showModal({ modal: 'InviteMemberModal' })
 
   return (
     <>

--- a/packages/ui/src/memberships/components/InviteMemberButton.tsx
+++ b/packages/ui/src/memberships/components/InviteMemberButton.tsx
@@ -1,11 +1,10 @@
 import React, { ReactNode } from 'react'
 
 import { TransactionButton } from '@/common/components/buttons/TransactionButton'
+import { useModal } from '@/common/hooks/useModal'
 import { useTransactionStatus } from '@/common/hooks/useTransactionStatus'
 
 import { ButtonSize } from '../../common/components/buttons'
-import { useToggle } from '../../common/hooks/useToggle'
-import { InviteMemberModal } from '../modals/InviteMemberModal'
 
 interface InviteMemberButtonProps {
   className?: string
@@ -14,21 +13,24 @@ interface InviteMemberButtonProps {
 }
 
 export const InviteMemberButton = ({ className, children, size }: InviteMemberButtonProps) => {
-  const [isOpen, toggleIsOpen] = useToggle()
+  const { showModal } = useModal()
   const { isTransactionPending } = useTransactionStatus()
+
+  const openModal = () => {
+    showModal({ modal: 'InviteMemberModal' })
+  }
 
   return (
     <>
       <TransactionButton
         style="ghost"
         size={size}
-        onClick={toggleIsOpen}
+        onClick={openModal}
         className={className}
         disabled={isTransactionPending}
       >
         {children}
       </TransactionButton>
-      {isOpen && <InviteMemberModal onClose={toggleIsOpen} />}
     </>
   )
 }

--- a/packages/ui/src/memberships/modals/InviteMemberModal/InviteMemberModal.tsx
+++ b/packages/ui/src/memberships/modals/InviteMemberModal/InviteMemberModal.tsx
@@ -4,6 +4,7 @@ import { useApi } from '@/api/hooks/useApi'
 import { TextMedium } from '@/common/components/typography'
 import { useFirstObservableValue } from '@/common/hooks/useFirstObservableValue'
 import { useMachine } from '@/common/hooks/useMachine'
+import { useModal } from '@/common/hooks/useModal'
 import { SignTransactionModal } from '@/common/modals/SignTransactionModal/SignTransactionModal'
 import { Address } from '@/common/types'
 import { toMemberTransactionParams } from '@/memberships/modals/utils'
@@ -13,12 +14,9 @@ import { InviteMemberRequirementsModal } from './InviteMemberRequirementsModal'
 import { InviteMemberSuccessModal } from './InviteMemberSuccessModal'
 import { inviteMemberMachine } from './machine'
 
-interface MembershipModalProps {
-  onClose: () => void
-}
-
-export function InviteMemberModal({ onClose }: MembershipModalProps) {
+export function InviteMemberModal() {
   const { api } = useApi()
+  const { hideModal } = useModal()
   const workingGroupBudget = useFirstObservableValue(
     () => api?.query.membershipWorkingGroup.budget(),
     [api?.isConnected]
@@ -34,11 +32,11 @@ export function InviteMemberModal({ onClose }: MembershipModalProps) {
   }, [workingGroupBudget, membershipPrice])
 
   if (state.matches('requirementsFailed')) {
-    return <InviteMemberRequirementsModal onClose={onClose} />
+    return <InviteMemberRequirementsModal onClose={hideModal} />
   }
 
   if (state.matches('prepare')) {
-    return <InviteMemberFormModal onClose={onClose} onSubmit={(params) => send({ type: 'DONE', form: params })} />
+    return <InviteMemberFormModal onClose={hideModal} onSubmit={(params) => send({ type: 'DONE', form: params })} />
   }
 
   if (state.matches('transaction') && api) {
@@ -60,7 +58,7 @@ export function InviteMemberModal({ onClose }: MembershipModalProps) {
   }
 
   if (state.matches('success')) {
-    return <InviteMemberSuccessModal onClose={onClose} formData={state.context.form} />
+    return <InviteMemberSuccessModal onClose={hideModal} formData={state.context.form} />
   }
 
   return null

--- a/packages/ui/src/memberships/modals/InviteMemberModal/types.ts
+++ b/packages/ui/src/memberships/modals/InviteMemberModal/types.ts
@@ -1,0 +1,3 @@
+import { ModalCall } from '../../../common/providers/modal/types'
+
+export type InviteMemberModalCall = ModalCall<'InviteMemberModal'>

--- a/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
+++ b/packages/ui/test/membership/modals/InviteMemberModal.test.tsx
@@ -173,7 +173,7 @@ describe('UI: InviteMemberModal', () => {
           <ApiContext.Provider value={api}>
             <ModalContextProvider>
               <GlobalModals />
-              <InviteMemberModal onClose={() => undefined} />
+              <InviteMemberModal />
             </ModalContextProvider>
           </ApiContext.Provider>
         </MockKeyringProvider>


### PR DESCRIPTION
Fixes https://github.com/Joystream/pioneer/issues/4053
Make InviteMemberModal a global modal.
<img width="1223" alt="image" src="https://user-images.githubusercontent.com/9252017/212415094-8e66ffcf-3dd0-4637-9095-24e5b263db1b.png">
