### PR TITLE
Catch empty `workerRewardAmountUpdatedEvents` (#4034)

### DIFF
--- a/packages/ui/src/working-groups/hooks/useGroupActivities.ts
+++ b/packages/ui/src/working-groups/hooks/useGroupActivities.ts
@@ -32,7 +32,7 @@ export const useGroupActivities = (groupId: string) => {
             ...data.openingCanceledEvents.map(asOpeningActivity),
             ...data.openingFilledEvents.map(asOpeningFilledActivity),
             ...data.workerExitedEvents.map(asWorkerExitedActivity),
-            ...data.workerRewardAmountUpdatedEvents.map(asWorkerRewardAmountUpdatedActivity),
+            ...data.workerRewardAmountUpdatedEvents?.map(asWorkerRewardAmountUpdatedActivity),
             ...data.statusTextChangedEvents.map(asStatusTextChangedEventActivities),
             ...data.budgetSetEvents.map(asBudgetSetActivity),
             ...data.terminatedLeaderEvents.map(asWorkerTerminatedActivity),


### PR DESCRIPTION
#4034

@zeeshanakram3 do you know why it is always empty?