### PR TITLE
🔌 Add an Apollo client instance for the backend

### DIFF
--- a/packages/ui/.env.example
+++ b/packages/ui/.env.example
@@ -3,12 +3,14 @@ REACT_APP_TESTNET_NODE_SOCKET=wss://rpc.joystream.org:9944
 REACT_APP_TESTNET_QUERY_NODE=https://query.joystream.org/graphql
 REACT_APP_TESTNET_QUERY_NODE_SOCKET=wss://query.joystream.org/graphql
 REACT_APP_TESTNET_MEMBERSHIP_FAUCET_URL=https://faucet.joystream.org/member-faucet/register
+REACT_APP_TESTNET_BACKEND=http://localhost:3000
 
 # MAINNET Endpoints
 REACT_APP_MAINNET_NODE_SOCKET=wss://rpc.joystream.org:9944
 REACT_APP_MAINNET_QUERY_NODE=https://query.joystream.org/graphql
 REACT_APP_MAINNET_QUERY_NODE_SOCKET=wss://query.joystream.org/graphql
 REACT_APP_MAINNET_MEMBERSHIP_FAUCET_URL=https://faucet.joystream.org/member-faucet/register
+REACT_APP_MAINNET_BACKEND=http://localhost:3000
 
 # Faucet CAPTCHA
 REACT_APP_CAPTCHA_SITE_KEY=10000000-ffff-ffff-ffff-000000000001

--- a/packages/ui/src/app/Providers.tsx
+++ b/packages/ui/src/app/Providers.tsx
@@ -13,6 +13,7 @@ import { OnBoardingProvider } from '@/common/providers/onboarding/provider'
 import { TransactionStatusProvider } from '@/common/providers/transactionStatus/provider'
 import { MembershipContextProvider } from '@/memberships/providers/membership/provider'
 
+import { BackendProvider } from './providers/backend/provider'
 import { GlobalStyle } from './providers/GlobalStyle'
 import { RouteActions } from './RouteActions'
 
@@ -32,12 +33,14 @@ export const Providers = ({ children }: Props) => (
                   <HashRouter>
                     <RouteActions>
                       <ModalContextProvider>
-                        <OnBoardingProvider>
-                          <ImageReportProvider>
-                            <GlobalStyle />
-                            {children}
-                          </ImageReportProvider>
-                        </OnBoardingProvider>
+                        <BackendProvider>
+                          <OnBoardingProvider>
+                            <ImageReportProvider>
+                              <GlobalStyle />
+                              {children}
+                            </ImageReportProvider>
+                          </OnBoardingProvider>
+                        </BackendProvider>
                       </ModalContextProvider>
                     </RouteActions>
                   </HashRouter>

--- a/packages/ui/src/app/config/network.ts
+++ b/packages/ui/src/app/config/network.ts
@@ -5,6 +5,7 @@ export interface NetworkEndpoints {
   queryNodeEndpoint: string
   queryNodeEndpointSubscription: string
   membershipFaucetEndpoint: string
+  backendEndpoint: string
   configEndpoint?: string
 }
 
@@ -12,6 +13,7 @@ const TESTNET_NODE_SOCKET = process.env.REACT_APP_TESTNET_NODE_SOCKET
 const TESTNET_QUERY_NODE = process.env.REACT_APP_TESTNET_QUERY_NODE
 const TESTNET_QUERY_NODE_SOCKET = process.env.REACT_APP_TESTNET_QUERY_NODE_SOCKET
 const TESTNET_MEMBERSHIP_FAUCET_URL = process.env.REACT_APP_TESTNET_MEMBERSHIP_FAUCET_URL
+const TESTNET_BACKEND = process.env.REACT_APP_TESTNET_BACKEND
 
 export const IS_TESTNET_DEFINED =
   TESTNET_NODE_SOCKET && TESTNET_QUERY_NODE && TESTNET_QUERY_NODE_SOCKET && TESTNET_MEMBERSHIP_FAUCET_URL
@@ -20,6 +22,7 @@ const MAINNET_NODE_SOCKET = process.env.REACT_APP_MAINNET_NODE_SOCKET
 const MAINNET_QUERY_NODE = process.env.REACT_APP_MAINNET_QUERY_NODE
 const MAINNET_QUERY_NODE_SOCKET = process.env.REACT_APP_MAINNET_QUERY_NODE_SOCKET
 const MAINNET_MEMBERSHIP_FAUCET_URL = process.env.REACT_APP_MAINNET_MEMBERSHIP_FAUCET_URL
+const MAINNET_BACKEND = process.env.REACT_APP_MAINNET_BACKEND
 
 export const IS_MAINNET_DEFINED =
   MAINNET_NODE_SOCKET && MAINNET_QUERY_NODE && MAINNET_QUERY_NODE_SOCKET && MAINNET_MEMBERSHIP_FAUCET_URL
@@ -54,11 +57,19 @@ const NODE_RPC_ENDPOINT: PredefinedEndpoint = {
   'local-mocks': 'ws://127.0.0.1:9944',
 }
 
+const BACKEND_ENDPOINT: PredefinedEndpoint = {
+  mainnet: MAINNET_BACKEND,
+  local: 'ws://127.0.0.1:3000',
+  testnet: TESTNET_BACKEND,
+  'local-mocks': 'ws://127.0.0.1:3000',
+}
+
 export const pickEndpoints = (network: NetworkType): Partial<NetworkEndpoints> => ({
   nodeRpcEndpoint: NODE_RPC_ENDPOINT[network],
   queryNodeEndpoint: QUERY_NODE_ENDPOINT[network],
   queryNodeEndpointSubscription: QUERY_NODE_ENDPOINT_SUBSCRIPTION[network],
   membershipFaucetEndpoint: MEMBERSHIP_FAUCET_ENDPOINT[network],
+  backendEndpoint: BACKEND_ENDPOINT[network],
   configEndpoint: undefined,
 })
 

--- a/packages/ui/src/app/providers/backend/context.ts
+++ b/packages/ui/src/app/providers/backend/context.ts
@@ -1,0 +1,4 @@
+import { ApolloClient } from '@apollo/client'
+import { createContext } from 'react'
+
+export const BackendContext = createContext<ApolloClient<any> | undefined>(undefined)

--- a/packages/ui/src/app/providers/backend/provider.tsx
+++ b/packages/ui/src/app/providers/backend/provider.tsx
@@ -1,0 +1,23 @@
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
+import React, { ReactNode, useEffect, useState } from 'react'
+
+import { useNetworkEndpoints } from '@/common/hooks/useNetworkEndpoints'
+
+import { BackendContext } from './context'
+
+export const BackendProvider = (props: { children: ReactNode }) => {
+  const [backendClient, setBackendClient] = useState<ApolloClient<any>>()
+  const [endpoints] = useNetworkEndpoints()
+
+  useEffect(() => {
+    if (backendClient || !endpoints.backendEndpoint) return
+
+    const client = new ApolloClient({
+      link: new HttpLink({ uri: endpoints.backendEndpoint }),
+      cache: new InMemoryCache(),
+    })
+    setBackendClient(client)
+  }, [endpoints.backendEndpoint])
+
+  return <BackendContext.Provider value={backendClient} {...props} />
+}

--- a/packages/ui/src/common/hooks/useBackend.ts
+++ b/packages/ui/src/common/hooks/useBackend.ts
@@ -4,9 +4,9 @@ import { useContext, useEffect, useReducer, useState } from 'react'
 import { BackendContext } from '@/app/providers/backend/context'
 
 type Props = QueryOptions & { skip?: boolean }
-type useBackend<T> = { data?: T; error?: Error }
+type UseBackend<T> = { data?: T; error?: Error }
 
-export const useBackend = <T>({ skip = false, ...queryOptions }: Props): useBackend<T> => {
+export const useBackend = <T>({ skip = false, ...queryOptions }: Props): UseBackend<T> => {
   const [data, setData] = useState<T | undefined>()
   const [error, setError] = useState<Error | undefined>()
   const backendClient = useContext(BackendContext)

--- a/packages/ui/src/common/hooks/useBackend.ts
+++ b/packages/ui/src/common/hooks/useBackend.ts
@@ -1,0 +1,36 @@
+import { QueryOptions } from '@apollo/client'
+import { useContext, useEffect, useReducer, useState } from 'react'
+
+import { BackendContext } from '@/app/providers/backend/context'
+
+type useBackend<T> = { data?: T; error?: Error }
+
+export const useBackend = <T>(props: QueryOptions, skip = false): useBackend<T> => {
+  const [data, setData] = useState<T | undefined>()
+  const [error, setError] = useState<Error | undefined>()
+  const backendClient = useContext(BackendContext)
+  const [retry, incrementRetry] = useReducer((retry) => retry + 1, 0)
+
+  useEffect(() => {
+    if (!backendClient || skip) return
+
+    let timeout: ReturnType<typeof setTimeout>
+    backendClient.query(props).then(
+      ({ data, error }) => {
+        if (error) {
+          setError(error)
+        } else {
+          setData(data ?? undefined)
+        }
+      },
+      (err) => {
+        setError(err)
+        timeout = setTimeout(incrementRetry, 5_000)
+      }
+    )
+
+    return () => clearTimeout(timeout)
+  }, [JSON.stringify(props.variables), backendClient, retry])
+
+  return { data, error }
+}

--- a/packages/ui/src/common/hooks/useBackend.ts
+++ b/packages/ui/src/common/hooks/useBackend.ts
@@ -3,9 +3,10 @@ import { useContext, useEffect, useReducer, useState } from 'react'
 
 import { BackendContext } from '@/app/providers/backend/context'
 
+type Props = QueryOptions & { skip?: boolean }
 type useBackend<T> = { data?: T; error?: Error }
 
-export const useBackend = <T>(props: QueryOptions, skip = false): useBackend<T> => {
+export const useBackend = <T>({ skip = false, ...queryOptions }: Props): useBackend<T> => {
   const [data, setData] = useState<T | undefined>()
   const [error, setError] = useState<Error | undefined>()
   const backendClient = useContext(BackendContext)
@@ -15,7 +16,7 @@ export const useBackend = <T>(props: QueryOptions, skip = false): useBackend<T> 
     if (!backendClient || skip) return
 
     let timeout: ReturnType<typeof setTimeout>
-    backendClient.query(props).then(
+    backendClient.query(queryOptions).then(
       ({ data, error }) => {
         if (error) {
           setError(error)
@@ -30,7 +31,7 @@ export const useBackend = <T>(props: QueryOptions, skip = false): useBackend<T> 
     )
 
     return () => clearTimeout(timeout)
-  }, [JSON.stringify(props.variables), backendClient, retry])
+  }, [JSON.stringify(queryOptions.variables), backendClient, retry])
 
   return { data, error }
 }

--- a/packages/ui/src/common/hooks/useIsMemberRegistered.ts
+++ b/packages/ui/src/common/hooks/useIsMemberRegistered.ts
@@ -12,10 +12,11 @@ const query = gql`
 type UseIsMemberRegistered = { isRegistered?: boolean; error?: Error }
 
 export const useIsMemberRegistered = (memberId: number | undefined): UseIsMemberRegistered => {
-  const { data, error } = useBackend<{ memberExist: boolean | null }>(
-    { query, variables: { id: memberId } },
-    isUndefined(memberId)
-  )
+  const { data, error } = useBackend<{ memberExist: boolean | null }>({
+    query,
+    variables: { id: memberId },
+    skip: isUndefined(memberId),
+  })
 
   return { isRegistered: data?.memberExist ?? undefined, error }
 }

--- a/packages/ui/src/common/hooks/useIsMemberRegistered.ts
+++ b/packages/ui/src/common/hooks/useIsMemberRegistered.ts
@@ -1,0 +1,21 @@
+import { gql } from '@apollo/client'
+import { isUndefined } from 'lodash'
+
+import { useBackend } from './useBackend'
+
+const query = gql`
+  query MemberExist($id: Int) {
+    memberExist(id: $id)
+  }
+`
+
+type UseIsMemberRegistered = { isRegistered?: boolean; error?: Error }
+
+export const useIsMemberRegistered = (memberId: number | undefined): UseIsMemberRegistered => {
+  const { data, error } = useBackend<{ memberExist: boolean | null }>(
+    { query, variables: { id: memberId } },
+    isUndefined(memberId)
+  )
+
+  return { isRegistered: data?.memberExist ?? undefined, error }
+}

--- a/packages/ui/src/common/providers/network-endpoints/provider.tsx
+++ b/packages/ui/src/common/providers/network-endpoints/provider.tsx
@@ -18,6 +18,7 @@ const EndpointsSchema = Yup.object().shape({
   queryNodeEndpoint: Yup.string().required(),
   queryNodeEndpointSubscription: Yup.string(),
   membershipFaucetEndpoint: Yup.string(),
+  backendEndpoint: Yup.string(),
 })
 
 export const NetworkEndpointsProvider = ({ children }: Props) => {
@@ -43,6 +44,7 @@ export const NetworkEndpointsProvider = ({ children }: Props) => {
         queryNodeEndpoint: config['graphql_server'],
         membershipFaucetEndpoint: config['member_faucet'],
         nodeRpcEndpoint: config['websocket_rpc'],
+        backendEndpoint: config['websocket_rpc'],
         configEndpoint: config['config'],
       }
 


### PR DESCRIPTION
Add a `useBackend` hook to connect to the backend. See the usage example: [`useIsMemberRegistered`](https://github.com/Joystream/pioneer/blob/feature/backend-connection/packages/ui/src/common/hooks/useIsMemberRegistered.ts)

This might not be the best/final solution but it should be good enough to get started implementing #4230.

> **Warning**
> The connection endpoint should be set in the `package/ui/.env` file. When using the development backend deployment from #4364:
> ```
> docker run --rm -it -e POSTGRES_PASSWORD="my-password123" --name api -p 3000:3000 thesan/pioneer-backend
> ```
> The mainnet backend endpoint should: `REACT_APP_MAINNET_BACKEND=http://localhost:3000`