### PR TITLE
🔧 Fix the storybook CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,16 +106,16 @@ jobs:
       - name: Get the Storybook preview deployment url
         run: |
           if [ "$PREFIX" == 'git-fork' ]; then
-            BRANCH=$(echo -n "$LABEL" | sed 's/:/-/')
+            BRANCH=$(echo -n '${{ env.LABEL }}' | sed 's/:/-/')
           else
-            BRANCH=$(echo -n "$LABEL" | cut -d ':' -f2-)
+            BRANCH=$(echo -n '${{ env.LABEL }}' | cut -d ':' -f2-)
           fi
 
           URL_BRANCH=$(echo -n "$BRANCH" | tr -d '#' | tr -c '[:alnum:]' '-' | tr '[:upper:]' '[:lower:]')
-          SUBDOMAIN="$PROJECT-$PREFIX-$URL_BRANCH-joystream"
+          SUBDOMAIN="${{ env.PROJECT }}-${{ env.PREFIX }}-$URL_BRANCH-joystream"
 
           if [ ${#SUBDOMAIN} -gt 63 ]; then
-            HASH=$(echo -n "$PREFIX-$BRANCH$PROJECT" | sha256sum | head -c 6)
+            HASH=$(echo -n "${{ env.PREFIX }}-$BRANCH${{ env.PROJECT }}" | sha256sum | head -c 6)
             SUBDOMAIN="$(echo -n "$SUBDOMAIN" | head -c 46)-$HASH-joystream"
           fi
 
@@ -128,11 +128,11 @@ jobs:
       - name: Wait for the deployment to complete
         run: |
           while true; do
-            RES=$(curl -L "https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}")
+            RES=$(curl -L 'https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}')
             STATUS=$(echo -n "$RES" | jq '.status')
             SHA=$(echo -n "$RES" | jq '.meta.githubCommitSha')
 
-            if [ "$SHA" == "$COMMIT_SHA" ] && [ "$STATUS" == 'READY' ]; then
+            if [ "$SHA" == '${{ env.COMMIT_SHA }}' ] && [ "$STATUS" == 'READY' ]; then
               break
             fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,6 @@ jobs:
         run: yarn --immutable
 
   test:
-    if: false
     needs: install
     timeout-minutes: 60
     strategy:
@@ -87,22 +86,22 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      # - name: Get yarn cache directory path
-      #   id: yarn-cache-dir-path
-      #   run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-      # - uses: actions/cache@v3
-      #   with:
-      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-yarn-
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-      # - name: Install dependencies
-      #   run: yarn --immutable
+      - name: Install dependencies
+        run: yarn --immutable
 
-      # - name: Install Playwright
-      #   run: npx playwright install --with-deps
+      - name: Install Playwright
+        run: npx playwright install --with-deps
 
       - name: Get the Storybook preview deployment url
         run: |
@@ -140,7 +139,7 @@ jobs:
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      # - name: Run Storybook tests
-      #   run: yarn workspace @joystream/pioneer test-storybook
-      #   env:
-      #     TARGET_URL: https://${{ env.VERCEL_DEPLOYMENT_URL }}
+      - name: Run Storybook tests
+        run: yarn workspace @joystream/pioneer test-storybook
+        env:
+          TARGET_URL: https://${{ env.VERCEL_DEPLOYMENT_URL }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,12 +110,15 @@ jobs:
           else
             BRANCH=$(echo -n "$LABEL" | cut -d ':' -f2-)
           fi
+
           URL_BRANCH=$(echo -n "$BRANCH" | tr -d '#' | tr -c '[:alnum:]' '-' | tr '[:upper:]' '[:lower:]')
           SUBDOMAIN="$PROJECT-$PREFIX-$URL_BRANCH-joystream"
+
           if [ ${#SUBDOMAIN} -gt 63 ]; then
             HASH=$(echo -n "$PREFIX-$BRANCH$PROJECT" | sha256sum | head -c 6)
             SUBDOMAIN="$(echo -n "$SUBDOMAIN" | head -c 46)-$HASH-joystream"
           fi
+
           echo "VERCEL_DEPLOYMENT_URL=$SUBDOMAIN.vercel.app" >> "$GITHUB_ENV"
         env:
           PROJECT: pioneer-2-storybook

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,6 +104,10 @@ jobs:
       - name: Install Playwright
         run: npx playwright install --with-deps
 
+      - name: Get branch names
+        id: branch-name
+        uses: tj-actions/branch-names@v7
+
       - name: Get the Storybook preview deployment url
         run: |
           PROJECT="pioneer-2-storybook"
@@ -122,7 +126,7 @@ jobs:
           )
           echo "VERCEL_DEPLOYMENT_URL=$SUBDOMAIN.vercel.app" >> "$GITHUB_ENV"
         env:
-          BRANCH: ${{ github.ref_name }}
+          BRANCH: ${{ steps.branch-name.outputs.head_ref_branch }}
 
       - name: Wait for the deployment to complete
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -108,6 +108,14 @@ jobs:
         id: branch-name
         uses: tj-actions/branch-names@v7
 
+      - run: |
+          echo ${{ toJSON(steps.branch-name.outputs) }}
+          echo ${{ toJSON(github.event.pull_request) }}
+          echo ${{ github.repository }}
+          echo ${{ github.repository_owner }}
+          echo ${{ github.repositoryUrl }}
+          echo ${{ github.ref }}
+
       - name: Get the Storybook preview deployment url
         run: |
           PROJECT="pioneer-2-storybook"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -132,8 +132,14 @@ jobs:
             STATUS=$(echo -n "$RES" | jq -r '.status')
             SHA=$(echo -n "$RES" | jq -r '.meta.githubCommitSha')
 
+
+            if [ "$SHA" == 'null' ] || [ "$STATUS" == 'null' ]; then
+              echo -e "\nError the JSON response is missing expected fields:\n\n$RES\n" >&2
+              exit 5
+            fi
+
             if [ "$SHA" == '${{ env.COMMIT_SHA }}' ] && [ "$STATUS" == 'READY' ]; then
-              exit
+              exit 0
             fi
 
             echo -e '\nWait for the Storybook deployment...\n\n'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -131,24 +131,13 @@ jobs:
         run: |
           while true; do
             RES=$(curl -L "https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}")
-            echo "$RES"
-            jq --version
-            echo 'RES.meta.githubCommitSha:'
-            echo "$RES" | jq '.meta.githubCommitSha'
-            break
+            STATUS=$(echo -n "$RES" | jq '.status')
+            SHA=$(echo -n "$RES" | jq '.meta.githubCommitSha')
 
+            if [ "$SHA" == "$COMMIT_SHA" ] && [ "$STATUS" == 'READY' ]; then
+              break
+            fi
 
-            ARR=($( \
-              node \
-                -e '
-                  const res = JSON.parse(process.argv[1]);
-                  process.stdout.write(`${res.status} ${res.meta.githubCommitSha}`);
-                ' \
-                "$RES" \
-            ))
-            STATUS=${ARR[0]}
-            SHA=${ARR[1]}
-            [ "$SHA" == "$COMMIT_SHA" ] && [ "$STATUS" == 'READY' ] && break
             echo -e '\nWait for the Storybook deployment...\n'
             sleep 20
           done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  push: { branches: [dev, main, fix/storybook-ci] }
-  # pull_request:
+  push: { branches: [dev, main] }
+  pull_request:
 
 jobs:
   install:
@@ -123,30 +123,33 @@ jobs:
           PREFIX: ${{ github.event.pull_request.head.repo.fork && 'git-fork' || 'git' }}
           BRANCH: ${{ github.event.pull_request.head.label || github.ref_name }}
 
-      - run: echo "$TARGET_URL"
-        env:
-          TARGET_URL: https://${{ env.VERCEL_DEPLOYMENT_URL }}
+      - name: Wait for the deployment to complete
+        run: |
+          while true; do
+            RES=$(curl -L "https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}")
+            echo "$RES"
+            jq --version
+            echo 'RES.meta.githubCommitSha:'
+            echo "$RES" | jq '.meta.githubCommitSha'
+            break
 
-      # - name: Wait for the deployment to complete
-      #   run: |
-      #     while true; do
-      #       RES=$(curl -L "https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}")
-      #       ARR=($( \
-      #         node \
-      #           -e '
-      #             const res = JSON.parse(process.argv[1]);
-      #             process.stdout.write(`${res.status} ${res.meta.githubCommitSha}`);
-      #           ' \
-      #           "$RES" \
-      #       ))
-      #       STATUS=${ARR[0]}
-      #       SHA=${ARR[1]}
-      #       [ "$SHA" == "$COMMIT_SHA" ] && [ "$STATUS" == "READY" ] && break
-      #       echo "Wait for the Storybook deployment..."
-      #       sleep 20
-      #     done
-      #   env:
-      #     COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+            ARR=($( \
+              node \
+                -e '
+                  const res = JSON.parse(process.argv[1]);
+                  process.stdout.write(`${res.status} ${res.meta.githubCommitSha}`);
+                ' \
+                "$RES" \
+            ))
+            STATUS=${ARR[0]}
+            SHA=${ARR[1]}
+            [ "$SHA" == "$COMMIT_SHA" ] && [ "$STATUS" == 'READY' ] && break
+            echo -e '\nWait for the Storybook deployment...\n'
+            sleep 20
+          done
+        env:
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
       # - name: Run Storybook tests
       #   run: yarn workspace @joystream/pioneer test-storybook

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,10 +104,6 @@ jobs:
       # - name: Install Playwright
       #   run: npx playwright install --with-deps
 
-      - name: Get branch names
-        id: branch-name
-        uses: tj-actions/branch-names@v7
-
       - name: Get the Storybook preview deployment url
         run: |
           if [ "$PREFIX" == 'git-fork' ]; then

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,13 +110,13 @@ jobs:
           PREFIX="git-"
           URL_BRANCH=$( \
             node \
-              -e "process.stdout.write(process.argv[1].replace(/#/g, '').replace(/\W/g, '-').toLowerCase())" \
+              -e 'process.stdout.write(process.argv[1].replace(/#/g, "").replace(/\W/g, "-").toLowerCase())' \
               "$BRANCH" \
           )
           LONG="$PROJECT-$PREFIX$URL_BRANCH-joystream"
           SHORT=$(echo "$LONG" | head -c 46)
           SUBDOMAIN=$( \
-            [ ${#LONG} -lte 63 ] \
+            [ ${#LONG} -le 63 ] \
               && echo "$LONG" \
               || echo "$SHORT-$(echo -n "$PREFIX$BRANCH$PROJECT" | sha256sum | head -c 6)" \
           )
@@ -127,13 +127,14 @@ jobs:
       - name: Wait for the deployment to complete
         run: |
           while true; do
+            RES=$(curl -L "https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}")
             ARR=($( \
               node \
-                -e " \
+                -e ' \
                   const res = JSON.parse(process.argv[1]); \
                   process.stdout.write(`${res.status} ${res.meta.githubCommitSha}`);
-                " \
-                "$(curl -L "https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}")" \
+                ' \
+                "$RES" \
             ))
             STATUS=${ARR[1]}
             SHA=${ARR[2]}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -134,15 +134,15 @@ jobs:
             RES=$(curl -L "https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}")
             ARR=($( \
               node \
-                -e ' \
-                  const res = JSON.parse(process.argv[1]); \
+                -e '
+                  const res = JSON.parse(process.argv[1]);
                   process.stdout.write(`${res.status} ${res.meta.githubCommitSha}`);
                 ' \
                 "$RES" \
             ))
-            STATUS=${ARR[1]}
-            SHA=${ARR[2]}
-            [ "SHA" == "$COMMIT_SHA" ] && [ "STATUS" == "READY"] && break
+            STATUS=${ARR[0]}
+            SHA=${ARR[1]}
+            [ "$SHA" == "$COMMIT_SHA" ] && [ "$STATUS" == "READY" ] && break
             echo "Wait for the Storybook deployment..."
             sleep 20
           done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,7 @@ jobs:
           SUBDOMAIN="${{ env.PROJECT }}-${{ env.PREFIX }}-$URL_BRANCH-joystream"
 
           if [ ${#SUBDOMAIN} -gt 63 ]; then
-            HASH=$(echo -n "${{ env.PREFIX }}-$BRANCH${{ env.PROJECT }}" | sha256sum | head -c 6)
+            HASH=$(echo -n "${{ env.PREFIX }}-${BRANCH}${{ env.PROJECT }}" | sha256sum | head -c 6)
             SUBDOMAIN="$(echo -n "$SUBDOMAIN" | head -c 46)-$HASH-joystream"
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
         name: Install dependencies
         run: yarn --immutable
 
-  test:
+  ui-unit-tests:
     needs: install
     timeout-minutes: 60
     strategy:
@@ -72,7 +72,7 @@ jobs:
         run: node --max_old_space_size=7000 --expose-gc $(yarn bin jest) --logHeapUsage --silent
         working-directory: packages/ui
 
-  storybook-test:
+  interaction-tests:
     needs: install
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,7 @@ jobs:
         run: yarn --immutable
 
   ui-unit-tests:
+    if: false
     needs: install
     timeout-minutes: 60
     strategy:
@@ -86,22 +87,22 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      # - name: Get yarn cache directory path
+      #   id: yarn-cache-dir-path
+      #   run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+      # - uses: actions/cache@v3
+      #   with:
+      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-yarn-
 
-      - name: Install dependencies
-        run: yarn --immutable
+      # - name: Install dependencies
+      #   run: yarn --immutable
 
-      - name: Install Playwright
-        run: npx playwright install --with-deps
+      # - name: Install Playwright
+      #   run: npx playwright install --with-deps
 
       - name: Get the Storybook preview deployment url
         run: |
@@ -129,20 +130,20 @@ jobs:
         run: |
           while true; do
             RES=$(curl -L 'https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}')
-            STATUS=$(echo -n "$RES" | jq '.status')
-            SHA=$(echo -n "$RES" | jq '.meta.githubCommitSha')
+            STATUS=$(echo -n "$RES" | jq -r '.status')
+            SHA=$(echo -n "$RES" | jq -r '.meta.githubCommitSha')
 
             if [ "$SHA" == '${{ env.COMMIT_SHA }}' ] && [ "$STATUS" == 'READY' ]; then
-              break
+              exit
             fi
 
-            echo -e '\nWait for the Storybook deployment...\n'
+            echo -e '\nWait for the Storybook deployment...\n\n'
             sleep 20
           done
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Run Storybook tests
-        run: yarn workspace @joystream/pioneer test-storybook
-        env:
-          TARGET_URL: https://${{ env.VERCEL_DEPLOYMENT_URL }}
+      # - name: Run Storybook tests
+      #   run: yarn workspace @joystream/pioneer test-storybook
+      #   env:
+      #     TARGET_URL: https://${{ env.VERCEL_DEPLOYMENT_URL }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,6 @@ jobs:
         run: yarn --immutable
 
   ui-unit-tests:
-    if: false
     needs: install
     timeout-minutes: 60
     strategy:
@@ -87,22 +86,22 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      # - name: Get yarn cache directory path
-      #   id: yarn-cache-dir-path
-      #   run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-      # - uses: actions/cache@v3
-      #   with:
-      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-yarn-
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-      # - name: Install dependencies
-      #   run: yarn --immutable
+      - name: Install dependencies
+        run: yarn --immutable
 
-      # - name: Install Playwright
-      #   run: npx playwright install --with-deps
+      - name: Install Playwright
+        run: npx playwright install --with-deps
 
       - name: Get the Storybook preview deployment url
         run: |
@@ -143,7 +142,7 @@ jobs:
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      # - name: Run Storybook tests
-      #   run: yarn workspace @joystream/pioneer test-storybook
-      #   env:
-      #     TARGET_URL: https://${{ env.VERCEL_DEPLOYMENT_URL }}
+      - name: Run Storybook tests
+        run: yarn workspace @joystream/pioneer test-storybook
+        env:
+          TARGET_URL: https://${{ env.VERCEL_DEPLOYMENT_URL }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,7 +110,7 @@ jobs:
 
       - run: |
           echo "${{ toJSON(steps.branch-name.outputs) }}"
-          echo "${{ toJSON(github.event.pull_request) }}"
+          echo "${{ toJSON(github.event.pull_request.head) }}"
           echo "${{ github.repository }}"
           echo "${{ github.repository_owner }}"
           echo "${{ github.repositoryUrl }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,7 @@ jobs:
         run: yarn --immutable
 
   test:
+    if: false
     needs: install
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,10 +110,14 @@ jobs:
 
       - name: Get the Storybook preview deployment url
         run: |
+          if [ "$PREFIX" == 'git-fork' ]; then
+            BRANCH=$(echo -n "$LABEL" | sed 's/:/-/')
+          else
+            BRANCH=$(echo -n "$LABEL" | cut -d ':' -f2-)
+          fi
           URL_BRANCH=$(echo -n "$BRANCH" | tr -d '#' | tr -c '[:alnum:]' '-' | tr '[:upper:]' '[:lower:]')
           SUBDOMAIN="$PROJECT-$PREFIX-$URL_BRANCH-joystream"
           if [ ${#SUBDOMAIN} -gt 63 ]; then
-            [ "$PREFIX" == 'git-fork' ] && BRANCH=$(echo -n "$BRANCH" | sed 's/:/-/')
             HASH=$(echo -n "$PREFIX-$BRANCH$PROJECT" | sha256sum | head -c 6)
             SUBDOMAIN="$(echo -n "$SUBDOMAIN" | head -c 46)-$HASH-joystream"
           fi
@@ -121,7 +125,7 @@ jobs:
         env:
           PROJECT: pioneer-2-storybook
           PREFIX: ${{ github.event.pull_request.head.repo.fork && 'git-fork' || 'git' }}
-          BRANCH: ${{ github.event.pull_request.head.label || github.ref_name }}
+          LABEL: ${{ github.event.pull_request.head.label || github.ref_name }}
 
       - name: Wait for the deployment to complete
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -109,12 +109,12 @@ jobs:
         uses: tj-actions/branch-names@v7
 
       - run: |
-          echo ${{ toJSON(steps.branch-name.outputs) }}
-          echo ${{ toJSON(github.event.pull_request) }}
-          echo ${{ github.repository }}
-          echo ${{ github.repository_owner }}
-          echo ${{ github.repositoryUrl }}
-          echo ${{ github.ref }}
+          echo "${{ toJSON(steps.branch-name.outputs) }}"
+          echo "${{ toJSON(github.event.pull_request) }}"
+          echo "${{ github.repository }}"
+          echo "${{ github.repository_owner }}"
+          echo "${{ github.repositoryUrl }}"
+          echo "${{ github.ref }}"
 
       - name: Get the Storybook preview deployment url
         run: |
@@ -135,8 +135,9 @@ jobs:
           echo "VERCEL_DEPLOYMENT_URL=$SUBDOMAIN.vercel.app" >> "$GITHUB_ENV"
         env:
           BRANCH: ${{ steps.branch-name.outputs.head_ref_branch }}
-        
-        run: echo "$TARGET_URL"
+
+      - run: echo "$TARGET_URL"
+        env:
           TARGET_URL: https://${{ env.VERCEL_DEPLOYMENT_URL }}
 
       # - name: Wait for the deployment to complete

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  push: { branches: [dev, main] }
-  pull_request:
+  push: { branches: [dev, main, fix/storybook-ci] }
+  # pull_request:
 
 jobs:
   install:
@@ -107,14 +107,6 @@ jobs:
       - name: Get branch names
         id: branch-name
         uses: tj-actions/branch-names@v7
-
-      - run: |
-          echo "${{ toJSON(steps.branch-name.outputs) }}"
-          echo "${{ toJSON(github.event.pull_request.head) }}"
-          echo "${{ github.repository }}"
-          echo "${{ github.repository_owner }}"
-          echo "${{ github.repositoryUrl }}"
-          echo "${{ github.ref }}"
 
       - name: Get the Storybook preview deployment url
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,22 +87,22 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      # - name: Get yarn cache directory path
+      #   id: yarn-cache-dir-path
+      #   run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+      # - uses: actions/cache@v3
+      #   with:
+      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-yarn-
 
-      - name: Install dependencies
-        run: yarn --immutable
+      # - name: Install dependencies
+      #   run: yarn --immutable
 
-      - name: Install Playwright
-        run: npx playwright install --with-deps
+      # - name: Install Playwright
+      #   run: npx playwright install --with-deps
 
       - name: Get branch names
         id: branch-name
@@ -127,29 +127,32 @@ jobs:
           echo "VERCEL_DEPLOYMENT_URL=$SUBDOMAIN.vercel.app" >> "$GITHUB_ENV"
         env:
           BRANCH: ${{ steps.branch-name.outputs.head_ref_branch }}
-
-      - name: Wait for the deployment to complete
-        run: |
-          while true; do
-            RES=$(curl -L "https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}")
-            ARR=($( \
-              node \
-                -e '
-                  const res = JSON.parse(process.argv[1]);
-                  process.stdout.write(`${res.status} ${res.meta.githubCommitSha}`);
-                ' \
-                "$RES" \
-            ))
-            STATUS=${ARR[0]}
-            SHA=${ARR[1]}
-            [ "$SHA" == "$COMMIT_SHA" ] && [ "$STATUS" == "READY" ] && break
-            echo "Wait for the Storybook deployment..."
-            sleep 20
-          done
-        env:
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Run Storybook tests
-        run: yarn workspace @joystream/pioneer test-storybook
-        env:
+        
+        run: echo "$TARGET_URL"
           TARGET_URL: https://${{ env.VERCEL_DEPLOYMENT_URL }}
+
+      # - name: Wait for the deployment to complete
+      #   run: |
+      #     while true; do
+      #       RES=$(curl -L "https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}")
+      #       ARR=($( \
+      #         node \
+      #           -e '
+      #             const res = JSON.parse(process.argv[1]);
+      #             process.stdout.write(`${res.status} ${res.meta.githubCommitSha}`);
+      #           ' \
+      #           "$RES" \
+      #       ))
+      #       STATUS=${ARR[0]}
+      #       SHA=${ARR[1]}
+      #       [ "$SHA" == "$COMMIT_SHA" ] && [ "$STATUS" == "READY" ] && break
+      #       echo "Wait for the Storybook deployment..."
+      #       sleep 20
+      #     done
+      #   env:
+      #     COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      # - name: Run Storybook tests
+      #   run: yarn workspace @joystream/pioneer test-storybook
+      #   env:
+      #     TARGET_URL: https://${{ env.VERCEL_DEPLOYMENT_URL }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,33 +103,47 @@ jobs:
       - name: Install Playwright
         run: npx playwright install --with-deps
 
-      - name: Install Vercel CLI
-        run: npm install --global vercel@latest
-
       - name: Get the Storybook preview deployment url
         run: |
-          URL=$( \
-            vercel list \
-              --meta githubCommitSha=$COMMIT_SHA \
-              --token=${{ secrets.VERCEL_STORYBOOK_TOKEN }} \
-            2>&1 | tail -n 2 | head -n 1 | awk '{print $2}' \
+          PROJECT="pioneer-2-storybook"
+          PREFIX="git-"
+          URL_BRANCH=$( \
+            node \
+              -e "process.stdout.write(process.argv[1].replace(/#/g, '').replace(/\W/g, '-').toLowerCase())" \
+              "$BRANCH" \
           )
-          echo "VERCEL_DEPLOYMENT_URL=$URL" >> "$GITHUB_ENV"
+          LONG="$PROJECT-$PREFIX$URL_BRANCH-joystream"
+          SHORT=$(echo "$LONG" | head -c 46)
+          SUBDOMAIN=$( \
+            [ ${#LONG} -lte 63 ] \
+              && echo "$LONG" \
+              || echo "$SHORT-$(echo -n "$PREFIX$BRANCH$PROJECT" | sha256sum | head -c 6)" \
+          )
+          echo "VERCEL_DEPLOYMENT_URL=$SUBDOMAIN.vercel.app" >> "$GITHUB_ENV"
         env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_STORYBOOK_PROJECT_ID }}
-          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          BRANCH: ${{ github.ref_name }}
 
       - name: Wait for the deployment to complete
         run: |
-          vercel inspect "${{ env.VERCEL_DEPLOYMENT_URL }}" \
-            --wait --timeout 10m \
-            --token=${{ secrets.VERCEL_STORYBOOK_TOKEN }}
+          while true; do
+            ARR=($( \
+              node \
+                -e " \
+                  const res = JSON.parse(process.argv[1]); \
+                  process.stdout.write(`${res.status} ${res.meta.githubCommitSha}`);
+                " \
+                "$(curl -L "https://api.vercel.com/v13/deployments/${{ env.VERCEL_DEPLOYMENT_URL }}")" \
+            ))
+            STATUS=${ARR[1]}
+            SHA=${ARR[2]}
+            [ "SHA" == "$COMMIT_SHA" ] && [ "STATUS" == "READY"] && break
+            echo "Wait for the Storybook deployment..."
+            sleep 20
+          done
         env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_STORYBOOK_PROJECT_ID }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run Storybook tests
         run: yarn workspace @joystream/pioneer test-storybook
         env:
-          TARGET_URL: ${{ env.VERCEL_DEPLOYMENT_URL }}
+          TARGET_URL: https://${{ env.VERCEL_DEPLOYMENT_URL }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,23 +118,18 @@ jobs:
 
       - name: Get the Storybook preview deployment url
         run: |
-          PROJECT="pioneer-2-storybook"
-          PREFIX="git-"
-          URL_BRANCH=$( \
-            node \
-              -e 'process.stdout.write(process.argv[1].replace(/#/g, "").replace(/\W/g, "-").toLowerCase())' \
-              "$BRANCH" \
-          )
-          LONG="$PROJECT-$PREFIX$URL_BRANCH-joystream"
-          SHORT=$(echo "$LONG" | head -c 46)
-          SUBDOMAIN=$( \
-            [ ${#LONG} -le 63 ] \
-              && echo "$LONG" \
-              || echo "$SHORT-$(echo -n "$PREFIX$BRANCH$PROJECT" | sha256sum | head -c 6)" \
-          )
+          URL_BRANCH=$(echo -n "$BRANCH" | tr -d '#' | tr -c '[:alnum:]' '-' | tr '[:upper:]' '[:lower:]')
+          SUBDOMAIN="$PROJECT-$PREFIX-$URL_BRANCH-joystream"
+          if [ ${#SUBDOMAIN} -gt 63 ]; then
+            [ "$PREFIX" == 'git-fork' ] && BRANCH=$(echo -n "$BRANCH" | sed 's/:/-/')
+            HASH=$(echo -n "$PREFIX-$BRANCH$PROJECT" | sha256sum | head -c 6)
+            SUBDOMAIN="$(echo -n "$SUBDOMAIN" | head -c 46)-$HASH-joystream"
+          fi
           echo "VERCEL_DEPLOYMENT_URL=$SUBDOMAIN.vercel.app" >> "$GITHUB_ENV"
         env:
-          BRANCH: ${{ steps.branch-name.outputs.head_ref_branch }}
+          PROJECT: pioneer-2-storybook
+          PREFIX: ${{ github.event.pull_request.head.repo.fork && 'git-fork' || 'git' }}
+          BRANCH: ${{ github.event.pull_request.head.label || github.ref_name }}
 
       - run: echo "$TARGET_URL"
         env:


### PR DESCRIPTION
This PR fixes the new CI for PRs made from forks, which basically will be all PRs made to Pioneer very soon.

E.g this is why the CI failed on #4453.

The previous version required secrets to use the Vercel CLI, but secrets are not available on workflows triggered from a fork. So now the CI generates the Storybook deployment URL following [the Vercel doc](https://vercel.com/docs/concepts/deployments/generated-urls#url-with-git-branch) and relies on one of the few public endpoints from the Vercel REST API to wait for the deployment to complete.

I couldn't find a way to rely on the `deployment_status` trigger [like in the Storybbok doc example](https://storybook.js.org/docs/react/writing-tests/test-runner#run-against-deployed-storybooks-via-github-actions-deployment) because of the 2 other Vercel preview deployments which are almost always slower and because GH only looks at the latest run of a given job (even if the job was skipped) and ignore the previous ones.