### PR TITLE
🔧 Fix wrong Vercel URL due to double "-" in the CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,7 +116,7 @@ jobs:
 
           if [ ${#SUBDOMAIN} -gt 63 ]; then
             HASH=$(echo -n "${{ env.PREFIX }}-${BRANCH}${{ env.PROJECT }}" | sha256sum | head -c 6)
-            SUBDOMAIN="$(echo -n "$SUBDOMAIN" | head -c 46)-$HASH-joystream"
+            SUBDOMAIN="$(echo -n "$SUBDOMAIN" | head -c 46 | sed -e 's/[^-]$/\0-/')$HASH-joystream"
           fi
 
           echo "VERCEL_DEPLOYMENT_URL=$SUBDOMAIN.vercel.app" >> "$GITHUB_ENV"


### PR DESCRIPTION
Address CI failing in:
- #4511
- #4518
