### PR TITLE
[backend] improve auth, add change email mutation

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -88,7 +88,7 @@ To check the validity of an authorization token:
 
 ```gql
 query {
-  member {
+  me {
     id
     name
     email
@@ -96,7 +96,7 @@ query {
 }
 ```
 
-When ran with a correct `Authorization` header, it returns the member data. Otherwise it returns `null`. The email field will be `null' if the member email address has not yet been verified.
+When ran with a correct `Authorization` header, it returns the authorized member data. Otherwise it returns unauthorized error. The email field will be `null' if the member email address has not yet been verified.
 
 To check that a member is registered in the API:
 

--- a/packages/server/src/auth/api/auth.ts
+++ b/packages/server/src/auth/api/auth.ts
@@ -1,15 +1,11 @@
-import { pick } from 'lodash'
 import { arg, intArg, mutationField, nonNull, stringArg } from 'nexus'
 import * as Yup from 'yup'
 
 import { verifySignature } from '@/auth/model/signature'
-import { createAuthToken, createEmailToken } from '@/auth/model/token'
+import { createAuthToken } from '@/auth/model/token'
 import { Context } from '@/common/api'
-import { PIONEER_URL } from '@/common/config'
-import { renderPioneerEmail } from '@/common/email-templates/pioneer-email'
-import { createEmailProvider } from '@/common/utils/email'
 
-const emailProvider = createEmailProvider()
+import { sendVerificationEmail } from '../model/emailVerification'
 
 interface SignInArgs {
   memberId: number
@@ -29,7 +25,7 @@ export const signin = mutationField('signin', {
   resolve: async (_, args: SignInArgs): Promise<string | null> => {
     const verification = await verifySignature(args.signature, args.memberId, args.timestamp)
     if (verification !== 'VALID') {
-      return null
+      throw new Error('Invalid signature')
     }
 
     return createAuthToken(args.memberId)
@@ -55,27 +51,26 @@ export const signup = mutationField('signup', {
   resolve: async (_, args: SignUpArgs, { req, prisma }: Context): Promise<string | null> => {
     const verification = await verifySignature(args.signature, args.memberId, args.timestamp)
     if (verification !== 'VALID') {
-      return null
+      throw new Error('Invalid signature')
     }
 
+    if (args.email && !(await Yup.string().email().isValid(args.email))) {
+      throw new Error('Invalid email')
+    }
+
+    // check if the member already exists
+    const member = await prisma.member.findUnique({ where: { id: args.memberId } })
+    if (member) {
+      throw new Error('Member already exists')
+    }
     await prisma.member.create({ data: { id: args.memberId, name: args.name } })
 
-    if (args.email && (await Yup.string().email().isValid(args.email))) {
-      const token = createEmailToken(pick(args as Required<SignUpArgs>, 'email', 'memberId'))
-      const verificationUrl = `${req?.headers.referer ?? PIONEER_URL}/#/?verify-email=${token}`
-
-      await emailProvider.sendEmail({
-        to: args.email,
-        subject: 'Confirm your email for Pioneer',
-        html: renderPioneerEmail({
-          memberHandle: args.name,
-          summary: 'Confirm your email for Pioneer',
-          text: 'Please use the link below to confirm your email address for Pioneer notifications',
-          button: {
-            label: 'Confirm email',
-            href: verificationUrl,
-          },
-        }),
+    if (args.email) {
+      await sendVerificationEmail({
+        email: args.email,
+        memberId: args.memberId,
+        name: args.name,
+        referer: req?.headers?.referer,
       })
     }
 

--- a/packages/server/src/auth/api/member.ts
+++ b/packages/server/src/auth/api/member.ts
@@ -2,7 +2,7 @@ import * as Prisma from '@prisma/client'
 import { intArg, mutationField, nonNull, objectType, queryField, stringArg } from 'nexus'
 import { Member } from 'nexus-prisma'
 
-import { authMemberId, verifyEmailToken } from '@/auth/model/token'
+import { verifyEmailToken } from '@/auth/model/token'
 import { Context } from '@/common/api'
 
 export const MemberFields = objectType({
@@ -18,7 +18,13 @@ export const MemberFields = objectType({
 export const MemberQuery = queryField('member', {
   type: Member.$name,
 
-  resolve: (_, __, { req }: Context): Promise<Prisma.Member | null> => authMemberId(req),
+  resolve: (_, __, { member }: Context) => {
+    if (!member) {
+      throw new Error('Unauthorized')
+    }
+
+    return member
+  },
 })
 
 type memberExistArg = { id: number }

--- a/packages/server/src/auth/api/member.ts
+++ b/packages/server/src/auth/api/member.ts
@@ -19,7 +19,7 @@ export const MemberFields = objectType({
   },
 })
 
-export const MemberQuery = queryField('member', {
+export const MeQuery = queryField('me', {
   type: NexusMember.$name,
 
   resolve: (_, __, { member }: Context) => {

--- a/packages/server/src/auth/api/member.ts
+++ b/packages/server/src/auth/api/member.ts
@@ -1,22 +1,26 @@
-import * as Prisma from '@prisma/client'
+import { Member } from '@prisma/client'
 import { intArg, mutationField, nonNull, objectType, queryField, stringArg } from 'nexus'
-import { Member } from 'nexus-prisma'
+import { Member as NexusMember } from 'nexus-prisma'
+import { error } from 'npmlog'
+import * as Yup from 'yup'
 
 import { verifyEmailToken } from '@/auth/model/token'
 import { Context } from '@/common/api'
 
+import { sendVerificationEmail } from '../model/emailVerification'
+
 export const MemberFields = objectType({
-  name: Member.$name,
-  description: Member.$description,
+  name: NexusMember.$name,
+  description: NexusMember.$description,
   definition(t) {
-    t.field(Member.id)
-    t.field(Member.name)
-    t.field(Member.email)
+    t.field(NexusMember.id)
+    t.field(NexusMember.name)
+    t.field(NexusMember.email)
   },
 })
 
 export const MemberQuery = queryField('member', {
-  type: Member.$name,
+  type: NexusMember.$name,
 
   resolve: (_, __, { member }: Context) => {
     if (!member) {
@@ -39,21 +43,48 @@ export const memberExist = queryField('memberExist', {
 
 type VerifyEmailArgs = { token: string }
 export const verifyEmail = mutationField('verifyEmail', {
-  type: Member.$name,
+  type: NexusMember.$name,
 
   args: { token: nonNull(stringArg()) },
 
-  resolve: async (_, { token }: VerifyEmailArgs, { prisma }: Context): Promise<Prisma.Member | null> => {
+  resolve: async (_, { token }: VerifyEmailArgs, { prisma }: Context): Promise<Member | null> => {
     const { memberId, email } = verifyEmailToken(token) ?? {}
-    if (!memberId || !email) return null
+    if (!memberId || !email) {
+      throw new Error('Invalid verification token')
+    }
 
     const member = await prisma.member.findUnique({ where: { id: memberId } })
-    if (!member) return null
+    if (!member) {
+      error('Auth', `Member ${memberId} with valid email verification token not found`)
+      throw new Error('Internal error')
+    }
 
     if (member.email === email) {
       return member
     }
 
     return await prisma.member.update({ where: { id: memberId }, data: { email } })
+  },
+})
+
+type InitEmailChangeArgs = { email: string }
+export const initEmailChange = mutationField('initEmailChange', {
+  type: 'Boolean',
+
+  args: { email: nonNull(stringArg()) },
+
+  resolve: async (_, { email }: InitEmailChangeArgs, { req, member }: Context): Promise<boolean> => {
+    if (!member) {
+      throw new Error('Unauthorized')
+    }
+
+    const isEmailValid = await Yup.string().email().isValid(email)
+    if (!isEmailValid) {
+      throw new Error('Invalid email')
+    }
+
+    await sendVerificationEmail({ email, memberId: member.id, name: member.name, referer: req?.headers?.referer })
+
+    return true
   },
 })

--- a/packages/server/src/auth/model/emailVerification.ts
+++ b/packages/server/src/auth/model/emailVerification.ts
@@ -1,0 +1,31 @@
+import { emailProvider } from '@/common/api/email'
+import { PIONEER_URL } from '@/common/config'
+import { renderPioneerEmail } from '@/common/email-templates/pioneer-email'
+
+import { createEmailToken } from './token'
+
+type SendVerificationEmailOpts = {
+  email: string
+  memberId: number
+  name: string
+  referer?: string
+}
+
+export const sendVerificationEmail = async ({ email, memberId, name, referer }: SendVerificationEmailOpts) => {
+  const token = createEmailToken({ email, memberId })
+  const verificationUrl = `${referer || PIONEER_URL}/#/?verify-email=${token}`
+
+  await emailProvider.sendEmail({
+    to: email,
+    subject: 'Confirm your email for Pioneer',
+    html: renderPioneerEmail({
+      memberHandle: name,
+      summary: 'Confirm your email for Pioneer',
+      text: `Please use the link below to confirm your email address "${email}" for Pioneer notifications.`,
+      button: {
+        label: 'Confirm email',
+        href: verificationUrl,
+      },
+    }),
+  })
+}

--- a/packages/server/src/auth/model/token.ts
+++ b/packages/server/src/auth/model/token.ts
@@ -2,6 +2,7 @@ import { Member } from '@prisma/client'
 import { ExpressContext } from 'apollo-server-express'
 import { JwtPayload, sign, verify } from 'jsonwebtoken'
 import { isNumber, pick } from 'lodash'
+import { error } from 'npmlog'
 import * as Yup from 'yup'
 
 import { APP_SECRET_KEY } from '@/common/config'
@@ -28,17 +29,24 @@ export const createAuthToken = (memberId: number): string => {
   return sign(payload, APP_SECRET_KEY)
 }
 
-export const authMemberId = async (req: ExpressContext['req'] | undefined): Promise<Member | null> => {
+export const getAuthenticatedMember = async (req: ExpressContext['req'] | undefined): Promise<Member | null> => {
   const authHeader = req?.get('Authorization')
   const token = authHeader?.match(/(?<=^Bearer +)\S+/)?.[0]
-  if (!token) return null
-
+  if (!token) {
+    return null
+  }
   const payload = verify(token, APP_SECRET_KEY)
   if (!isValidAuthTokenPayload(payload) || payload.exp < Date.now() || !isNumber(payload.memberId)) {
     return null
   }
 
-  return prisma.member.findUnique({ where: { id: payload.memberId } })
+  const member = await prisma.member.findUnique({ where: { id: payload.memberId } })
+  if (!member) {
+    // this shouldn't happen - if it does, it means that the token was created for a member that no longer exists
+    error('Auth', `Member ${payload.memberId} with valid JWT not found`)
+    return null
+  }
+  return member
 }
 
 const isValidAuthTokenPayload = (payload: string | JwtPayload): payload is AuthTokenPayload =>

--- a/packages/server/src/common/api/context.ts
+++ b/packages/server/src/common/api/context.ts
@@ -1,13 +1,16 @@
-import { PrismaClient } from '@prisma/client'
+import { Member, PrismaClient } from '@prisma/client'
 import { ExpressContext } from 'apollo-server-express'
 
+import { getAuthenticatedMember } from '@/auth/model/token'
 import { prisma } from '@/common/prisma'
 
 export interface Context {
   prisma: PrismaClient
   req?: ExpressContext['req']
+  member: Member | null
 }
 
-export function createContext({ req }: ExpressContext): Context {
-  return { req, prisma }
+export async function createContext({ req }: ExpressContext): Promise<Context> {
+  const member = await getAuthenticatedMember(req)
+  return { req, prisma, member }
 }

--- a/packages/server/src/common/api/email.ts
+++ b/packages/server/src/common/api/email.ts
@@ -1,0 +1,3 @@
+import { createEmailProvider } from '../utils'
+
+export const emailProvider = createEmailProvider()

--- a/packages/server/src/notifier/api/notification.ts
+++ b/packages/server/src/notifier/api/notification.ts
@@ -2,7 +2,6 @@ import * as Prisma from '@prisma/client'
 import { arg, booleanArg, enumType, list, objectType, queryField, stringArg } from 'nexus'
 import { Notification, NotificationKind, NotificationStatus } from 'nexus-prisma'
 
-import { authMemberId } from '@/auth/model/token'
 import { Context } from '@/common/api'
 
 export const NotificationKindEnum = enumType(NotificationKind)
@@ -34,10 +33,11 @@ export const notificationsQuery = queryField('notifications', {
     isRead: booleanArg(),
   },
 
-  resolve: async (_, args: QueryArgs, { prisma, req }: Context): Promise<Prisma.Notification[] | null> => {
-    const memberId = (await authMemberId(req))?.id
-    if (!memberId) return null
+  resolve: async (_, args: QueryArgs, { prisma, member }: Context): Promise<Prisma.Notification[] | null> => {
+    if (!member) {
+      throw new Error('Unauthorized')
+    }
 
-    return prisma.notification.findMany({ where: { ...args, memberId } })
+    return prisma.notification.findMany({ where: { ...args, memberId: member.id } })
   },
 })

--- a/packages/server/test/api/auth.test.ts
+++ b/packages/server/test/api/auth.test.ts
@@ -180,7 +180,7 @@ describe('API: Authentication', () => {
     const unknownMember = await signin({ signature: signWith(BOB, `${BOB.id}:${timestamp}`), memberId: BOB.id })
     expect(unknownMember).toEqual({ signin: expect.stringMatching(jwtRegex) })
     const unknownMemberToken = (unknownMember as any).signin
-    expect(await api(memberQuery, { Authorization: `Bearer ${unknownMemberToken}` })).toEqual({ member: null })
+    expect(await api(memberQuery, { Authorization: `Bearer ${unknownMemberToken}` }, true)).toEqual({ member: null })
 
     // This one should succeed
     const success = await signin({ signature: signWith(ALICE, `${ALICE.id}:${timestamp}`), memberId: ALICE.id })

--- a/packages/server/test/api/auth.test.ts
+++ b/packages/server/test/api/auth.test.ts
@@ -19,6 +19,7 @@ describe('API: Authentication', () => {
   })
 
   let authToken: string
+  let emailVerifyToken: string
 
   it('Member does not exist', async () => {
     const memberExistQuery = gql`
@@ -29,6 +30,21 @@ describe('API: Authentication', () => {
     expect(await api(memberExistQuery)).toEqual({ memberExist: false })
   })
 
+  const extractEmailToken = (emailRecipient: string) => {
+    expect(mockEmailProvider.sentEmails.length).toBe(1)
+    expect(mockEmailProvider.sentEmails).toContainEqual(
+      expect.objectContaining({
+        to: emailRecipient,
+        subject: 'Confirm your email for Pioneer',
+        html: expect.stringMatching(verifyEmailLinkRegex),
+      })
+    )
+
+    const emailVerifyToken = verifyEmailLinkRegex.exec(mockEmailProvider.sentEmails[0].html)?.[1] ?? ''
+    expect(emailVerifyToken).toMatch(jwtRegex)
+    return emailVerifyToken
+  }
+
   it('Member signs up ', async () => {
     mockEmailProvider.reset()
     mockRequest.mockReset()
@@ -36,8 +52,12 @@ describe('API: Authentication', () => {
 
     const timestamp = Date.now()
 
-    const signup = (input: { memberId?: number; signature?: string; timestamp?: number }) => {
+    const signup = (
+      input: { memberId?: number; signature?: string; timestamp?: number; email?: string },
+      expectFailure = false
+    ) => {
       const memberId = isUndefined(input.memberId) ? ALICE.id : input.memberId
+      const email = isUndefined(input.email) ? ALICE.email : input.email
       const t = isUndefined(input.timestamp) ? timestamp : input.timestamp
       const signature = isUndefined(input.signature) ? signWith(ALICE, `${memberId}:${t}`) : input.signature
 
@@ -46,37 +66,44 @@ describe('API: Authentication', () => {
             signup(
               memberId: ${memberId}
               name: ${ALICE.name}
-              email: ${ALICE.email}
+              email: ${email}
               signature: ${signature}
               timestamp: ${t}
             )
           }
         `
-      return api(mutation)
+      return api(mutation, undefined, expectFailure)
     }
 
     // Empty signature
-    const emptySignature = await signup({ signature: '' })
+    const emptySignature = await signup({ signature: '' }, true)
     expect(emptySignature).toEqual({ signup: null })
 
     // Wrong signature
-    const wrongSig1 = await signup({ signature: signWith(ALICE, `${ALICE.id + 1}:${timestamp}`) })
+    const wrongSig1 = await signup({ signature: signWith(ALICE, `${ALICE.id + 1}:${timestamp}`) }, true)
     expect(wrongSig1).toEqual({ signup: null })
 
     // Wrong signature
-    const wrongSig2 = await signup({ signature: signWith(ALICE, `${ALICE.id}:${timestamp + 1}`) })
+    const wrongSig2 = await signup({ signature: signWith(ALICE, `${ALICE.id}:${timestamp + 1}`) }, true)
     expect(wrongSig2).toEqual({ signup: null })
 
     // Outdated old timestamp
-    const oldTimestamp = await signup({ signature: signWith(ALICE, `${ALICE.id}:${1}`), timestamp: 1 })
+    const oldTimestamp = await signup({ signature: signWith(ALICE, `${ALICE.id}:${1}`), timestamp: 1 }, true)
     expect(oldTimestamp).toEqual({ signup: null })
 
     // Signed with the wrong controller account
-    const wrongController = await signup({ signature: signWith(BOB, `${ALICE.id}:${timestamp}`), memberId: ALICE.id })
+    const wrongController = await signup(
+      { signature: signWith(BOB, `${ALICE.id}:${timestamp}`), memberId: ALICE.id },
+      true
+    )
     expect(wrongController).toEqual({ signup: null })
 
+    // Invalid email
+    const invalidEmail = await signup({ email: 'foo' }, true)
+    expect(invalidEmail).toEqual({ signup: null })
+
     // Membership not in the QN
-    const unknownMember = await signup({ signature: signWith(BOB, `${BOB.id}:${timestamp}`), memberId: BOB.id })
+    const unknownMember = await signup({ signature: signWith(BOB, `${BOB.id}:${timestamp}`), memberId: BOB.id }, true)
     expect(unknownMember).toEqual({ signup: null })
 
     // No member should have been created
@@ -85,19 +112,18 @@ describe('API: Authentication', () => {
     // This one should succeed
     const success = await signup({ signature: signWith(ALICE, `${ALICE.id}:${timestamp}`), memberId: ALICE.id })
 
+    // Second signup for the same member should fail
+    const secondSuccess = await signup(
+      { signature: signWith(ALICE, `${ALICE.id}:${timestamp}`), memberId: ALICE.id },
+      true
+    )
+
     expect(success).toEqual({ signup: expect.stringMatching(jwtRegex) })
+    expect(secondSuccess).toEqual({ signup: null })
     expect(await prisma.member.count({ where: { id: ALICE.id } })).toBe(1)
 
     authToken = success?.signup
-
-    expect(mockEmailProvider.sentEmails.length).toBe(1)
-    expect(mockEmailProvider.sentEmails).toContainEqual(
-      expect.objectContaining({
-        to: ALICE.email,
-        subject: 'Confirm your email for Pioneer',
-        html: expect.stringMatching(verifyEmailLinkRegex),
-      })
-    )
+    emailVerifyToken = extractEmailToken(ALICE.email)
   })
 
   it('Member exist', async () => {
@@ -139,7 +165,7 @@ describe('API: Authentication', () => {
       }
     `
 
-    const signin = (input: { memberId?: number; signature?: string; timestamp?: number }) => {
+    const signin = (input: { memberId?: number; signature?: string; timestamp?: number }, expectFailure = false) => {
       const memberId = isUndefined(input.memberId) ? ALICE.id : input.memberId
       const t = isUndefined(input.timestamp) ? timestamp : input.timestamp
       const signature = isUndefined(input.signature) ? signWith(ALICE, `${memberId}:${t}`) : input.signature
@@ -153,27 +179,29 @@ describe('API: Authentication', () => {
             )
           }
         `
-      return api(mutation)
+      return api(mutation, undefined, expectFailure)
     }
 
     // Empty signature
-    const emptySignature = await signin({ signature: '' })
+    const emptySignature = await signin({ signature: '' }, true)
     expect(emptySignature).toEqual({ signin: null })
-
     // Wrong signature
-    const wrongSig1 = await signin({ signature: signWith(ALICE, `123:${timestamp}`) })
+    const wrongSig1 = await signin({ signature: signWith(ALICE, `123:${timestamp}`) }, true)
     expect(wrongSig1).toEqual({ signin: null })
 
     // Wrong signature
-    const wrongSig2 = await signin({ signature: signWith(ALICE, `${ALICE.id}:${timestamp - 1}`) })
+    const wrongSig2 = await signin({ signature: signWith(ALICE, `${ALICE.id}:${timestamp - 1}`) }, true)
     expect(wrongSig2).toEqual({ signin: null })
 
     // Outdated old timestamp
-    const oldTimestamp = await signin({ signature: signWith(ALICE, `${ALICE.id}:1`), timestamp: 1 })
+    const oldTimestamp = await signin({ signature: signWith(ALICE, `${ALICE.id}:1`), timestamp: 1 }, true)
     expect(oldTimestamp).toEqual({ signin: null })
 
     // Signed with the wrong controller account
-    const wrongController = await signin({ signature: signWith(BOB, `${ALICE.id}:${timestamp}`), memberId: ALICE.id })
+    const wrongController = await signin(
+      { signature: signWith(BOB, `${ALICE.id}:${timestamp}`), memberId: ALICE.id },
+      true
+    )
     expect(wrongController).toEqual({ signin: null })
 
     // Membership not registered (will returned a valid token but without access to an existing member)
@@ -193,5 +221,85 @@ describe('API: Authentication', () => {
 
     const authorized = await api(memberQuery, { Authorization: `Bearer ${signInToken}` })
     expect(authorized).toEqual({ member: { id: ALICE.id } })
+  })
+
+  const verifyEmail = (emailToken: string, expectFailure = false) => {
+    const verifyEmailMutation = gql`
+      mutation {
+        verifyEmail(token: ${emailToken}) {
+          id
+          name
+          email
+        }
+      }
+    `
+    return api(verifyEmailMutation, undefined, expectFailure)
+  }
+
+  it('Member verifies email', async () => {
+    // Empty token
+    expect(await verifyEmail('', true)).toEqual({ verifyEmail: null })
+
+    // Wrong token
+    expect(await verifyEmail('foo', true)).toEqual({ verifyEmail: null })
+
+    // Invalid token
+    expect(await verifyEmail('foo.bar.baz', true)).toEqual({ verifyEmail: null })
+
+    // Valid token
+    expect(await verifyEmail(emailVerifyToken)).toEqual({
+      verifyEmail: { id: ALICE.id, name: ALICE.name, email: ALICE.email },
+    })
+
+    // Email should be updated
+    expect(await prisma.member.findUnique({ where: { id: ALICE.id } })).toEqual(
+      expect.objectContaining({ email: ALICE.email })
+    )
+  })
+
+  it('Member changes email', async () => {
+    mockEmailProvider.reset()
+
+    const changeEmail = (newEmail: string, token: string, expectFailure = false) => {
+      const mutation = gql`
+        mutation {
+          initEmailChange(email: ${newEmail})
+        }
+      `
+      return api(
+        mutation,
+        {
+          Authorization: `Bearer ${token}`,
+        },
+        expectFailure
+      )
+    }
+
+    // Not authenticated
+    expect(await changeEmail('foo', '', true)).toEqual({ initEmailChange: null })
+
+    // Invalid email
+    expect(await changeEmail('foo', authToken, true)).toEqual({ initEmailChange: null })
+
+    const newAliceEmail = 'alice-new@example.com'
+
+    // Valid email
+    expect(await changeEmail(newAliceEmail, authToken)).toEqual({ initEmailChange: true })
+    emailVerifyToken = extractEmailToken(newAliceEmail)
+
+    // Email should not be updated yet
+    expect(await prisma.member.findUnique({ where: { id: ALICE.id } })).toEqual(
+      expect.objectContaining({ email: ALICE.email })
+    )
+
+    // Verify new email
+    expect(await verifyEmail(emailVerifyToken)).toEqual({
+      verifyEmail: { id: ALICE.id, name: ALICE.name, email: newAliceEmail },
+    })
+
+    // Email should be updated
+    expect(await prisma.member.findUnique({ where: { id: ALICE.id } })).toEqual(
+      expect.objectContaining({ email: newAliceEmail })
+    )
   })
 })

--- a/packages/server/test/api/auth.test.ts
+++ b/packages/server/test/api/auth.test.ts
@@ -135,17 +135,17 @@ describe('API: Authentication', () => {
     expect(await api(memberExistQuery)).toEqual({ memberExist: true })
   })
 
-  it('Member query', async () => {
-    const memberQuery = gql`
+  it('Me query', async () => {
+    const meQuery = gql`
       query {
-        member {
+        me {
           id
           name
           email
         }
       }
     `
-    expect(await authApi(memberQuery, authToken)).toEqual({ member: { id: ALICE.id, name: ALICE.name, email: null } })
+    expect(await authApi(meQuery, authToken)).toEqual({ me: { id: ALICE.id, name: ALICE.name, email: null } })
   })
 
   it('Member sign in', async () => {
@@ -157,9 +157,9 @@ describe('API: Authentication', () => {
     }))
 
     const timestamp = Date.now()
-    const memberQuery = gql`
+    const meQuery = gql`
       query {
-        member {
+        me {
           id
         }
       }
@@ -208,7 +208,7 @@ describe('API: Authentication', () => {
     const unknownMember = await signin({ signature: signWith(BOB, `${BOB.id}:${timestamp}`), memberId: BOB.id })
     expect(unknownMember).toEqual({ signin: expect.stringMatching(jwtRegex) })
     const unknownMemberToken = (unknownMember as any).signin
-    expect(await api(memberQuery, { Authorization: `Bearer ${unknownMemberToken}` }, true)).toEqual({ member: null })
+    expect(await api(meQuery, { Authorization: `Bearer ${unknownMemberToken}` }, true)).toEqual({ me: null })
 
     // This one should succeed
     const success = await signin({ signature: signWith(ALICE, `${ALICE.id}:${timestamp}`), memberId: ALICE.id })
@@ -219,8 +219,8 @@ describe('API: Authentication', () => {
 
     expect(signInToken).not.toBe(authToken)
 
-    const authorized = await api(memberQuery, { Authorization: `Bearer ${signInToken}` })
-    expect(authorized).toEqual({ member: { id: ALICE.id } })
+    const authorized = await api(meQuery, { Authorization: `Bearer ${signInToken}` })
+    expect(authorized).toEqual({ me: { id: ALICE.id } })
   })
 
   const verifyEmail = (emailToken: string, expectFailure = false) => {

--- a/packages/server/test/api/notifier.test.ts
+++ b/packages/server/test/api/notifier.test.ts
@@ -64,7 +64,8 @@ describe('API: notifier', () => {
         }
       }
     `
-    await expect(authApi(wrongMutation1, authToken, true)).rejects.toBeDefined()
+    // expectFailure = true already checks for errors
+    expect(await authApi(wrongMutation1, authToken, true)).toBeFalsy()
 
     const wrongMutation2 = gql`
       mutation {
@@ -73,7 +74,8 @@ describe('API: notifier', () => {
         }
       }
     `
-    await expect(authApi(wrongMutation2, authToken, true)).rejects.toBeDefined()
+    // expectFailure = true already checks for errors
+    expect(await authApi(wrongMutation2, authToken, true)).toBeFalsy()
 
     const generalSubscriptionsMutation = gql`
       mutation {
@@ -132,7 +134,8 @@ describe('API: notifier', () => {
         }
       }
     `
-    await expect(authApi(wrongMutation1, authToken, true)).rejects.toBeDefined()
+    // expectFailure = true already checks for errors
+    expect(await authApi(wrongMutation1, authToken, true)).toBeFalsy()
 
     const wrongMutation2 = gql`
       mutation {
@@ -141,7 +144,8 @@ describe('API: notifier', () => {
         }
       }
     `
-    await expect(authApi(wrongMutation2, authToken, true)).rejects.toBeDefined()
+    // expectFailure = true already checks for errors
+    expect(await authApi(wrongMutation2, authToken, true)).toBeFalsy()
 
     const watchThreadMutation = (id: string) => gql`
         mutation {

--- a/packages/server/test/api/utils.ts
+++ b/packages/server/test/api/utils.ts
@@ -51,4 +51,4 @@ export const authApi = async (query: string, authToken: string, expectFailure = 
 export const signWith = (member: Member, value: string) => u8aToHex(member.controller.sign(value))
 
 export const jwtRegex = /^ey[\w-]+\.[\w-]+\.[\w-]+$/
-export const verifyEmailLinkRegex = RegExp(String.raw`\b/#/\?verify-email=${jwtRegex.source.slice(1, -1)}\b`, 's')
+export const verifyEmailLinkRegex = RegExp(String.raw`\b/#/\?verify-email=(${jwtRegex.source.slice(1, -1)})\b`, 's')

--- a/packages/server/test/api/utils.ts
+++ b/packages/server/test/api/utils.ts
@@ -26,7 +26,6 @@ export const api = async (query: string, headers?: Record<string, string>, expec
 
   if (expectFailure) {
     expect(res.errors).toBeDefined()
-    throw res.errors
   } else {
     expect(res.errors).toBeUndefined()
   }
@@ -36,13 +35,13 @@ export const api = async (query: string, headers?: Record<string, string>, expec
 
 export const authApi = async (query: string, authToken: string, expectFailure = false) => {
   if (!expectFailure) {
-    const unAuthorized1 = await api(query)
+    const unAuthorized1 = await api(query, {}, true)
     expect(Object.values(unAuthorized1 ?? {})).not.toContainEqual(expect.anything())
 
-    const unAuthorized2 = await api(query, { Authorization: 'foo' })
+    const unAuthorized2 = await api(query, { Authorization: 'foo' }, true)
     expect(Object.values(unAuthorized2 ?? {})).not.toContainEqual(expect.anything())
 
-    const unAuthorized3 = await api(query, { Authorization: `Bearer ${createAuthToken(1234)}` })
+    const unAuthorized3 = await api(query, { Authorization: `Bearer ${createAuthToken(1234)}` }, true)
     expect(Object.values(unAuthorized3 ?? {})).not.toContainEqual(expect.anything())
   }
 


### PR DESCRIPTION
Based on #4522, will rebase after it's merged

Summary of changes:
- Added `initEmailChange` mutation
- Added authenticated `member` to Context so each mutation doesn't have to extract it manually
- Added explicit errors when user is not authenticated or token/signature is invalid. This should give clients more info to work with instead of just returning `null`
- Added auth tests that check email verification
- Added auth tests that check email change
- Minor misc auth and tests improvements

Resolves #4278