### PR TITLE
[backend] update schema

### DIFF
--- a/packages/server/prisma/migrations/20231004111039_init/migration.sql
+++ b/packages/server/prisma/migrations/20231004111039_init/migration.sql
@@ -2,13 +2,15 @@
 CREATE TYPE "NotificationKind" AS ENUM ('FORUM_POST_ALL', 'FORUM_POST_MENTION', 'FORUM_POST_REPLY', 'FORUM_THREAD_CREATOR', 'FORUM_THREAD_CONTRIBUTOR', 'FORUM_THREAD_ALL', 'FORUM_THREAD_MENTION', 'ELECTION_ANNOUNCING_STARTED', 'ELECTION_VOTING_STARTED', 'ELECTION_REVEALING_STARTED', 'FORUM_THREAD_ENTITY_POST', 'FORUM_CATEGORY_ENTITY_POST', 'FORUM_CATEGORY_ENTITY_THREAD');
 
 -- CreateEnum
-CREATE TYPE "NotificationStatus" AS ENUM ('PENDING', 'SENT', 'FAILED');
+CREATE TYPE "NotificationEmailStatus" AS ENUM ('PENDING', 'SENT', 'FAILED', 'IGNORED');
 
 -- CreateTable
 CREATE TABLE "Member" (
     "id" INTEGER NOT NULL,
     "name" TEXT NOT NULL,
     "email" TEXT,
+    "unverifiedEmail" TEXT,
+    "receiveEmails" BOOLEAN NOT NULL DEFAULT true,
 
     CONSTRAINT "Member_pkey" PRIMARY KEY ("id")
 );
@@ -32,7 +34,7 @@ CREATE TABLE "Notification" (
     "kind" "NotificationKind" NOT NULL,
     "eventId" TEXT NOT NULL,
     "entityId" TEXT,
-    "status" "NotificationStatus" NOT NULL DEFAULT 'PENDING',
+    "emailStatus" "NotificationEmailStatus" NOT NULL DEFAULT 'PENDING',
     "retryCount" INTEGER NOT NULL DEFAULT 0,
     "isRead" BOOLEAN NOT NULL DEFAULT false,
 

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -15,11 +15,13 @@ datasource db {
 }
 
 model Member {
-  id            Int            @id
-  name          String
-  email         String?
-  subscriptions Subscription[]
-  notifications Notification[]
+  id              Int            @id
+  name            String
+  email           String?
+  unverifiedEmail String?
+  receiveEmails   Boolean        @default(true)
+  subscriptions   Subscription[]
+  notifications   Notification[]
 }
 
 model Subscription {
@@ -38,15 +40,15 @@ model Subscription {
 }
 
 model Notification {
-  id         Int                @id @default(autoincrement())
-  member     Member             @relation(fields: [memberId], references: [id])
-  memberId   Int
-  kind       NotificationKind
-  eventId    String
-  entityId   String?
-  status     NotificationStatus @default(PENDING)
-  retryCount Int                @default(0)
-  isRead     Boolean            @default(false)
+  id          Int                     @id @default(autoincrement())
+  member      Member                  @relation(fields: [memberId], references: [id])
+  memberId    Int
+  kind        NotificationKind
+  eventId     String
+  entityId    String?
+  emailStatus NotificationEmailStatus @default(PENDING)
+  retryCount  Int                     @default(0)
+  isRead      Boolean                 @default(false)
 
   @@unique([memberId, eventId])
   @@index(memberId)
@@ -109,8 +111,9 @@ enum NotificationKind {
   // PROPOSAL_ENTITY_DISCUSSION
 }
 
-enum NotificationStatus {
+enum NotificationEmailStatus {
   PENDING
   SENT
   FAILED
+  IGNORED
 }

--- a/packages/server/src/auth/api/auth.ts
+++ b/packages/server/src/auth/api/auth.ts
@@ -63,7 +63,7 @@ export const signup = mutationField('signup', {
     if (member) {
       throw new Error('Member already exists')
     }
-    await prisma.member.create({ data: { id: args.memberId, name: args.name } })
+    await prisma.member.create({ data: { id: args.memberId, name: args.name, unverifiedEmail: args.email } })
 
     if (args.email) {
       await sendVerificationEmail({

--- a/packages/server/src/auth/api/member.ts
+++ b/packages/server/src/auth/api/member.ts
@@ -80,22 +80,23 @@ export const updateMember = mutationField('updateMember', {
       throw new Error('Unauthorized')
     }
 
-    let updatedMember = member
+    const hasChanges = email || receiveEmails != null
+    if (!hasChanges) return member
 
     if (email) {
       const isEmailValid = await Yup.string().email().isValid(email)
       if (!isEmailValid) {
         throw new Error('Invalid email')
       }
-
       await sendVerificationEmail({ email, memberId: member.id, name: member.name, referer: req?.headers?.referer })
-      updatedMember = await prisma.member.update({ where: { id: member.id }, data: { unverifiedEmail: email } })
     }
 
-    if (receiveEmails != null) {
-      updatedMember = await prisma.member.update({ where: { id: member.id }, data: { receiveEmails } })
-    }
-
-    return updatedMember
+    return await prisma.member.update({
+      where: { id: member.id },
+      data: {
+        unverifiedEmail: email ?? undefined,
+        receiveEmails: receiveEmails ?? undefined,
+      },
+    })
   },
 })

--- a/packages/server/src/notifier/api/notification.ts
+++ b/packages/server/src/notifier/api/notification.ts
@@ -1,11 +1,11 @@
 import * as Prisma from '@prisma/client'
 import { arg, booleanArg, enumType, list, objectType, queryField, stringArg } from 'nexus'
-import { Notification, NotificationKind, NotificationStatus } from 'nexus-prisma'
+import { Notification, NotificationKind, NotificationEmailStatus } from 'nexus-prisma'
 
 import { Context } from '@/common/api'
 
 export const NotificationKindEnum = enumType(NotificationKind)
-export const NotificationStatusEnum = enumType(NotificationStatus)
+export const NotificationEmailStatusEnum = enumType(NotificationEmailStatus)
 
 export const NotificationFields = objectType({
   name: Notification.$name,
@@ -15,7 +15,7 @@ export const NotificationFields = objectType({
     t.field(Notification.kind)
     t.field(Notification.eventId)
     t.field(Notification.entityId)
-    t.field(Notification.status)
+    t.field(Notification.emailStatus)
     t.field(Notification.isRead)
   },
 })
@@ -29,7 +29,7 @@ export const notificationsQuery = queryField('notifications', {
     kind: arg({ type: NotificationKind.name }),
     eventId: stringArg(),
     entityId: stringArg(),
-    status: arg({ type: NotificationStatus.name }),
+    emailStatus: arg({ type: NotificationEmailStatus.name }),
     isRead: booleanArg(),
   },
 

--- a/packages/server/src/notifier/model/notifications.ts
+++ b/packages/server/src/notifier/model/notifications.ts
@@ -10,14 +10,16 @@ interface PotentialNotifByMember {
   shouldNotify: boolean
 }
 
-export const notificationsFromEvent =
-  (subscriptions: Subscription[], allMembers: { id: number; receiveEmails: boolean }[]) =>
-  (event: NotificationEvent): Notification[] => {
-    const membersEmailPreferences = allMembers.reduce<Record<number, boolean>>(
-      (acc, { id, receiveEmails }) => ({ ...acc, [id]: receiveEmails }),
-      {}
-    )
-    const allMemberIds = Object.keys(membersEmailPreferences).map(Number)
+export const notificationsFromEvent = (
+  subscriptions: Subscription[],
+  allMembers: { id: number; receiveEmails: boolean }[]
+) => {
+  const membersEmailPreferences = allMembers.reduce<Record<number, boolean>>(
+    (acc, { id, receiveEmails }) => ({ ...acc, [id]: receiveEmails }),
+    {}
+  )
+  const allMemberIds = Object.keys(membersEmailPreferences).map(Number)
+  return (event: NotificationEvent): Notification[] => {
     const notifsByMembers = event.potentialNotifications.flatMap<PotentialNotifByMember>(
       getEventsByMember(subscriptions, allMemberIds)
     )
@@ -29,6 +31,7 @@ export const notificationsFromEvent =
       emailStatus: membersEmailPreferences[notif.memberId] ? 'PENDING' : 'IGNORED',
     }))
   }
+}
 
 const getEventsByMember =
   (subscriptions: Subscription[], allMemberIds: number[]) =>

--- a/packages/server/src/notifier/model/notifications.ts
+++ b/packages/server/src/notifier/model/notifications.ts
@@ -17,11 +17,9 @@ export const notificationsFromEvent =
       (acc, { id, receiveEmails }) => ({ ...acc, [id]: receiveEmails }),
       {}
     )
+    const allMemberIds = Object.keys(membersEmailPreferences).map(Number)
     const notifsByMembers = event.potentialNotifications.flatMap<PotentialNotifByMember>(
-      getEventsByMember(
-        subscriptions,
-        allMembers.map(({ id }) => id)
-      )
+      getEventsByMember(subscriptions, allMemberIds)
     )
     return pickNotifs(notifsByMembers).map<Notification>((notif) => ({
       kind: notif.data.kind,

--- a/packages/server/src/notifier/processNotifications.ts
+++ b/packages/server/src/notifier/processNotifications.ts
@@ -16,7 +16,10 @@ export const processNotifications = async (): Promise<void> => {
     return
   }
 
-  const notifications = await prisma.notification.findMany({ where: { status: 'PENDING' }, include: { member: true } })
+  const notifications = await prisma.notification.findMany({
+    where: { emailStatus: 'PENDING' },
+    include: { member: true },
+  })
   await sendNotifications(notifications, emailProvider)
 }
 
@@ -35,7 +38,7 @@ export const sendNotifications = async (
 
       try {
         await notifyViaEmail(notification)
-        return await prisma.notification.update({ where: { id }, data: { status: 'SENT' } })
+        return await prisma.notification.update({ where: { id }, data: { emailStatus: 'SENT' } })
       } catch (errData) {
         if (retryCount >= EMAIL_MAX_RETRY_COUNT) {
           error(
@@ -43,7 +46,7 @@ export const sendNotifications = async (
             `Failed to email ${notification.id} with ${EMAIL_MAX_RETRY_COUNT} retries. Error:`,
             errorMessage(errData)
           )
-          return await prisma.notification.update({ where: { id }, data: { status: 'FAILED' } })
+          return await prisma.notification.update({ where: { id }, data: { emailStatus: 'FAILED' } })
         } else {
           warn(
             'Email notification failure',

--- a/packages/server/src/notifier/scripts/mockEmail.ts
+++ b/packages/server/src/notifier/scripts/mockEmail.ts
@@ -21,11 +21,13 @@ const sendEmail = async () => {
       id: 1,
       name: 'test',
       email: emailAddress,
+      unverifiedEmail: null,
+      receiveEmails: true,
     },
     memberId: 1,
     isRead: false,
     retryCount: 0,
-    status: 'PENDING' as const,
+    emailStatus: 'PENDING' as const,
   }
 
   const notification = {

--- a/packages/server/test/_mocks/notifier/createMember.ts
+++ b/packages/server/test/_mocks/notifier/createMember.ts
@@ -3,13 +3,14 @@ import { Prisma } from '@prisma/client'
 import { prisma } from '@/common/prisma'
 
 type MockedSubscription = Prisma.SubscriptionCreateManyMemberInput
-export const createMember = (id: number, name: string, subscriptions?: MockedSubscription[]) =>
+export const createMember = (id: number, name: string, subscriptions?: MockedSubscription[], receiveEmails = true) =>
   prisma.member.create({
     data: {
       id,
       name,
       email: `${name}@${name}.com`,
       subscriptions: subscriptions && { createMany: { data: subscriptions } },
+      receiveEmails,
     },
     include: { subscriptions: true },
   })

--- a/packages/server/test/api/auth.test.ts
+++ b/packages/server/test/api/auth.test.ts
@@ -298,7 +298,7 @@ describe('API: Authentication', () => {
 
     // Email should not be updated yet
     expect(await prisma.member.findUnique({ where: { id: ALICE.id } })).toEqual(
-      expect.objectContaining({ email: ALICE.email, unverifiedEmail: newAliceEmail })
+      expect.objectContaining({ email: ALICE.email, unverifiedEmail: newAliceEmail, receiveEmails: true })
     )
 
     // Verify new email

--- a/packages/server/test/api/notifier.test.ts
+++ b/packages/server/test/api/notifier.test.ts
@@ -245,7 +245,7 @@ describe('API: notifier', () => {
           kind
           eventId
           entityId
-          status
+          emailStatus
           isRead
         }
       }
@@ -271,7 +271,7 @@ describe('API: notifier', () => {
           kind: 'FORUM_POST_ALL',
           eventId: 'post_creation:1',
           entityId: 'post:1',
-          status: 'PENDING',
+          emailStatus: 'PENDING',
           isRead: false,
         },
       ],

--- a/packages/server/test/notifier.test.ts
+++ b/packages/server/test/notifier.test.ts
@@ -38,6 +38,10 @@ describe('Notifier', () => {
       // Charlie had not registered in the back-end he should not get any notification
       const charlie = { id: 3 }
 
+      // Dave is using the default behavior for general subscriptions
+      // However he should not get any email notifications
+      const dave = await createMember(4, 'dave', undefined, false)
+
       // -------------------
       // Mock QN responses
       // -------------------
@@ -57,6 +61,7 @@ describe('Notifier', () => {
               author: alice.id,
               text: `I [@Alice](#mention?member-id=${alice.id})`,
             }),
+            postAddedEvent(5, { thread: 'qux', text: `Hi [@Dave](#mention?member-id=${dave.id})`, category: 'qux' }),
           ],
         })
         .mockReturnValue({
@@ -88,7 +93,7 @@ describe('Notifier', () => {
           kind: 'FORUM_THREAD_CREATOR',
           entityId: 'post:1',
           isRead: false,
-          status: 'SENT',
+          emailStatus: 'SENT',
           retryCount: 0,
         })
       )
@@ -97,7 +102,7 @@ describe('Notifier', () => {
           eventId: 'event:2',
           memberId: alice.id,
           kind: 'FORUM_POST_MENTION',
-          status: 'SENT',
+          emailStatus: 'SENT',
           retryCount: 0,
         })
       )
@@ -106,7 +111,7 @@ describe('Notifier', () => {
           eventId: 'event:2',
           memberId: bob.id,
           kind: 'FORUM_THREAD_ENTITY_POST',
-          status: 'SENT',
+          emailStatus: 'SENT',
           retryCount: 0,
         })
       )
@@ -115,7 +120,7 @@ describe('Notifier', () => {
           eventId: 'event:3',
           memberId: alice.id,
           kind: 'FORUM_CATEGORY_ENTITY_POST',
-          status: 'SENT',
+          emailStatus: 'SENT',
           retryCount: 0,
         })
       )
@@ -124,11 +129,20 @@ describe('Notifier', () => {
           eventId: 'event:3',
           memberId: bob.id,
           kind: 'FORUM_POST_ALL',
-          status: 'SENT',
+          emailStatus: 'SENT',
           retryCount: 0,
         })
       )
-      expect(notifications).toHaveLength(5)
+      expect(notifications).toContainEqual(
+        expect.objectContaining({
+          eventId: 'event:5',
+          memberId: dave.id,
+          kind: 'FORUM_POST_MENTION',
+          emailStatus: 'IGNORED',
+          retryCount: 0,
+        })
+      )
+      expect(notifications).toHaveLength(6)
 
       // -------------------
       // Check emails
@@ -332,7 +346,7 @@ describe('Notifier', () => {
           memberId: alice.id,
           kind: 'ELECTION_ANNOUNCING_STARTED',
           isRead: false,
-          status: 'SENT',
+          emailStatus: 'SENT',
           retryCount: 0,
         })
       )
@@ -395,7 +409,7 @@ describe('Notifier', () => {
           eventId: votingId,
           memberId: alice.id,
           kind: 'ELECTION_VOTING_STARTED',
-          status: 'SENT',
+          emailStatus: 'SENT',
           retryCount: 0,
         })
       )
@@ -458,7 +472,7 @@ describe('Notifier', () => {
           eventId: revealingId,
           memberId: alice.id,
           kind: 'ELECTION_REVEALING_STARTED',
-          status: 'SENT',
+          emailStatus: 'SENT',
           retryCount: 0,
         })
       )
@@ -524,7 +538,7 @@ describe('Notifier', () => {
             eventId: 'event:1',
             memberId: alice.id,
             kind: 'FORUM_POST_MENTION',
-            status: 'PENDING',
+            emailStatus: 'PENDING',
             retryCount: i + 1,
           })
         )
@@ -542,7 +556,7 @@ describe('Notifier', () => {
           eventId: 'event:1',
           memberId: alice.id,
           kind: 'FORUM_POST_MENTION',
-          status: 'FAILED',
+          emailStatus: 'FAILED',
           retryCount: EMAIL_MAX_RETRY_COUNT,
         })
       )
@@ -598,7 +612,7 @@ describe('Notifier', () => {
           eventId: 'event:1',
           memberId: alice.id,
           kind: 'FORUM_POST_MENTION',
-          status: 'PENDING',
+          emailStatus: 'PENDING',
           retryCount: 1,
         })
       )
@@ -617,7 +631,7 @@ describe('Notifier', () => {
           eventId: 'event:1',
           memberId: alice.id,
           kind: 'FORUM_POST_MENTION',
-          status: 'SENT',
+          emailStatus: 'SENT',
           retryCount: 1,
         })
       )


### PR DESCRIPTION
1. Adds `receiveEmails` field to member that indicates whether notifications should be sent as emails
2. Adds `unverifiedEmail` field to member that holds an email that wasn't yet verified
3. Renames `status` field on notification to `emailStatus`