### PR TITLE
🪛 Do not create to WalletConnect instances

### DIFF
--- a/packages/ui/src/accounts/providers/accounts/useWallets.ts
+++ b/packages/ui/src/accounts/providers/accounts/useWallets.ts
@@ -62,7 +62,7 @@ export const useWallets = (): UseWallets => {
 
     const genesisHash = firstValueFrom(genesisHash$)
     return new WalletConnect(wcProjectId, genesisHash, WalletDisconnection$, () => setWallet(undefined))
-  }, [api?.isConnected])
+  }, [])
 
   const allWallets = useMemo(
     () => [


### PR DESCRIPTION
That's a small detail since only the constructor would be called twice the first instance is garbage collected.