### PR TITLE
📊 Add a unit prop to the `Numeric` proposal details renderer

### DIFF
--- a/packages/ui/src/proposals/components/ProposalDetails/renderers/Numeric.tsx
+++ b/packages/ui/src/proposals/components/ProposalDetails/renderers/Numeric.tsx
@@ -2,10 +2,21 @@ import BN from 'bn.js'
 import React from 'react'
 
 import { NumericValueStat } from '@/common/components/statistics'
+import { TextSmall } from '@/common/components/typography'
 
 interface Props {
   label: string
   value: BN
+  units?: string
 }
 
-export const Numeric = ({ label, value }: Props) => <NumericValueStat title={label} value={value} />
+export const Numeric = ({ label, value, units }: Props) => (
+  <NumericValueStat title={label} value={value}>
+    {units && (
+      <TextSmall as="span" lighter>
+        {' '}
+        {units}
+      </TextSmall>
+    )}
+  </NumericValueStat>
+)


### PR DESCRIPTION
Both reward curve (payout damping factor) and crt constraints proposals need this.