### PR TITLE
🔧 Change the election announcing period notification copy

### DIFF
--- a/packages/server/src/notifier/model/email/election.ts
+++ b/packages/server/src/notifier/model/email/election.ts
@@ -13,7 +13,7 @@ export const fromElectionAnnouncingStartedNotification: EmailFromNotificationFn 
     html: renderPioneerEmail({
       memberHandle: member.name,
       summary: 'New election started.',
-      text: 'New Joystream council has just been elected and announcing period for the next election has started. Follow the link below to announce your candidacy.',
+      text: 'New election announcing period has just started. Follow the link below to announce your candidacy.',
       button: {
         label: 'See on Pioneer',
         href: `${PIONEER_URL}/#/election`,


### PR DESCRIPTION
At first I thought of adding a "new council elected" notification, but there's no CTA so I think it would be best to skip this one.