### PR TITLE
Update mainnet RPC endpoint

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -19,7 +19,7 @@ To deploy Pioneer on Vercel click on the button bellow:
    For example, for the Joystream mainnet:
 
    ```shell
-   REACT_APP_MAINNET_NODE_SOCKET=wss://rpc.joystream.org:9944
+   REACT_APP_MAINNET_NODE_SOCKET=wss://rpc.joystream.org
    REACT_APP_MAINNET_QUERY_NODE=https://query.joystream.org/graphql
    REACT_APP_MAINNET_QUERY_NODE_SOCKET=wss://query.joystream.org/graphql
    ```

--- a/packages/ui/.env.example
+++ b/packages/ui/.env.example
@@ -1,5 +1,5 @@
 # TESTNET Endpoints
-REACT_APP_TESTNET_NODE_SOCKET=wss://rpc.joystream.org:9944
+REACT_APP_TESTNET_NODE_SOCKET=wss://rpc.joystream.org
 REACT_APP_TESTNET_NODE_HTTP_RPC=https://rpc.joystream.org
 REACT_APP_TESTNET_QUERY_NODE=https://query.joystream.org/graphql
 REACT_APP_TESTNET_QUERY_NODE_SOCKET=wss://query.joystream.org/graphql
@@ -7,7 +7,7 @@ REACT_APP_TESTNET_MEMBERSHIP_FAUCET_URL=https://faucet.joystream.org/member-fauc
 REACT_APP_TESTNET_BACKEND=http://localhost:3000
 
 # MAINNET Endpoints
-REACT_APP_MAINNET_NODE_SOCKET=wss://rpc.joystream.org:9944
+REACT_APP_MAINNET_NODE_SOCKET=wss://rpc.joystream.org
 REACT_APP_MAINNET_NODE_HTTP_RPC=https://rpc.joystream.org
 REACT_APP_MAINNET_QUERY_NODE=https://query.joystream.org/graphql
 REACT_APP_MAINNET_QUERY_NODE_SOCKET=wss://query.joystream.org/graphql

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -339,7 +339,7 @@ In case there is the network you wish to connect to has no JSON configuration (o
 
 To use custom addresses add the `.env` file in `packages/ui` (example: `packages/ui/.env.example`) and set
 
-1. `REACT_APP_MAINNET_NODE_SOCKET` example `wss://rpc.joystream.org:9944`
+1. `REACT_APP_MAINNET_NODE_SOCKET` example `wss://rpc.joystream.org`
 2. `REACT_APP_MAINNET_QUERY_NODE` example `https://query.joystream.org/graphql`
 3. `REACT_APP_MAINNET_QUERY_NODE_SOCKET` example `wss://query.joystream.org/graphql`
 4. `REACT_APP_MAINNET_MEMBERSHIP_FAUCET_URL` example `https://faucet.joystream.org/member-faucet/register`

--- a/packages/ui/dev/helpers/apiBenchmarking.ts
+++ b/packages/ui/dev/helpers/apiBenchmarking.ts
@@ -7,7 +7,7 @@ import { benchmark } from '../../src/common/utils/benchmark'
 import { ALICE } from '../node-mocks/data/addresses'
 import { withPromiseApi, withRxApi } from '../node-mocks/lib/api'
 
-const ENDPOINT = 'wss://rpc.joystream.org:9944' // TODO pass as a parameter
+const ENDPOINT = 'wss://rpc.joystream.org' // TODO pass as a parameter
 const DEFAULT_DURATION = 5_000
 
 export const apiBenchmarking = {


### PR DESCRIPTION
Replace `wss://rpc.joystream.org:9944` with `wss://rpc.joystream.org` as the former is no longer available.